### PR TITLE
fix: changelog workflow detached HEAD and branch protection

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: main
+          token: ${{ secrets.COMMITTER_TOKEN }}
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4


### PR DESCRIPTION
## Summary

- Add `ref: main` to checkout step so the workflow isn't in detached HEAD state on release events
- Use `COMMITTER_TOKEN` instead of default token to push past branch protection rules

Two issues: `actions/checkout` defaults to detached HEAD on release triggers, causing `git push` to fail. And the default `GITHUB_TOKEN` can't push to protected branches.