### PR TITLE
feat: add enhanced worker identity

### DIFF
--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -123,6 +123,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "Claude worker pool. Use pool_run to execute tasks synchronously, \
              pool_submit/pool_result for async. pool_fan_out for parallel execution. \
              pool_chain for sequential pipelines. context_set/get/list for shared state. \
+             pool_configure_worker to set worker identity. \
              Skills are available as prompts (code_review, implement, write_tests, refactor, summarize).",
         )
         .tools(tool_list)

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -62,6 +62,18 @@ pub struct ContextKeyInput {
     pub key: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ConfigureWorkerInput {
+    /// Worker ID to configure (e.g. "worker-0").
+    pub worker_id: String,
+    /// Human-readable name for the worker.
+    pub name: Option<String>,
+    /// Role classification for the worker.
+    pub role: Option<String>,
+    /// Description of the worker's purpose.
+    pub description: Option<String>,
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
@@ -294,6 +306,57 @@ pub fn context_list_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
         .build()
 }
 
+pub fn pool_configure_worker_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_configure_worker")
+        .title("Configure Worker")
+        .description("Set name/role/description for a worker to give it persistent identity")
+        .handler(move |input: ConfigureWorkerInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let worker_id = claude_pool::WorkerId(input.worker_id.clone());
+
+                match state.pool.store().get_worker(&worker_id).await {
+                    Ok(Some(mut worker)) => {
+                        // Update identity fields
+                        if let Some(name) = input.name {
+                            worker.config.name = Some(name);
+                        }
+                        if let Some(role) = input.role {
+                            worker.config.role = Some(role);
+                        }
+                        if let Some(description) = input.description {
+                            worker.config.description = Some(description);
+                        }
+
+                        // Persist updated worker
+                        match state.pool.store().put_worker(worker.clone()).await {
+                            Ok(_) => {
+                                let response = serde_json::json!({
+                                    "worker_id": worker_id.0,
+                                    "name": worker.config.name,
+                                    "role": worker.config.role,
+                                    "description": worker.config.description,
+                                });
+                                Ok(CallToolResult::json(response))
+                            }
+                            Err(e) => Ok(CallToolResult::error(format!(
+                                "failed to update worker: {e}"
+                            ))),
+                        }
+                    }
+                    Ok(None) => Ok(CallToolResult::error(format!(
+                        "worker not found: {}",
+                        input.worker_id
+                    ))),
+                    Err(e) => Ok(CallToolResult::error(format!(
+                        "failed to fetch worker: {e}"
+                    ))),
+                }
+            }
+        })
+        .build()
+}
+
 // ── Skill + chain tools ──────────────────────────────────────────────
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -426,5 +489,6 @@ pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
         context_get_tool(Arc::clone(state)),
         context_delete_tool(Arc::clone(state)),
         context_list_tool(Arc::clone(state)),
+        pool_configure_worker_tool(Arc::clone(state)),
     ]
 }

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -602,8 +602,8 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         let resolved = ResolvedConfig::resolve(&self.inner.config, worker_config, task_cfg);
 
-        // Build the system prompt with context injection.
-        let system_prompt = self.build_system_prompt(&resolved);
+        // Build the system prompt with identity and context injection.
+        let system_prompt = self.build_system_prompt(&resolved, worker_config);
 
         // Build and execute the query.
         let mut cmd = claude_wrapper::QueryCommand::new(prompt)
@@ -669,15 +669,50 @@ impl<S: PoolStore + 'static> Pool<S> {
         })
     }
 
-    /// Build the system prompt by combining resolved config and context.
-    fn build_system_prompt(&self, resolved: &ResolvedConfig) -> Option<String> {
+    /// Build the system prompt by combining worker identity, resolved config and context.
+    fn build_system_prompt(
+        &self,
+        resolved: &ResolvedConfig,
+        worker_config: &WorkerConfig,
+    ) -> Option<String> {
         let context_entries: Vec<_> = self.list_context();
 
-        if resolved.system_prompt.is_none() && context_entries.is_empty() {
+        // Check if there's any content to include
+        let has_identity = worker_config.name.is_some()
+            || worker_config.role.is_some()
+            || worker_config.description.is_some();
+
+        if resolved.system_prompt.is_none() && context_entries.is_empty() && !has_identity {
             return None;
         }
 
         let mut parts = Vec::new();
+
+        // Inject worker identity
+        if has_identity {
+            let mut identity = String::new();
+            identity.push_str("You are ");
+
+            if let Some(ref name) = worker_config.name {
+                identity.push_str(name);
+            } else {
+                identity.push_str("a worker");
+            }
+
+            if let Some(ref role) = worker_config.role {
+                identity.push_str(", a ");
+                identity.push_str(role);
+            }
+
+            if let Some(ref description) = worker_config.description {
+                identity.push_str(". ");
+                identity.push_str(description);
+            } else if worker_config.role.is_some() {
+                identity.push('.');
+            }
+
+            parts.push(identity);
+        }
 
         if let Some(ref sp) = resolved.system_prompt {
             parts.push(sp.clone());
@@ -876,5 +911,30 @@ mod tests {
 
         let err = pool.run("hello").await.unwrap_err();
         assert!(matches!(err, Error::NoIdleWorkers));
+    }
+
+    #[tokio::test]
+    async fn worker_identity_fields_persisted() {
+        let pool = Pool::builder(mock_claude())
+            .workers(1)
+            .worker_config(WorkerConfig {
+                name: Some("reviewer".into()),
+                role: Some("code_review".into()),
+                description: Some("Reviews PRs for correctness and style".into()),
+                ..Default::default()
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let workers = pool.store().list_workers().await.unwrap();
+        let worker = workers.iter().find(|w| w.id.0 == "worker-0").unwrap();
+
+        assert_eq!(worker.config.name.as_deref(), Some("reviewer"));
+        assert_eq!(worker.config.role.as_deref(), Some("code_review"));
+        assert_eq!(
+            worker.config.description.as_deref(),
+            Some("Reviews PRs for correctness and style")
+        );
     }
 }

--- a/crates/claude-pool/src/types.rs
+++ b/crates/claude-pool/src/types.rs
@@ -118,6 +118,12 @@ pub struct WorkerConfig {
 
     /// Optional name/role for this worker (e.g. "reviewer", "coder").
     pub role: Option<String>,
+
+    /// Optional human-readable name for the worker (e.g. "reviewer", "writer").
+    pub name: Option<String>,
+
+    /// Optional description of the worker's purpose or responsibilities.
+    pub description: Option<String>,
 }
 
 /// Current state of a worker.


### PR DESCRIPTION
## Summary

Closes #29.

- Adds `name` and `description` fields to `WorkerConfig` for worker identity
- Injects worker identity into system prompts: "You are {name}, a {role}. {description}"
- Adds `pool_configure_worker` MCP tool to set identity at runtime
- Includes unit test for identity persistence

## Test plan

- [x] 59 claude-wrapper + 23 claude-pool tests passing (82 total)
- [x] `cargo clippy` clean
- [ ] Manual test: configure worker identity via `pool_configure_worker` and verify system prompt injection