### PR TITLE
feat: dynamic McpConfig tempfile and stream_query example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["json"]
+default = ["json", "tempfile"]
 json = ["serde_json"]
+tempfile = ["dep:tempfile"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -25,6 +26,7 @@ serde_json = { version = "1", optional = true }
 thiserror = "2"
 tokio = { version = "1", features = ["process", "time", "io-util"] }
 tracing = "0.1"
+tempfile = { version = "3", optional = true }
 which = "8"
 
 [dev-dependencies]

--- a/examples/stream_query.rs
+++ b/examples/stream_query.rs
@@ -1,0 +1,46 @@
+//! Stream NDJSON events from a query in real time.
+//!
+//! ```sh
+//! cargo run --example stream_query
+//! ```
+
+use claude_wrapper::streaming::{StreamEvent, stream_query};
+use claude_wrapper::{Claude, OutputFormat, PermissionMode, QueryCommand};
+
+#[tokio::main]
+async fn main() -> claude_wrapper::Result<()> {
+    let claude = Claude::builder().build()?;
+
+    let cmd = QueryCommand::new("Explain quicksort in 3 sentences.")
+        .model("haiku")
+        .output_format(OutputFormat::StreamJson)
+        .permission_mode(PermissionMode::Plan)
+        .max_turns(1)
+        .no_session_persistence();
+
+    let output = stream_query(&claude, &cmd, |event: StreamEvent| {
+        match event.event_type() {
+            Some("result") => {
+                println!("\n--- Result ---");
+                if let Some(text) = event.result_text() {
+                    println!("{text}");
+                }
+                if let Some(cost) = event.cost_usd() {
+                    println!("Cost: ${cost:.4}");
+                }
+                if let Some(session) = event.session_id() {
+                    println!("Session: {session}");
+                }
+            }
+            Some(t) => {
+                println!("[{t}]");
+            }
+            None => {}
+        }
+    })
+    .await?;
+
+    println!("\nExit code: {}", output.exit_code);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,8 @@ pub use command::raw::RawCommand;
 pub use command::version::VersionCommand;
 pub use error::{Error, Result};
 pub use exec::CommandOutput;
+#[cfg(feature = "tempfile")]
+pub use mcp_config::TempMcpConfig;
 pub use mcp_config::{McpConfigBuilder, McpServerConfig};
 pub use types::*;
 

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -191,6 +191,78 @@ impl McpConfigBuilder {
 
         Ok(path)
     }
+
+    /// Write the config to a temporary file that is cleaned up on drop.
+    ///
+    /// Returns a [`TempMcpConfig`] that holds the temp file and provides
+    /// the path for use with [`QueryCommand::mcp_config()`](crate::QueryCommand::mcp_config).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use claude_wrapper::{Claude, ClaudeCommand, McpConfigBuilder, QueryCommand};
+    ///
+    /// # async fn example() -> claude_wrapper::Result<()> {
+    /// let claude = Claude::builder().build()?;
+    ///
+    /// let config = McpConfigBuilder::new()
+    ///     .http_server("hub", "http://localhost:9090")
+    ///     .stdio_server("tool", "npx", ["my-server"])
+    ///     .build_temp()?;
+    ///
+    /// let output = QueryCommand::new("list tools")
+    ///     .mcp_config(config.path())
+    ///     .execute(&claude)
+    ///     .await?;
+    /// // temp file is cleaned up when `config` is dropped
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "tempfile")]
+    pub fn build_temp(&self) -> Result<TempMcpConfig> {
+        use std::io::Write;
+
+        let json = self.to_json()?;
+        let mut file = tempfile::Builder::new()
+            .suffix(".mcp.json")
+            .tempfile()
+            .map_err(|e| crate::error::Error::Io {
+                message: "failed to create temp MCP config file".to_string(),
+                source: e,
+            })?;
+
+        file.write_all(json.as_bytes())
+            .map_err(|e| crate::error::Error::Io {
+                message: "failed to write temp MCP config".to_string(),
+                source: e,
+            })?;
+
+        Ok(TempMcpConfig { file })
+    }
+}
+
+/// A temporary MCP config file that is cleaned up when dropped.
+///
+/// Created by [`McpConfigBuilder::build_temp()`]. Use [`path()`](TempMcpConfig::path)
+/// to get the file path for passing to [`QueryCommand::mcp_config()`](crate::QueryCommand::mcp_config).
+#[cfg(feature = "tempfile")]
+#[derive(Debug)]
+pub struct TempMcpConfig {
+    file: tempfile::NamedTempFile,
+}
+
+#[cfg(feature = "tempfile")]
+impl TempMcpConfig {
+    /// Get the path to the temporary config file.
+    ///
+    /// Returns a string suitable for passing to `QueryCommand::mcp_config()`.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        self.file
+            .path()
+            .to_str()
+            .expect("temp file path is valid UTF-8")
+    }
 }
 
 #[cfg(test)]
@@ -220,6 +292,22 @@ mod tests {
         assert!(json.contains("npx"));
         assert!(json.contains("my-mcp-server"));
         assert!(json.contains(r#""type": "stdio""#));
+    }
+
+    #[test]
+    #[cfg(feature = "tempfile")]
+    fn test_build_temp() {
+        let config = McpConfigBuilder::new()
+            .http_server("hub", "http://localhost:9090")
+            .stdio_server("tool", "echo", ["hello"]);
+
+        let temp = config.build_temp().unwrap();
+        let path = temp.path();
+        assert!(path.ends_with(".mcp.json"));
+
+        let contents = std::fs::read_to_string(path).unwrap();
+        assert!(contents.contains("hub"));
+        assert!(contents.contains("localhost:9090"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **`McpConfigBuilder::build_temp()`**: Writes config to a temporary file, returns `TempMcpConfig` handle that cleans up on drop. Makes it easy to generate ephemeral MCP configs without managing file paths.
- **`TempMcpConfig`**: Wrapper around `NamedTempFile` with a `path()` method for direct use with `QueryCommand::mcp_config()`.
- **`tempfile` feature**: New default feature gating the temp config functionality.
- **`stream_query` example**: Shows real-time NDJSON event processing with `stream_query()`.

## Usage

```rust
let config = McpConfigBuilder::new()
    .http_server("hub", "http://localhost:9090")
    .build_temp()?;

let output = QueryCommand::new("list tools")
    .mcp_config(config.path())
    .execute(&claude)
    .await?;
// temp file cleaned up when config is dropped
```

Closes #11