### PR TITLE
chore: add workflow_dispatch trigger to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release-plz:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the release-plz workflow so it can be manually re-run from the Actions tab
- The workflow previously only triggered on push to main, making it impossible to retry after fixing secrets or other config issues