### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.2.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.2.0...v0.2.1) - 2026-03-10
+
+### Added
+
+- add project-specific skills for claude-wrapper workspace ([#57](https://github.com/joshrotenberg/claude-wrapper/pull/57))
+
 ## [0.2.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.1.0...v0.2.0) - 2026-03-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "claude-wrapper"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `claude-pool`: 0.1.0
* `claude-pool-server`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-wrapper`

<blockquote>

## [0.2.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.2.0...v0.2.1) - 2026-03-10

### Added

- add project-specific skills for claude-wrapper workspace ([#57](https://github.com/joshrotenberg/claude-wrapper/pull/57))
</blockquote>

## `claude-pool`

<blockquote>

## [0.1.0](https://github.com/joshrotenberg/claude-wrapper/releases/tag/claude-pool-v0.1.0) - 2026-03-10

### Added

- add claude-pool slot pool and MCP server ([#25](https://github.com/joshrotenberg/claude-wrapper/pull/25))
</blockquote>

## `claude-pool-server`

<blockquote>

## [0.1.0](https://github.com/joshrotenberg/claude-wrapper/releases/tag/claude-pool-server-v0.1.0) - 2026-03-10

### Added

- add claude-pool slot pool and MCP server ([#25](https://github.com/joshrotenberg/claude-wrapper/pull/25))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).