### PR TITLE
feat: CLI version parsing and compatibility checks

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,13 @@ pub enum Error {
         #[source]
         source: serde_json::Error,
     },
+
+    /// The installed CLI version does not meet the minimum requirement.
+    #[error("CLI version {found} does not meet minimum requirement {minimum}")]
+    VersionMismatch {
+        found: crate::version::CliVersion,
+        minimum: crate::version::CliVersion,
+    },
 }
 
 impl From<std::io::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@ pub mod exec;
 pub mod mcp_config;
 pub mod streaming;
 pub mod types;
+pub mod version;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -200,6 +201,7 @@ pub use exec::CommandOutput;
 pub use mcp_config::TempMcpConfig;
 pub use mcp_config::{McpConfigBuilder, McpServerConfig};
 pub use types::*;
+pub use version::{CliVersion, VersionParseError};
 
 /// The Claude CLI client. Holds shared configuration applied to all commands.
 ///
@@ -238,6 +240,57 @@ impl Claude {
         let mut clone = self.clone();
         clone.working_dir = Some(dir.into());
         clone
+    }
+
+    /// Query the installed CLI version.
+    ///
+    /// Runs `claude --version` and parses the output into a [`CliVersion`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # async fn example() -> claude_wrapper::Result<()> {
+    /// let claude = claude_wrapper::Claude::builder().build()?;
+    /// let version = claude.cli_version().await?;
+    /// println!("Claude CLI {version}");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn cli_version(&self) -> Result<CliVersion> {
+        let output = VersionCommand::new().execute(self).await?;
+        CliVersion::parse_version_output(&output.stdout).map_err(|e| Error::Io {
+            message: format!("failed to parse CLI version: {e}"),
+            source: std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()),
+        })
+    }
+
+    /// Check that the installed CLI version meets a minimum requirement.
+    ///
+    /// Returns the detected version on success, or an error if the version
+    /// is below the minimum.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use claude_wrapper::CliVersion;
+    ///
+    /// # async fn example() -> claude_wrapper::Result<()> {
+    /// let claude = claude_wrapper::Claude::builder().build()?;
+    /// let version = claude.check_version(&CliVersion::new(2, 1, 0)).await?;
+    /// println!("CLI version {version} meets minimum requirement");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn check_version(&self, minimum: &CliVersion) -> Result<CliVersion> {
+        let version = self.cli_version().await?;
+        if version.satisfies_minimum(minimum) {
+            Ok(version)
+        } else {
+            Err(Error::VersionMismatch {
+                found: version,
+                minimum: *minimum,
+            })
+        }
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,163 @@
+use std::fmt;
+use std::str::FromStr;
+
+/// A parsed Claude CLI version (semver).
+///
+/// # Example
+///
+/// ```
+/// use claude_wrapper::CliVersion;
+///
+/// let v: CliVersion = "2.1.71".parse().unwrap();
+/// assert_eq!(v.major, 2);
+/// assert_eq!(v.minor, 1);
+/// assert_eq!(v.patch, 71);
+///
+/// let min: CliVersion = "2.1.0".parse().unwrap();
+/// assert!(v >= min);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CliVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl CliVersion {
+    /// Create a new version.
+    #[must_use]
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Parse a version from the output of `claude --version`.
+    ///
+    /// Expects format like `"2.1.71 (Claude Code)"` or just `"2.1.71"`.
+    pub fn parse_version_output(output: &str) -> Result<Self, VersionParseError> {
+        let version_str = output.split_whitespace().next().unwrap_or("");
+        version_str.parse()
+    }
+
+    /// Check if this version satisfies a minimum version requirement.
+    #[must_use]
+    pub fn satisfies_minimum(&self, minimum: &CliVersion) -> bool {
+        self >= minimum
+    }
+}
+
+impl PartialOrd for CliVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CliVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.major
+            .cmp(&other.major)
+            .then(self.minor.cmp(&other.minor))
+            .then(self.patch.cmp(&other.patch))
+    }
+}
+
+impl fmt::Display for CliVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl FromStr for CliVersion {
+    type Err = VersionParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 {
+            return Err(VersionParseError(s.to_string()));
+        }
+
+        let major = parts[0]
+            .parse()
+            .map_err(|_| VersionParseError(s.to_string()))?;
+        let minor = parts[1]
+            .parse()
+            .map_err(|_| VersionParseError(s.to_string()))?;
+        let patch = parts[2]
+            .parse()
+            .map_err(|_| VersionParseError(s.to_string()))?;
+
+        Ok(Self {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+/// Error returned when a version string cannot be parsed.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("invalid version string: {0:?}")]
+pub struct VersionParseError(pub String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple() {
+        let v: CliVersion = "2.1.71".parse().unwrap();
+        assert_eq!(v.major, 2);
+        assert_eq!(v.minor, 1);
+        assert_eq!(v.patch, 71);
+    }
+
+    #[test]
+    fn test_parse_version_output() {
+        let v = CliVersion::parse_version_output("2.1.71 (Claude Code)").unwrap();
+        assert_eq!(v, CliVersion::new(2, 1, 71));
+    }
+
+    #[test]
+    fn test_parse_version_output_trimmed() {
+        let v = CliVersion::parse_version_output("  2.1.71 (Claude Code)\n").unwrap();
+        assert_eq!(v, CliVersion::new(2, 1, 71));
+    }
+
+    #[test]
+    fn test_display() {
+        let v = CliVersion::new(2, 1, 71);
+        assert_eq!(v.to_string(), "2.1.71");
+    }
+
+    #[test]
+    fn test_ordering() {
+        let v1 = CliVersion::new(2, 0, 0);
+        let v2 = CliVersion::new(2, 1, 0);
+        let v3 = CliVersion::new(2, 1, 71);
+        let v4 = CliVersion::new(3, 0, 0);
+
+        assert!(v1 < v2);
+        assert!(v2 < v3);
+        assert!(v3 < v4);
+        assert!(v1 < v4);
+    }
+
+    #[test]
+    fn test_satisfies_minimum() {
+        let v = CliVersion::new(2, 1, 71);
+        assert!(v.satisfies_minimum(&CliVersion::new(2, 0, 0)));
+        assert!(v.satisfies_minimum(&CliVersion::new(2, 1, 71)));
+        assert!(!v.satisfies_minimum(&CliVersion::new(2, 2, 0)));
+        assert!(!v.satisfies_minimum(&CliVersion::new(3, 0, 0)));
+    }
+
+    #[test]
+    fn test_parse_invalid() {
+        assert!("not-a-version".parse::<CliVersion>().is_err());
+        assert!("2.1".parse::<CliVersion>().is_err());
+        assert!("2.1.x".parse::<CliVersion>().is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- **`CliVersion`** type: parses `"2.1.71"` or `"2.1.71 (Claude Code)"`, implements `Ord`, `Display`, `FromStr`
- **`Claude::cli_version()`**: runs `claude --version` and returns parsed `CliVersion`
- **`Claude::check_version(minimum)`**: asserts minimum CLI version, returns `VersionMismatch` error if below
- **`Error::VersionMismatch`**: new error variant with `found` and `minimum` versions

## Usage

```rust
let claude = Claude::builder().build()?;

// Query version
let v = claude.cli_version().await?;
println!("Claude CLI {v}");

// Assert minimum
claude.check_version(&CliVersion::new(2, 1, 0)).await?;
```

Closes #10