### PR TITLE
fix!: correct AuthStatus fields, add licenses and docs

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,199 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to the Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by the Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding any notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. Please also get an appropriate
+   open-source license header file from the Software Freedom Law Center.
+
+   Copyright 2026 Josh Rotenberg
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Josh Rotenberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # claude-wrapper
 
+[![Crates.io](https://img.shields.io/crates/v/claude-wrapper.svg)](https://crates.io/crates/claude-wrapper)
+[![Documentation](https://docs.rs/claude-wrapper/badge.svg)](https://docs.rs/claude-wrapper)
+[![CI](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/claude-wrapper.svg)](LICENSE-MIT)
+
 A type-safe Claude Code CLI wrapper for Rust.
 
 `claude-wrapper` provides a builder-pattern interface for invoking the `claude` CLI programmatically. Same design philosophy as [docker-wrapper](https://crates.io/crates/docker-wrapper) and [terraform-wrapper](https://crates.io/crates/terraform-wrapper): each CLI subcommand is a builder struct that produces typed output.
@@ -158,7 +163,7 @@ let output = VersionCommand::new().execute(&claude).await?;
 
 // Auth status
 let status = AuthStatusCommand::new().execute_json(&claude).await?;
-assert!(status.authenticated);
+assert!(status.logged_in);
 
 // Doctor (health check)
 let output = DoctorCommand::new().execute(&claude).await?;
@@ -218,6 +223,26 @@ This is an early-stage spike. The API is functional but may change.
 
 - Retry/backoff policies
 - Process lifecycle management (restart loops for agent patterns)
+- CLI version compatibility checks
+
+## Scope
+
+### Will Do
+
+- Full coverage of `claude` CLI subcommands and flags
+- Typed builders for every subcommand
+- JSON output parsing into Rust structs
+- Streaming NDJSON event processing
+- MCP config file generation
+- Process spawning with timeout, env, and working directory control
+- Track CLI version changes and update types accordingly
+
+### Won't Do
+
+- Interactive/REPL mode (this wraps print mode and subcommands only)
+- Direct API calls to Anthropic (use the [Anthropic SDK](https://crates.io/crates/anthropic) for that)
+- Prompt engineering or conversation management
+- Token counting or cost estimation beyond what the CLI returns
 
 ## License
 

--- a/examples/health_check.rs
+++ b/examples/health_check.rs
@@ -17,7 +17,7 @@ async fn main() -> claude_wrapper::Result<()> {
     // Auth status
     match AuthStatusCommand::new().execute_json(&claude).await {
         Ok(status) => {
-            println!("Authenticated: {}", status.authenticated);
+            println!("Logged in: {}", status.logged_in);
             if let Some(email) = &status.email {
                 println!("Email: {email}");
             }

--- a/src/command/auth.rs
+++ b/src/command/auth.rs
@@ -13,7 +13,7 @@ use crate::exec::{self, CommandOutput};
 /// # async fn example() -> claude_wrapper::Result<()> {
 /// let claude = Claude::builder().build()?;
 /// let status = AuthStatusCommand::new().execute_json(&claude).await?;
-/// println!("authenticated: {}", status.authenticated);
+/// println!("logged in: {}", status.logged_in);
 /// # Ok(())
 /// # }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,15 +26,140 @@
 //! # }
 //! ```
 //!
-//! # MCP Config Generation
+//! # Two-Layer Builder
+//!
+//! The [`Claude`] client holds shared config (binary path, env vars, timeout).
+//! Command builders hold per-invocation options and call `execute(&claude)`.
 //!
 //! ```no_run
-//! use claude_wrapper::McpConfigBuilder;
+//! use claude_wrapper::{Claude, ClaudeCommand, QueryCommand, PermissionMode, Effort};
 //!
-//! # fn example() -> claude_wrapper::Result<()> {
-//! let config = McpConfigBuilder::new()
+//! # async fn example() -> claude_wrapper::Result<()> {
+//! // Configure once, reuse across commands
+//! let claude = Claude::builder()
+//!     .env("AWS_REGION", "us-west-2")
+//!     .timeout_secs(300)
+//!     .build()?;
+//!
+//! // Each command is a separate builder
+//! let output = QueryCommand::new("review the code in src/main.rs")
+//!     .model("opus")
+//!     .system_prompt("You are a senior Rust developer")
+//!     .permission_mode(PermissionMode::Plan)
+//!     .effort(Effort::High)
+//!     .max_turns(5)
+//!     .no_session_persistence()
+//!     .execute(&claude)
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # JSON Output Parsing
+//!
+//! Use `execute_json()` to get structured results:
+//!
+//! ```no_run
+//! use claude_wrapper::{Claude, QueryCommand};
+//!
+//! # async fn example() -> claude_wrapper::Result<()> {
+//! let claude = Claude::builder().build()?;
+//! let result = QueryCommand::new("what is 2+2?")
+//!     .execute_json(&claude)
+//!     .await?;
+//!
+//! println!("answer: {}", result.result);
+//! println!("cost: ${:.4}", result.cost_usd.unwrap_or(0.0));
+//! println!("session: {}", result.session_id);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # MCP Config Generation
+//!
+//! Generate `.mcp.json` files for use with `--mcp-config`:
+//!
+//! ```no_run
+//! use claude_wrapper::{Claude, ClaudeCommand, McpConfigBuilder, QueryCommand};
+//!
+//! # async fn example() -> claude_wrapper::Result<()> {
+//! // Build a config file with multiple servers
+//! let config_path = McpConfigBuilder::new()
 //!     .http_server("my-hub", "http://127.0.0.1:9090")
+//!     .stdio_server("my-tool", "npx", ["my-mcp-server"])
+//!     .stdio_server_with_env(
+//!         "secure-tool", "node", ["server.js"],
+//!         [("API_KEY", "secret")],
+//!     )
 //!     .write_to("/tmp/my-project/.mcp.json")?;
+//!
+//! // Use it in a query
+//! let claude = Claude::builder().build()?;
+//! let output = QueryCommand::new("list available tools")
+//!     .mcp_config("/tmp/my-project/.mcp.json")
+//!     .execute(&claude)
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Working with Multiple Directories
+//!
+//! Clone the client with a different working directory:
+//!
+//! ```no_run
+//! use claude_wrapper::{Claude, ClaudeCommand, QueryCommand};
+//!
+//! # async fn example() -> claude_wrapper::Result<()> {
+//! let claude = Claude::builder().build()?;
+//!
+//! for project in &["/srv/project-a", "/srv/project-b"] {
+//!     let local = claude.with_working_dir(project);
+//!     QueryCommand::new("summarize this project")
+//!         .no_session_persistence()
+//!         .execute(&local)
+//!         .await?;
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Streaming
+//!
+//! Process NDJSON events in real time:
+//!
+//! ```no_run
+//! use claude_wrapper::{Claude, QueryCommand, OutputFormat};
+//! use claude_wrapper::streaming::{StreamEvent, stream_query};
+//!
+//! # async fn example() -> claude_wrapper::Result<()> {
+//! let claude = Claude::builder().build()?;
+//! let cmd = QueryCommand::new("explain quicksort")
+//!     .output_format(OutputFormat::StreamJson);
+//!
+//! let output = stream_query(&claude, &cmd, |event: StreamEvent| {
+//!     if event.is_result() {
+//!         println!("Result: {}", event.result_text().unwrap_or(""));
+//!     }
+//! }).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Escape Hatch
+//!
+//! For subcommands or flags not yet covered by the typed API:
+//!
+//! ```no_run
+//! use claude_wrapper::{Claude, ClaudeCommand, RawCommand};
+//!
+//! # async fn example() -> claude_wrapper::Result<()> {
+//! let claude = Claude::builder().build()?;
+//! let output = RawCommand::new("some-future-command")
+//!     .arg("--new-flag")
+//!     .arg("value")
+//!     .execute(&claude)
+//!     .await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/types.rs
+++ b/src/types.rs
@@ -113,16 +113,47 @@ impl Scope {
 }
 
 /// Authentication status returned by `claude auth status --json`.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = claude_wrapper::Claude::builder().build()?;
+/// let status = claude_wrapper::AuthStatusCommand::new()
+///     .execute_json(&claude).await?;
+///
+/// if status.logged_in {
+///     println!("Logged in as {}", status.email.unwrap_or_default());
+/// }
+/// # Ok(())
+/// # }
+/// ```
 #[cfg(feature = "json")]
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AuthStatus {
+    /// Whether the user is currently logged in.
     #[serde(default)]
-    pub authenticated: bool,
+    pub logged_in: bool,
+    /// Authentication method (e.g. "claude.ai").
     #[serde(default)]
-    pub account_type: Option<String>,
+    pub auth_method: Option<String>,
+    /// API provider (e.g. "firstParty").
+    #[serde(default)]
+    pub api_provider: Option<String>,
+    /// Authenticated user's email address.
     #[serde(default)]
     pub email: Option<String>,
-    // Capture any additional fields
+    /// Organization ID.
+    #[serde(default)]
+    pub org_id: Option<String>,
+    /// Organization name.
+    #[serde(default)]
+    pub org_name: Option<String>,
+    /// Subscription type (e.g. "pro", "max").
+    #[serde(default)]
+    pub subscription_type: Option<String>,
+    /// Any additional fields not explicitly modeled.
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -30,7 +30,7 @@ async fn test_auth_status() {
         .execute_json(&claude)
         .await
         .unwrap();
-    assert!(status.authenticated);
+    assert!(status.logged_in);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- **Fix AuthStatus bug**: `authenticated` field renamed to `logged_in` with `#[serde(rename_all = "camelCase")]` to match actual `claude auth status --json` output. Added all real fields: `auth_method`, `api_provider`, `email`, `org_id`, `org_name`, `subscription_type`.
- **Add license files**: LICENSE-MIT and LICENSE-APACHE
- **Add README badges**: crates.io, docs.rs, CI, license
- **Improve rustdoc**: lib.rs front page now has 7 example sections (quick start, two-layer builder, JSON parsing, MCP config, multiple directories, streaming, escape hatch). Added doc example on `AuthStatus`.
- **Add scope section to README**: will/won't do to clarify project boundaries

## Breaking Change

`AuthStatus.authenticated` is now `AuthStatus.logged_in`. The old field name didn't match the CLI output and never worked correctly.

Closes #5, closes #6, closes #7, closes #8, closes #9