### PR TITLE
feat: add project-specific skills for claude-wrapper workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,6 @@ dependencies = [
 name = "claude-pool-server"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "claude-pool",
  "claude-wrapper",

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ A comprehensive Rust tooling suite for the Claude Code CLI: type-safe wrapper, w
 [![CI](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml)
 [![License](https://img.shields.io/crates/l/claude-wrapper.svg)](LICENSE-MIT)
 
-## Workspace Overview
-
-Three complementary crates:
+## The Three Crates
 
 ```
 ┌─────────────────────────────────────────────────┐
@@ -37,11 +35,9 @@ Three complementary crates:
 
 | Crate | Purpose | Docs |
 |-------|---------|------|
-| **claude-wrapper** | Type-safe CLI wrapper with builder pattern | [docs.rs](https://docs.rs/claude-wrapper) |
-| **claude-pool** | Worker pool, orchestration, budget control | [docs.rs](https://docs.rs/claude-pool) |
-| **claude-pool-server** | MCP server exposing the pool | [docs.rs](https://docs.rs/claude-pool-server) |
-
----
+| **[claude-wrapper](crates/claude-wrapper/)** | Type-safe CLI wrapper with builder pattern | [README](crates/claude-wrapper/README.md) ⟡ [docs.rs](https://docs.rs/claude-wrapper) |
+| **[claude-pool](crates/claude-pool/)** | Worker pool, orchestration, budget control | [README](crates/claude-pool/README.md) ⟡ [docs.rs](https://docs.rs/claude-pool) |
+| **[claude-pool-server](crates/claude-pool-server/)** | MCP server exposing the pool | [README](crates/claude-pool-server/README.md) ⟡ [docs.rs](https://docs.rs/claude-pool-server) |
 
 ## Quick Start
 
@@ -66,6 +62,7 @@ async fn main() -> claude_wrapper::Result<()> {
 
 ```rust
 use claude_pool::Pool;
+use claude_wrapper::Claude;
 
 #[tokio::main]
 async fn main() -> claude_pool::Result<()> {
@@ -87,389 +84,82 @@ claude-pool-server -n 4 --budget-usd 10.0 --model sonnet
 # Stdio transport. Add to .mcp.json and use from Claude.
 ```
 
----
-
-## claude-wrapper: Type-Safe CLI Wrapper
-
-Invoke the `claude` CLI programmatically with a builder pattern. Same philosophy as [docker-wrapper](https://crates.io/crates/docker-wrapper).
-
-### QueryCommand
-
-Full coverage of `claude -p` (print mode) options:
-
-```rust
-let output = QueryCommand::new("implement the feature in TASK.md")
-    .model("sonnet")
-    .system_prompt("You are a Rust expert")
-    .output_format(OutputFormat::Json)
-    .max_budget_usd(1.00)
-    .permission_mode(PermissionMode::AcceptEdits)
-    .allowed_tools(["Bash", "Read", "Edit", "Write"])
-    .mcp_config("/tmp/project/.mcp.json")
-    .effort(Effort::High)
-    .max_turns(10)
-    .no_session_persistence()
-    .execute(&claude)
-    .await?;
-```
-
-### MCP Commands
-
-```rust
-// List servers
-McpListCommand::new().execute(&claude).await?;
-
-// Add HTTP server
-McpAddCommand::new("sentry", "https://mcp.sentry.dev/mcp")
-    .transport("http")
-    .execute(&claude).await?;
-
-// Add stdio server
-McpAddCommand::new("my-tool", "npx")
-    .server_args(["my-mcp-server"])
-    .env("API_KEY", "xxx")
-    .execute(&claude).await?;
-```
-
-### MCP Config Builder
-
-Generate `.mcp.json` files:
-
-```rust
-use claude_wrapper::McpConfigBuilder;
-
-McpConfigBuilder::new()
-    .http_server("hub", "http://127.0.0.1:9090")
-    .stdio_server("tool", "npx", ["my-server"])
-    .write_to("/tmp/my-project/.mcp.json")?;
-```
-
-### Streaming
-
-For real-time NDJSON events:
-
-```rust
-use claude_wrapper::streaming::stream_query;
-
-let output = stream_query(&claude, &cmd, |event| {
-    if event.is_result() {
-        println!("Result: {}", event.result_text().unwrap_or(""));
-    }
-}).await?;
-```
-
-### All QueryCommand Options
-
-| Method | CLI Flag | Description |
-|--------|----------|-------------|
-| `model()` | `--model` | Model alias or full ID |
-| `system_prompt()` | `--system-prompt` | Replace default system prompt |
-| `append_system_prompt()` | `--append-system-prompt` | Append to system prompt |
-| `output_format()` | `--output-format` | text, json, stream-json |
-| `max_budget_usd()` | `--max-budget-usd` | Spending cap |
-| `permission_mode()` | `--permission-mode` | default, acceptEdits, bypassPermissions, plan, auto |
-| `allowed_tools()` | `--allowed-tools` | Tool permission allow list |
-| `disallowed_tools()` | `--disallowed-tools` | Tool permission deny list |
-| `tools()` | `--tools` | Restrict available tools |
-| `mcp_config()` | `--mcp-config` | MCP server config file |
-| `strict_mcp_config()` | `--strict-mcp-config` | Only use MCP from config |
-| `add_dir()` | `--add-dir` | Additional accessible directories |
-| `effort()` | `--effort` | low, medium, high |
-| `max_turns()` | `--max-turns` | Conversation turn limit |
-| `json_schema()` | `--json-schema` | Structured output validation |
-| `agent()` | `--agent` | Agent for session |
-| `agents_json()` | `--agents` | Custom agents JSON |
-| `continue_session()` | `--continue` | Resume most recent |
-| `resume()` | `--resume` | Resume by session ID |
-| `session_id()` | `--session-id` | Use specific session ID |
-| `fork_session()` | `--fork-session` | Fork when resuming |
-| `fallback_model()` | `--fallback-model` | Fallback model |
-| `no_session_persistence()` | `--no-session-persistence` | Don't save session |
-| `dangerously_skip_permissions()` | `--dangerously-skip-permissions` | Bypass permissions |
-| `file()` | `--file` | File resources to download |
-| `input_format()` | `--input-format` | text or stream-json |
-| `include_partial_messages()` | `--include-partial-messages` | Partial chunks |
-| `settings()` | `--settings` | Settings JSON file |
-
----
-
-## claude-pool: Worker Pool & Orchestration
-
-A library for managing N Claude CLI workers with task routing, budget tracking, and composable execution patterns.
-
-### Key Features
-
-- **Worker pool**: Spawn N Claude instances, route tasks by load/availability
-- **Synchronous tasks**: `pool.run(prompt)` — blocks until complete
-- **Asynchronous tasks**: `pool.submit(prompt)` → task ID → `pool.result(id)` later
-- **Parallel fan-out**: `pool.fan_out([prompt1, prompt2, ...])` — execute all at once
-- **Sequential chains**: `pool.execute_chain(steps)` with step-by-step progress and failure policies (retry, skip, abort)
-- **Budget control**: Per-pool and per-worker caps; track spend atomically
-- **Worker identity**: Name, role, description fields for context and coordination
-- **Shared context**: `pool.context_set(key, value)` — inject into all worker system prompts
-- **Worktree isolation**: Optional Git worktree per worker for safe, isolated execution
-- **Skills system**: Register reusable prompts/templates with argument validation
-
-### Usage: Pool Builder
-
-```rust
-use claude_pool::{Pool, GlobalWorkerConfig, Effort};
-
-let claude = Claude::builder().build()?;
-
-let pool = Pool::builder(claude)
-    .workers(4)
-    .config(
-        GlobalWorkerConfig::default()
-            .with_model("sonnet")
-            .with_effort(Effort::Medium)
-            .with_budget_usd(50.0)
-            .with_permission_mode(PermissionMode::Plan)
-    )
-    .build()
-    .await?;
-
-// Single task (sync)
-let result = pool.run("fix the bug in main.rs").await?;
-println!("Output:\n{}", result.output);
-```
-
-### Async Task Submission
-
-```rust
-// Submit without blocking
-let task_id = pool.submit("long-running task").await?;
-
-// Do other work...
-
-// Poll for result later
-let result = pool.result(&task_id).await??;
-```
-
-### Parallel Fan-Out
-
-```rust
-let prompts = [
-    "write a poem",
-    "write a haiku",
-    "write a limerick",
-];
-
-let results = pool.fan_out(&prompts).await?;
-for result in results {
-    println!("{}", result.output);
-}
-```
-
-### Sequential Chains with Failure Policies
-
-```rust
-use claude_pool::{ChainStep, StepFailurePolicy, execute_chain};
-
-let steps = vec![
-    ChainStep::new("analyze the error: file not found"),
-    ChainStep::new("write a fix"),
-    ChainStep::new("write unit tests"),
-];
-
-let result = execute_chain(&pool, steps, ChainOptions::default()).await?;
-println!("Chain result: {}", result.final_output);
-```
-
-### Shared Context
-
-```rust
-pool.context_set("language", "rust").await?;
-pool.context_set("framework", "tokio").await?;
-pool.context_set("style", "idiomatic").await?;
-
-// All workers now see these in their system prompts
-```
-
-### Skills Registry
-
-Skills are templates for reusable task patterns. Register them with the MCP server:
-
-```rust
-use claude_pool::{SkillRegistry, Skill, SkillArgument};
-
-let mut registry = SkillRegistry::new();
-registry.register(Skill {
-    name: "code_review".to_string(),
-    description: "Review code for bugs and style".to_string(),
-    prompt: "Review the code at {path} for bugs and style".to_string(),
-    arguments: vec![
-        SkillArgument {
-            name: "path".to_string(),
-            description: "Path to code file".to_string(),
-            required: true,
-        }
-    ],
-    config: None,
-});
-```
-
-Skills are referenced via the `pool_skill_run` MCP tool when the server is running.
-
----
-
-## claude-pool-server: MCP Server
-
-A standalone binary that exposes `claude-pool` as an MCP server over stdio. Add to your `.mcp.json` and call from an interactive Claude session.
-
-### Installation & Running
-
-```bash
-cargo install claude-pool-server
-claude-pool-server -n 4 --budget-usd 10.0 --model sonnet --permission-mode plan
-```
-
-### CLI Flags
-
-| Flag | Description |
-|------|-------------|
-| `-n, --workers N` | Number of workers (default: 2) |
-| `--model MODEL` | Default model for all workers |
-| `--effort LEVEL` | Default effort: min, low, medium, high, max |
-| `--budget-usd AMOUNT` | Total budget cap |
-| `--system-prompt TEXT` | System prompt for all workers |
-| `--permission-mode MODE` | default, acceptEdits, bypassPermissions, plan, auto |
-| `-w, --worktree` | Enable Git worktree isolation |
-| `--no-builtins` | Disable built-in skills |
-
-### Add to `.mcp.json`
-
-```json
-{
-  "mcpServers": {
-    "claude-pool": {
-      "command": "claude-pool-server",
-      "args": ["-n", "4", "--budget-usd", "10.0", "--model", "sonnet"]
-    }
-  }
-}
-```
-
-### MCP Tools
-
-All tools are async and return JSON results:
-
-```
-pool_run         → Submit task, wait for result
-pool_submit      → Submit async (returns task ID)
-pool_result      → Get result by task ID
-pool_fan_out     → Execute multiple prompts in parallel
-pool_chain       → Execute sequential pipeline with failure policies
-pool_submit_chain → Submit chain for async execution
-pool_chain_result → Get chain progress and results
-pool_status      → Get pool status (workers, tasks, spend)
-pool_drain       → Graceful shutdown
-pool_cancel      → Cancel a pending or running task
-
-context_set      → Inject key-value pair into worker system prompts
-context_get      → Retrieve context value
-context_list     → List all context keys
-context_delete   → Remove context key
-
-pool_skill_run   → Execute a skill by name
-```
-
-### MCP Resources
-
-Access pool state and task details:
-
-```
-pool://status              → Current pool state (workers, tasks, spend)
-pool://workers             → List all workers
-pool://budget              → Budget breakdown (total, spent, remaining)
-pool://context             → Current context key-value pairs
-pool://workers/{id}        → Get a single worker by ID
-pool://results/{task_id}   → Get a single task result
-pool://chains/{chain_id}   → Get chain progress and results
-```
-
-### Example: From Claude
-
-```
-You are working with a claude-pool MCP server (4 workers, $10 budget).
-
-Use pool/fan-out to parallelize:
-> @mcp pool/fan-out prompts:["write test for fn A", "write test for fn B", "write test for fn C"]
-
-Then chain results:
-> @mcp pool/chain steps:[{"prompt": "review the tests"}, {"prompt": "refactor for clarity"}]
-
-Check spend:
-> @mcp pool/status
-```
-
----
-
 ## Features
 
-| Feature | Default | Description |
-|---------|---------|-------------|
-| `json` | Yes | JSON output parsing, `execute_json()`, streaming events |
-| `tempfile` | Yes | Temporary file support for MCP config |
+- **claude-wrapper**: Type-safe CLI wrapper with full option coverage (28 options), MCP server management, plugin management, streaming NDJSON events
+- **claude-pool**: Multi-worker coordination, synchronous/async task execution, parallel fan-out, sequential chains with failure policies, budget control, shared context injection, optional worktree isolation, reusable skills registry
+- **claude-pool-server**: Standalone MCP server binary, configurable via CLI flags, full pool tool exposure, MCP resources for state inspection
 
----
+## Installation
+
+```bash
+# Library: type-safe CLI wrapper
+cargo add claude-wrapper
+
+# Library: worker pool orchestration
+cargo add claude-pool
+
+# Binary: MCP server for the pool
+cargo install claude-pool-server
+```
+
+## Documentation
+
+- **API Docs**: [docs.rs/claude-wrapper](https://docs.rs/claude-wrapper), [docs.rs/claude-pool](https://docs.rs/claude-pool), [docs.rs/claude-pool-server](https://docs.rs/claude-pool-server)
+- **Crate READMEs**: See individual crate directories above
+- **Examples**: Each crate README contains detailed examples
 
 ## Status
 
-**Stable and actively maintained.**
+**Production-ready.** All three crates are actively maintained with comprehensive test coverage (85+ tests).
 
-All three crates are production-ready with comprehensive test coverage (85+ tests). Recent releases add chain execution, failure policies, worker identity, worktree isolation, and resource templates.
+### Latest Releases
+
+- **claude-wrapper** v0.2.0 - Full CLI surface, streaming, all subcommands
+- **claude-pool** v0.1.0 - Worker pool, chains, skills, worktree isolation
+- **claude-pool-server** v0.1.0 - MCP server with all tools and resources
 
 ### Implemented
 
-- **claude-wrapper**: Full CLI surface (28 options), all subcommands, MCP management, streaming
-- **claude-pool**: Worker pool, task submission (sync/async), fan-out, chains, skills, context injection, budget tracking, worktree isolation
-- **claude-pool-server**: MCP binary with all pool tools and resources, CLI configuration
+- Full CLI wrapper (28 QueryCommand options + all subcommands)
+- Worker pool with task routing, budgets, and worker identity
+- MCP server binary with tools and resources
+- Sequential chains with failure policies
+- Parallel fan-out execution
+- Shared context injection across workers
+- Worktree isolation per worker
+- Reusable skills registry
 
-### Not Yet Planned
+## Development & Testing
 
-- Interactive/REPL mode (print mode only)
-- Direct Anthropic API calls (use [anthropic SDK](https://crates.io/crates/anthropic))
-
----
-
-## Scope
-
-### Will Do
-
-- Maintain compatibility with Claude CLI versions
-- Add new pool features (scheduling, circuit breakers, metrics)
-- Improve documentation and examples
-- Performance optimization for large worker pools
-
-### Won't Do
-
-- Claude Code IDE integration (IDE features out of scope)
-- Conversation management or prompt engineering
-- Token counting beyond what the CLI returns
-- Interactive sessions (print mode only)
-
----
-
-## Release & Testing
+Pre-commit checks:
 
 ```bash
-# Pre-commit checks
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --lib --all-features
 cargo test --test '*' --all-features
+```
 
-# Doc tests
+Doc tests:
+
+```bash
 cargo test --doc --all-features
+```
 
-# Workspace release (in dependency order)
+Full release checklist (before merging release PR):
+
+```bash
+cargo doc --no-deps --all-features  # Docs build without warnings
+cargo test --doc --all-features     # Doc tests pass
 cargo publish --dry-run -p claude-wrapper
 cargo publish --dry-run -p claude-pool
 cargo publish --dry-run -p claude-pool-server
 ```
 
----
+## Contributing
+
+Issues and PRs welcome. Please ensure all checks pass before submitting.
 
 ## License
 

--- a/crates/claude-pool-server/Cargo.toml
+++ b/crates/claude-pool-server/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 description = "MCP server binary for claude-pool"
 documentation = "https://docs.rs/claude-pool-server"
+readme = "README.md"
 keywords = ["claude", "mcp", "pool", "server"]
 categories = ["development-tools"]
 

--- a/crates/claude-pool-server/README.md
+++ b/crates/claude-pool-server/README.md
@@ -1,0 +1,502 @@
+# claude-pool-server
+
+MCP server binary for managing Claude worker pools
+
+[![Crates.io](https://img.shields.io/crates/v/claude-pool-server.svg)](https://crates.io/crates/claude-pool-server)
+[![Documentation](https://docs.rs/claude-pool-server/badge.svg)](https://docs.rs/claude-pool-server)
+[![CI](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/claude-pool-server.svg)](LICENSE-MIT)
+
+## Overview
+
+`claude-pool-server` is a standalone binary that exposes `claude-pool` as an MCP server over stdio transport. Add it to your `.mcp.json` and interact with worker pools directly from interactive Claude sessions.
+
+Perfect for:
+- Delegating work to background Claude workers
+- Scaling tasks in parallel
+- Long-running analysis jobs
+- Budget-aware task orchestration
+
+## Installation
+
+### From crates.io
+
+```bash
+cargo install claude-pool-server
+```
+
+### From source
+
+```bash
+git clone https://github.com/joshrotenberg/claude-wrapper
+cargo install --path crates/claude-pool-server
+```
+
+## Quick Start
+
+```bash
+# Start server with 4 workers, $10 budget, Sonnet model
+claude-pool-server -n 4 --budget-usd 10.0 --model sonnet
+```
+
+Add to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "claude-pool": {
+      "command": "claude-pool-server",
+      "args": ["-n", "4", "--budget-usd", "10.0", "--model", "sonnet"]
+    }
+  }
+}
+```
+
+Reload your Claude Code session to enable the server.
+
+## CLI Flags
+
+### Worker Configuration
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-n, --workers` | `NUMBER` | 2 | Number of workers to spawn |
+| `--model` | `STRING` | - | Default model for all workers (e.g. `sonnet`, `opus`) |
+
+### Default Settings
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--effort` | `LEVEL` | Default effort: min, low, medium, high, max |
+| `--system-prompt` | `TEXT` | System prompt for all workers |
+| `--permission-mode` | `MODE` | default, acceptEdits, bypassPermissions, plan, auto (default: plan) |
+
+### Budget Control
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--budget-usd` | `AMOUNT` | Total budget cap in USD (e.g. 10.0) |
+
+### Advanced Options
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `-w, --worktree` | - | Enable Git worktree isolation per worker |
+| `--no-builtins` | - | Disable built-in skills (code_review, refactor, etc.) |
+
+### Examples
+
+```bash
+# 8 workers, $50 budget, high effort
+claude-pool-server -n 8 --budget-usd 50 --effort high
+
+# Lightweight setup with worktree isolation
+claude-pool-server -n 2 --budget-usd 5.0 --worktree
+
+# Custom system prompt
+claude-pool-server -n 4 --system-prompt "You are a Rust expert. Focus on idiomatic code."
+
+# Plan mode (no auto-execution, requires approval)
+claude-pool-server -n 4 --permission-mode plan
+```
+
+## .mcp.json Configuration
+
+Full example with all options:
+
+```json
+{
+  "mcpServers": {
+    "claude-pool": {
+      "command": "claude-pool-server",
+      "args": [
+        "-n", "4",
+        "--budget-usd", "20.0",
+        "--model", "sonnet",
+        "--effort", "high",
+        "--permission-mode", "plan"
+      ],
+      "env": {
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}
+```
+
+## MCP Tools
+
+All tools are async and return JSON results.
+
+### Task Execution
+
+#### pool_run
+
+Execute a task synchronously (wait for completion):
+
+```
+Prompt: Execute this task and wait for result
+@mcp pool_run prompt: "write a haiku about rust"
+
+Returns: { output: "...", spend_usd: 0.15, tokens_used: { input: 50, output: 20 } }
+```
+
+Parameters:
+- `prompt` (string, required) - The task to execute
+
+Response includes:
+- `output` - Claude's response
+- `spend_usd` - Cost of this task
+- `tokens_used` - Input and output tokens
+
+#### pool_submit
+
+Submit a task asynchronously (returns immediately with task ID):
+
+```
+@mcp pool_submit prompt: "long-running analysis"
+
+Returns: { task_id: "task_abc123" }
+```
+
+Parameters:
+- `prompt` (string, required) - The task to submit
+
+#### pool_result
+
+Retrieve result by task ID:
+
+```
+@mcp pool_result task_id: "task_abc123"
+
+Returns: { output: "...", spend_usd: 0.15, status: "completed" }
+```
+
+Parameters:
+- `task_id` (string, required) - Task ID from pool_submit
+
+#### pool_cancel
+
+Cancel a pending or running task:
+
+```
+@mcp pool_cancel task_id: "task_abc123"
+
+Returns: { status: "cancelled" }
+```
+
+Parameters:
+- `task_id` (string, required) - Task ID to cancel
+
+### Parallel Execution
+
+#### pool_fan_out
+
+Execute multiple prompts in parallel:
+
+```
+@mcp pool_fan_out prompts: ["write a poem", "write a haiku", "write a limerick"]
+
+Returns: [
+  { output: "Roses are red...", spend_usd: 0.10 },
+  { output: "A haiku here...", spend_usd: 0.08 },
+  { output: "A limerick...", spend_usd: 0.12 }
+]
+```
+
+Parameters:
+- `prompts` (array of strings, required) - Tasks to execute in parallel
+
+All tasks run concurrently. Returns when all complete.
+
+### Sequential Chains
+
+#### pool_chain
+
+Execute a sequential pipeline synchronously:
+
+```
+@mcp pool_chain steps: [
+  { prompt: "analyze the error" },
+  { prompt: "write a fix" },
+  { prompt: "write tests" }
+]
+
+Returns: { final_output: "...", steps: [...], total_spend: 0.45 }
+```
+
+Parameters:
+- `steps` (array, required) - Steps to execute in order
+  - `prompt` (string) - The step task
+  - `failure_policy` (string, optional) - retry, skip, or abort (default: abort)
+
+#### pool_submit_chain
+
+Submit a chain for async execution:
+
+```
+@mcp pool_submit_chain steps: [...]
+
+Returns: { chain_id: "chain_xyz789" }
+```
+
+#### pool_chain_result
+
+Get chain progress and results:
+
+```
+@mcp pool_chain_result chain_id: "chain_xyz789"
+
+Returns: {
+  status: "in_progress",
+  completed_steps: 1,
+  total_steps: 3,
+  current_step: { name: "write a fix", status: "running" },
+  steps: [...]
+}
+```
+
+### Context Management
+
+Share key-value data with all workers (injected into system prompts).
+
+#### context_set
+
+Inject a key-value pair:
+
+```
+@mcp context_set key: "language" value: "rust"
+@mcp context_set key: "framework" value: "tokio"
+
+Returns: { key: "language", value: "rust" }
+```
+
+#### context_get
+
+Retrieve a value:
+
+```
+@mcp context_get key: "language"
+
+Returns: { value: "rust" }
+```
+
+#### context_list
+
+List all context keys:
+
+```
+@mcp context_list
+
+Returns: {
+  language: "rust",
+  framework: "tokio",
+  style: "idiomatic"
+}
+```
+
+#### context_delete
+
+Remove a context key:
+
+```
+@mcp context_delete key: "framework"
+
+Returns: { deleted: true }
+```
+
+### Worker Management
+
+#### pool_status
+
+Get current pool state:
+
+```
+@mcp pool_status
+
+Returns: {
+  workers: [
+    { id: "worker-0", status: "idle", active_tasks: 0 },
+    { id: "worker-1", status: "busy", active_tasks: 1 }
+  ],
+  active_tasks: 1,
+  pending_tasks: 3,
+  spend_usd: 2.50,
+  budget_usd: 10.0,
+  budget_remaining: 7.50
+}
+```
+
+#### pool_drain
+
+Graceful shutdown (cancel pending tasks, wait for active tasks):
+
+```
+@mcp pool_drain
+
+Returns: {
+  total_tasks: 15,
+  completed: 12,
+  errors: 1,
+  total_spend: 3.45
+}
+```
+
+### Skills
+
+Skills are reusable task templates with argument validation.
+
+#### pool_skill_run
+
+Execute a named skill:
+
+```
+@mcp pool_skill_run skill: "code_review" arguments: { path: "src/main.rs", criteria: "bugs" }
+
+Returns: { output: "Review findings...", spend_usd: 0.20 }
+```
+
+Parameters:
+- `skill` (string, required) - Skill name
+- `arguments` (object, optional) - Skill arguments by name
+
+## MCP Resources
+
+Access pool state and task details via resources.
+
+| Resource | Description |
+|----------|-------------|
+| `pool://status` | Current pool state (workers, tasks, spend) |
+| `pool://workers` | List of all workers |
+| `pool://workers/{id}` | Single worker details by ID |
+| `pool://budget` | Budget info (total, spent, remaining) |
+| `pool://context` | All context key-value pairs |
+| `pool://results/{task_id}` | Task result by ID |
+| `pool://chains/{chain_id}` | Chain progress and results |
+
+## Usage Patterns from Claude
+
+### Example 1: Parallel Code Review
+
+```
+I need to review 3 files in parallel.
+
+Use pool/fan-out to review them:
+@mcp pool_fan_out prompts: [
+  "Review src/main.rs for bugs",
+  "Review src/lib.rs for style",
+  "Review src/error.rs for clarity"
+]
+
+Then summarize:
+@mcp pool_run prompt: "Summarize the reviews"
+```
+
+### Example 2: Sequential Workflow
+
+```
+Let's implement and test a feature:
+
+@mcp pool_chain steps: [
+  { prompt: "Implement login feature in src/auth.rs" },
+  { prompt: "Write integration tests for authentication" },
+  { prompt: "Review code for security issues" }
+]
+```
+
+### Example 3: Async Long-Running Task
+
+```
+Start a long analysis:
+@mcp pool_submit prompt: "Analyze entire codebase for refactoring opportunities"
+
+# ... do other work ...
+
+Check progress:
+@mcp pool_status
+
+Get result:
+@mcp pool_result task_id: "task_abc123"
+```
+
+### Example 4: Budget-Aware Work
+
+```
+Set context for all workers:
+@mcp context_set key: "budget_constraint" value: "optimize for cost"
+
+Then submit work:
+@mcp pool_run prompt: "Write a minimal test suite"
+```
+
+## Built-in Skills
+
+Pre-registered skills available by default (unless `--no-builtins`):
+
+- **code_review** - Review code for bugs, style, and clarity
+- **write_tests** - Generate tests for code
+- **refactor** - Refactor code for clarity and performance
+- **summarize** - Summarize text or code
+
+Use with `pool_skill_run`.
+
+## Troubleshooting
+
+### Server Won't Start
+
+**"command not found: claude-pool-server"**
+- Ensure installation: `cargo install claude-pool-server`
+- Or run from source: `cargo run -p claude-pool-server -- ...`
+
+**"claude: command not found"**
+- Install Claude CLI: https://claude.ai/download
+- Or specify path: needs investigation
+
+### Workers Not Responding
+
+Check worker status:
+```
+@mcp pool_status
+```
+
+If workers are offline, restart the server.
+
+### Budget Exceeded
+
+Tasks are rejected when budget cap is reached:
+```
+@mcp pool_status
+# Check budget_remaining
+
+# Increase budget:
+# Restart server with larger --budget-usd
+```
+
+### High Latency
+
+Consider:
+- Reducing worker count (fewer concurrent tasks)
+- Increasing timeout settings
+- Using async submission for non-urgent tasks
+
+## Performance Tuning
+
+### Worker Count
+
+- **2 workers** - Light tasks, minimal resource usage
+- **4 workers** - Balanced for typical workflows
+- **8+ workers** - Heavy parallelization, requires higher budget
+
+### Effort Level
+
+- `low` - Fast responses, fewer resources
+- `medium` - Balanced speed and quality (default)
+- `high` - Thorough analysis, higher cost
+
+### Worktree Isolation
+
+`--worktree` adds overhead but enables safe parallel file edits.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 description = "MCP server for managing a pool of Claude CLI workers"
 documentation = "https://docs.rs/claude-pool"
+readme = "README.md"
 keywords = ["claude", "mcp", "pool", "ai", "orchestration"]
 categories = ["development-tools", "asynchronous"]
 

--- a/crates/claude-pool/README.md
+++ b/crates/claude-pool/README.md
@@ -1,0 +1,369 @@
+# claude-pool
+
+Worker pool orchestration library for Claude CLI
+
+[![Crates.io](https://img.shields.io/crates/v/claude-pool.svg)](https://crates.io/crates/claude-pool)
+[![Documentation](https://docs.rs/claude-pool/badge.svg)](https://docs.rs/claude-pool)
+[![CI](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/claude-pool.svg)](LICENSE-MIT)
+
+## Overview
+
+`claude-pool` manages N Claude CLI workers behind a unified interface. A coordinator (typically an interactive Claude session) submits work, and the pool routes tasks by availability, tracks budgets, and handles worker lifecycle and session management.
+
+Perfect for:
+- Scaling Claude work across multiple workers
+- Budget-aware task distribution
+- Parallel and sequential task orchestration
+- Worker isolation with optional Git worktrees
+
+## Architecture
+
+```
+Coordinator (your app or interactive session)
+  │
+  ├─ pool.run("task")           → synchronous
+  ├─ pool.submit("task")        → async, returns task ID
+  ├─ pool.fan_out([tasks])      → parallel execution
+  └─ execute_chain(steps)       → sequential pipeline
+        │
+        ├── Pool (task queue, context, budget)
+        │
+        ├── Worker-0 (Claude instance)
+        ├── Worker-1 (Claude instance)
+        └── Worker-N (Claude instance)
+```
+
+## Installation
+
+```bash
+cargo add claude-pool
+```
+
+Requires: `claude-wrapper` (included as dependency)
+
+## Quick Start
+
+```rust
+use claude_pool::Pool;
+use claude_wrapper::Claude;
+
+#[tokio::main]
+async fn main() -> claude_pool::Result<()> {
+    let claude = Claude::builder().build()?;
+    let pool = Pool::builder(claude)
+        .workers(4)
+        .build()
+        .await?;
+
+    let result = pool.run("write a haiku about rust").await?;
+    println!("{}", result.output);
+
+    pool.drain().await?;
+    Ok(())
+}
+```
+
+## Core Concepts
+
+### Synchronous vs Asynchronous Tasks
+
+**Synchronous (blocking):**
+```rust
+let result = pool.run("your task here").await?;
+println!("{}", result.output);
+```
+
+**Asynchronous (non-blocking):**
+```rust
+let task_id = pool.submit("long-running task").await?;
+// Do other work...
+let result = pool.result(&task_id).await??;
+```
+
+### Budget Control
+
+Track and limit spending:
+
+```rust
+let pool = Pool::builder(claude)
+    .workers(4)
+    .config(
+        GlobalWorkerConfig::default()
+            .with_budget_usd(50.0)  // Pool-level cap
+    )
+    .build()
+    .await?;
+```
+
+Budget is tracked atomically per task. When the pool reaches its cap, subsequent tasks are rejected.
+
+### Worker Identity
+
+Each worker has metadata for coordination:
+
+```rust
+pool.configure_worker("worker-0", "analyzer", "Code review specialist")
+    .await?;
+pool.configure_worker("worker-1", "writer", "Code generation specialist")
+    .await?;
+```
+
+Access worker info:
+```rust
+let status = pool.status().await?;
+for worker in status.workers {
+    println!("{}: {} ({} active)", worker.id, worker.role, worker.busy_tasks);
+}
+```
+
+### Shared Context
+
+Inject key-value pairs into all worker system prompts:
+
+```rust
+pool.context_set("language", "rust").await?;
+pool.context_set("framework", "tokio").await?;
+pool.context_set("style", "idiomatic").await?;
+
+// All workers now see these in their system prompts
+```
+
+Access context:
+```rust
+let value = pool.context_get("language").await??;
+pool.context_delete("framework").await?;
+let all = pool.context_list().await?;
+```
+
+## Pool Builder Configuration
+
+```rust
+use claude_pool::{Pool, GlobalWorkerConfig, Effort, PermissionMode};
+
+let pool = Pool::builder(claude)
+    .workers(8)
+    .config(
+        GlobalWorkerConfig::default()
+            .with_model("sonnet")
+            .with_effort(Effort::High)
+            .with_budget_usd(100.0)
+            .with_permission_mode(PermissionMode::Plan)
+            .with_system_prompt("You are a Rust expert")
+            .with_worktree(true)
+    )
+    .build()
+    .await?;
+```
+
+Available config options:
+- `with_model(name)` - Default model for all workers
+- `with_effort(level)` - Effort: Min, Low, Medium, High, Max
+- `with_budget_usd(amount)` - Total pool budget
+- `with_permission_mode(mode)` - Permission defaults
+- `with_system_prompt(text)` - Base system prompt
+- `with_worktree(true)` - Enable Git worktree per worker
+
+## Execution Patterns
+
+### Single Task (Synchronous)
+
+```rust
+let result = pool.run("fix the bug in main.rs").await?;
+println!("Output:\n{}", result.output);
+println!("Spend: ${}", result.spend_usd);
+```
+
+Result includes:
+- `output` - Claude's response
+- `spend_usd` - Cost of this task
+- `tokens_used` - Input and output tokens
+
+### Async Task Submission
+
+```rust
+// Submit and get task ID immediately
+let task_id = pool.submit("long-running analysis").await?;
+
+// Do other work...
+
+// Poll for result later
+let result = pool.result(&task_id).await??;
+```
+
+### Parallel Fan-Out
+
+Execute multiple prompts in parallel, all at once:
+
+```rust
+let prompts = vec![
+    "write a poem",
+    "write a haiku",
+    "write a limerick",
+];
+
+let results = pool.fan_out(&prompts).await?;
+for (i, result) in results.iter().enumerate() {
+    println!("Result {}: {}", i, result.output);
+}
+```
+
+All tasks run concurrently. Returns when all complete (or timeout).
+
+### Sequential Chains with Failure Policies
+
+Execute steps in order, with control over failures:
+
+```rust
+use claude_pool::{ChainStep, StepFailurePolicy};
+
+let steps = vec![
+    ChainStep::new("analyze the error").with_policy(StepFailurePolicy::Abort),
+    ChainStep::new("write a fix").with_policy(StepFailurePolicy::Retry(2)),
+    ChainStep::new("write tests").with_policy(StepFailurePolicy::Skip),
+];
+
+let result = execute_chain(&pool, steps, ChainOptions::default()).await?;
+println!("Chain result: {}", result.final_output);
+```
+
+Failure policies:
+- **Abort** - Stop chain on failure
+- **Retry(n)** - Retry up to N times
+- **Skip** - Skip this step, continue
+
+Access chain progress:
+```rust
+let progress = pool.chain_result(&chain_id).await?;
+for step in progress.steps {
+    println!("{}: {}", step.name, step.status);
+}
+```
+
+## Skills Registry
+
+Register reusable task patterns with argument validation:
+
+```rust
+use claude_pool::{Skill, SkillArgument, SkillRegistry};
+
+let mut registry = SkillRegistry::new();
+registry.register(Skill {
+    name: "code_review".to_string(),
+    description: "Review code for bugs and style".to_string(),
+    prompt: "Review the code at {path} for {criteria}".to_string(),
+    arguments: vec![
+        SkillArgument {
+            name: "path".to_string(),
+            description: "File to review".to_string(),
+            required: true,
+        },
+        SkillArgument {
+            name: "criteria".to_string(),
+            description: "What to focus on (bugs, style, performance)".to_string(),
+            required: false,
+        },
+    ],
+    config: None,
+});
+```
+
+Skills can be triggered via the MCP server or called programmatically.
+
+## Worktree Isolation
+
+Enable optional Git worktree per worker for safe, isolated execution:
+
+```rust
+let pool = Pool::builder(claude)
+    .workers(4)
+    .config(
+        GlobalWorkerConfig::default()
+            .with_worktree(true)
+    )
+    .build()
+    .await?;
+```
+
+Each worker gets an isolated worktree:
+- Independent filesystem
+- Safe for parallel edits
+- Cleanup on drain
+
+Benefits:
+- Parallel file edits without conflicts
+- Isolated git state
+- Safe cleanup
+
+## Worker Lifecycle
+
+### Spawning
+
+Workers are created during `build()` and remain alive until `drain()`.
+
+### Session Resumption
+
+Workers automatically resume sessions if available, reducing startup cost.
+
+### Graceful Shutdown
+
+```rust
+let summary = pool.drain().await?;
+println!("Processed {} tasks", summary.total_tasks);
+println!("Total spend: ${}", summary.total_spend_usd);
+println!("Errors: {}", summary.error_count);
+```
+
+All pending tasks are cancelled. Active tasks complete gracefully.
+
+## Status & Monitoring
+
+Get current pool state:
+
+```rust
+let status = pool.status().await?;
+println!("Workers: {}", status.workers.len());
+println!("Active tasks: {}", status.active_tasks);
+println!("Budget: ${} / ${}", status.spend_usd, status.budget_usd);
+println!("Remaining: ${}", status.budget_usd - status.spend_usd);
+```
+
+Status includes:
+- Worker list with ID, status, and active task count
+- Active and pending task counts
+- Total spend and budget
+- Budget remaining
+
+## Error Handling
+
+All operations return `Result<T>`:
+
+```rust
+use claude_pool::Error;
+
+match pool.run("task").await {
+    Ok(result) => println!("{}", result.output),
+    Err(Error::TaskFailed(msg)) => eprintln!("Task error: {}", msg),
+    Err(Error::BudgetExceeded) => eprintln!("Out of budget"),
+    Err(Error::NoWorkersAvailable) => eprintln!("All workers busy"),
+    Err(e) => eprintln!("Other error: {}", e),
+}
+```
+
+Common errors:
+- `TaskFailed` - Task execution failed
+- `BudgetExceeded` - Pool exceeded spending cap
+- `NoWorkersAvailable` - All workers busy/offline
+- `TaskNotFound` - Invalid task ID
+
+## Testing
+
+Requires the `claude` CLI binary:
+
+```bash
+cargo test --lib --all-features
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/claude-pool/src/skill.rs
+++ b/crates/claude-pool/src/skill.rs
@@ -197,6 +197,157 @@ pub fn builtin_skills() -> Vec<Skill> {
             arguments: vec![],
             config: None,
         },
+        Skill {
+            name: "project_pre_push".into(),
+            description: "Pre-push checks for claude-wrapper workspace (all 3 crates in order)."
+                .into(),
+            prompt:
+                "Run the pre-push checklist for the claude-wrapper workspace:\n\n\
+                 Workspace structure: claude-pool → claude-pool-server → claude-wrapper\n\
+                 MSRV: 1.90 | Edition: 2024 | License: MIT OR Apache-2.0\n\n\
+                 Run these checks IN ORDER and stop on first failure:\n\n\
+                 1. Format check:   `cargo fmt --all -- --check`\n\
+                 2. Clippy lint:    `cargo clippy --all-targets --all-features -- -D warnings`\n\
+                 3. Unit tests:     `cargo test --lib --all-features`\n\
+                 4. Integration:    `cargo test --test '*' --all-features`\n\
+                 5. Docs build:     `cargo doc --no-deps --all-features`\n\
+                 6. Doc tests:      `cargo test --doc --all-features`\n\n\
+                 If any check fails, fix the issue and re-run ONLY that check. \
+                 Do NOT skip to the next check.\n\n\
+                 Report:\n\
+                 - Each step result (pass/fail)\n\
+                 - What was fixed (if anything)\n\
+                 - Final status (ready to push / blocked)"
+                    .into(),
+            arguments: vec![],
+            config: None,
+        },
+        Skill {
+            name: "project_release".into(),
+            description: "Release readiness checks for all 3 crates in dependency order."
+                .into(),
+            prompt:
+                "Check release readiness for all 3 crates. Test in dependency order:\n\n\
+                 1. claude-pool (core crate)\n\
+                 2. claude-pool-server (depends on claude-pool)\n\
+                 3. claude-wrapper (leaf crate)\n\n\
+                 For EACH crate in order:\n\n\
+                 a) Run all pre-commit checks:\n\
+                    - `cargo fmt --all -- --check`\n\
+                    - `cargo clippy --all-targets --all-features -- -D warnings`\n\
+                    - `cargo test --lib --all-features`\n\
+                    - `cargo test --test '*' --all-features`\n\n\
+                 b) Run release-specific checks:\n\
+                    - `cargo doc --no-deps --all-features` (docs build without warnings)\n\
+                    - `cargo test --doc --all-features` (doc tests pass)\n\
+                    - `cargo publish --dry-run -p {crate}` (package builds)\n\n\
+                 Stop on first failure. Fix and re-run that crate, then continue.\n\n\
+                 Report:\n\
+                 - Crate-by-crate status\n\
+                 - Any failures with fixes applied\n\
+                 - Final readiness verdict (ready / blocked)"
+                    .into(),
+            arguments: vec![],
+            config: None,
+        },
+        Skill {
+            name: "project_review".into(),
+            description: "Review code/PR against claude-wrapper project standards."
+                .into(),
+            prompt:
+                "Review the following code/changes against claude-wrapper standards:\n\n\
+                 STANDARDS (from CLAUDE.md):\n\
+                 ✓ Rust 2024 edition\n\
+                 ✓ MSRV 1.90\n\
+                 ✓ thiserror for library errors, anyhow for app errors\n\
+                 ✓ ALL public APIs have doc comments (required)\n\
+                 ✓ `cargo fmt` applied\n\
+                 ✓ Conventional commits: feat/fix/docs/refactor/test/chore\n\
+                 ✓ Branch naming: fix/, feat/, docs/, refactor/, test/\n\
+                 ✓ No backward-compat hacks or unused code\n\
+                 ✓ Builder pattern for CLIs and command APIs\n\
+                 ✓ Typed outputs over stringly-typed\n\n\
+                 WORKSPACE CONTEXT:\n\
+                 - claude-pool: core skill/worker system\n\
+                 - claude-pool-server: MCP server exposing pool\n\
+                 - claude-wrapper: CLI wrapper library\n\
+                 - Dependencies: pool → pool-server, both used by wrapper\n\n\
+                 Review thoroughly for:\n\
+                 - Missing doc comments on public items\n\
+                 - Unconventional error handling\n\
+                 - Style/formatting issues\n\
+                 - Breaking changes without ! marker\n\
+                 - Architecture misalignment\n\n\
+                 {target}"
+                    .into(),
+            arguments: vec![SkillArgument {
+                name: "target".into(),
+                description: "Code diff, file path, or PR # to review.".into(),
+                required: true,
+            }],
+            config: None,
+        },
+        Skill {
+            name: "project_implement".into(),
+            description: "Implement features with claude-wrapper workspace context."
+                .into(),
+            prompt:
+                "Implement the following feature for claude-wrapper.\n\n\
+                 PROJECT CONTEXT:\n\
+                 - 3-crate workspace: claude-pool (core), claude-pool-server (MCP), claude-wrapper (CLI lib)\n\
+                 - Rust 2024 edition | MSRV 1.90\n\
+                 - License: MIT OR Apache-2.0\n\
+                 - Error handling: thiserror for libs, anyhow for apps\n\n\
+                 KEY PATTERNS:\n\
+                 - Builder pattern for command APIs (see QueryCommand, McpAddCommand examples)\n\
+                 - Typed outputs over stringly-typed returns\n\
+                 - All public APIs MUST have doc comments\n\
+                 - Streaming support for long operations (NDJSON)\n\
+                 - Process spawning with timeout and env control\n\n\
+                 CONVENTIONS:\n\
+                 - Use conventional commits (feat:, fix:, docs:, refactor:, test:, chore:)\n\
+                 - Features that change behavior use feat!: (minor version bump)\n\
+                 - No backward-compat hacks; delete unused code cleanly\n\
+                 - Over-engineering is anti-pattern: minimum complexity for task\n\n\
+                 BEFORE PUSHING:\n\
+                 1. Pass all pre-commit checks (fmt, clippy, tests)\n\
+                 2. Doc build and doc tests pass\n\
+                 3. New public APIs have comprehensive doc comments\n\
+                 4. Commit follows conventional format\n\n\
+                 {description}"
+                    .into(),
+            arguments: vec![SkillArgument {
+                name: "description".into(),
+                description: "Feature description, issue #, or requirements.".into(),
+                required: true,
+            }],
+            config: None,
+        },
+        Skill {
+            name: "project_pr".into(),
+            description: "Create a PR following claude-wrapper conventions."
+                .into(),
+            prompt:
+                "Create a pull request for the following changes.\n\n\
+                 CONVENTIONS:\n\
+                 - Title: Use conventional commit format (e.g., 'feat: add xyz', 'fix: resolve bug')\n\
+                 - Link: Reference issues for auto-closing (Closes #123)\n\
+                 - Description: Include what changed and why\n\
+                 - NO merge: PR author does not merge (maintainer will review and merge)\n\
+                 - NO signatures: Remove any 'Generated with Claude Code' or Co-Authored-By lines\n\n\
+                 BRANCH INFO:\n\
+                 - Branch naming: fix/, feat/, docs/, refactor/, test/, chore/\n\
+                 - Branch should be based on main\n\
+                 - Branch should be pushed before creating PR\n\n\
+                 {details}"
+                    .into(),
+            arguments: vec![SkillArgument {
+                name: "details".into(),
+                description: "PR details: branch name, issue ref, what changed.".into(),
+                required: true,
+            }],
+            config: None,
+        },
     ]
 }
 
@@ -275,12 +426,17 @@ mod tests {
     #[test]
     fn builtins_load() {
         let registry = SkillRegistry::with_builtins();
-        assert_eq!(registry.list().len(), 6);
+        assert_eq!(registry.list().len(), 11);
         assert!(registry.get("code_review").is_some());
         assert!(registry.get("implement").is_some());
         assert!(registry.get("write_tests").is_some());
         assert!(registry.get("refactor").is_some());
         assert!(registry.get("summarize").is_some());
         assert!(registry.get("pre_push").is_some());
+        assert!(registry.get("project_pre_push").is_some());
+        assert!(registry.get("project_release").is_some());
+        assert!(registry.get("project_review").is_some());
+        assert!(registry.get("project_implement").is_some());
+        assert!(registry.get("project_pr").is_some());
     }
 }

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 description = "A type-safe Claude Code CLI wrapper for Rust"
 documentation = "https://docs.rs/claude-wrapper"
+readme = "README.md"
 keywords = ["claude", "cli", "wrapper", "ai", "mcp"]
 categories = ["development-tools", "api-bindings"]
 

--- a/crates/claude-wrapper/README.md
+++ b/crates/claude-wrapper/README.md
@@ -1,0 +1,336 @@
+# claude-wrapper
+
+A type-safe Claude Code CLI wrapper for Rust
+
+[![Crates.io](https://img.shields.io/crates/v/claude-wrapper.svg)](https://crates.io/crates/claude-wrapper)
+[![Documentation](https://docs.rs/claude-wrapper/badge.svg)](https://docs.rs/claude-wrapper)
+[![CI](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/claude-wrapper.svg)](LICENSE-MIT)
+
+## Overview
+
+`claude-wrapper` provides a type-safe builder-pattern interface for invoking the `claude` CLI programmatically. It follows the same design philosophy as [`docker-wrapper`](https://crates.io/crates/docker-wrapper) and [`terraform-wrapper`](https://crates.io/crates/terraform-wrapper): each CLI subcommand is a builder struct that produces typed output.
+
+Perfect for Rust applications that need to integrate with Claude Code CLI.
+
+## Installation
+
+```bash
+cargo add claude-wrapper
+```
+
+## Quick Start
+
+```rust
+use claude_wrapper::{Claude, QueryCommand};
+
+#[tokio::main]
+async fn main() -> claude_wrapper::Result<()> {
+    let claude = Claude::builder().build()?;
+    let output = QueryCommand::new("explain this error")
+        .model("sonnet")
+        .execute(&claude)
+        .await?;
+    println!("{}", output.stdout);
+    Ok(())
+}
+```
+
+## Two-Layer Builder Architecture
+
+The `Claude` client holds shared configuration (binary path, environment, timeout). Command builders hold per-invocation options and call `execute(&claude)`.
+
+### Claude Client
+
+Configure once, reuse across commands:
+
+```rust
+let claude = Claude::builder()
+    .env("AWS_REGION", "us-west-2")
+    .timeout_secs(300)
+    .build()?;
+```
+
+Options:
+- `binary_path()` - Path to `claude` binary (auto-detected by default)
+- `working_dir()` - Working directory for commands
+- `env()` - Set environment variables
+- `timeout_secs()` - Command timeout (default: 300)
+- `global_args()` - Additional global args
+
+### Command Builders
+
+Each command is a separate builder. Available commands:
+
+- **QueryCommand** - Execute queries with full option coverage (28 options)
+- **McpListCommand** - List MCP servers
+- **McpAddCommand** - Add HTTP or stdio MCP server
+- **McpAddJsonCommand** - Add server from JSON config
+- **McpRemoveCommand** - Remove MCP server
+- **McpAddFromDesktopCommand** - Add desktop MCP server
+- **McpResetProjectChoicesCommand** - Reset project-specific choices
+- **PluginListCommand** - List plugins
+- **PluginInstallCommand** - Install plugin
+- **PluginUninstallCommand** - Uninstall plugin
+- **PluginEnableCommand** - Enable plugin
+- **PluginDisableCommand** - Disable plugin
+- **PluginUpdateCommand** - Update plugin
+- **PluginValidateCommand** - Validate plugin
+- **AuthStatusCommand** - Check authentication status
+- **VersionCommand** - Get CLI version
+- **DoctorCommand** - Run health check
+- **AgentsListCommand** - List available agents
+- **RawCommand** - Escape hatch for unsupported options
+
+## QueryCommand: The Workhorse
+
+Full coverage of `claude -p` (print mode) options.
+
+### All QueryCommand Options
+
+| Method | CLI Flag | Type | Description |
+|--------|----------|------|-------------|
+| `model()` | `--model` | `&str` | Model alias or full ID |
+| `system_prompt()` | `--system-prompt` | `&str` | Replace default system prompt |
+| `append_system_prompt()` | `--append-system-prompt` | `&str` | Append to system prompt |
+| `output_format()` | `--output-format` | `OutputFormat` | text, json, stream-json |
+| `max_budget_usd()` | `--max-budget-usd` | `f64` | Spending cap |
+| `permission_mode()` | `--permission-mode` | `PermissionMode` | default, acceptEdits, bypassPermissions, plan, auto |
+| `allowed_tools()` | `--allowed-tools` | `&[&str]` | Tool permission allow list |
+| `disallowed_tools()` | `--disallowed-tools` | `&[&str]` | Tool permission deny list |
+| `tools()` | `--tools` | `&[&str]` | Restrict available tools |
+| `mcp_config()` | `--mcp-config` | `&str` | MCP server config file |
+| `strict_mcp_config()` | `--strict-mcp-config` | - | Only use MCP from config |
+| `add_dir()` | `--add-dir` | `&str` | Additional accessible directories |
+| `effort()` | `--effort` | `Effort` | low, medium, high |
+| `max_turns()` | `--max-turns` | `u32` | Conversation turn limit |
+| `json_schema()` | `--json-schema` | `&str` | Structured output validation |
+| `agent()` | `--agent` | `&str` | Agent for session |
+| `agents_json()` | `--agents` | `&str` | Custom agents JSON |
+| `continue_session()` | `--continue` | - | Resume most recent session |
+| `resume()` | `--resume` | `&str` | Resume by session ID |
+| `session_id()` | `--session-id` | `&str` | Use specific session ID |
+| `fork_session()` | `--fork-session` | - | Fork when resuming |
+| `fallback_model()` | `--fallback-model` | `&str` | Fallback model |
+| `no_session_persistence()` | `--no-session-persistence` | - | Don't save session |
+| `dangerously_skip_permissions()` | `--dangerously-skip-permissions` | - | Bypass permissions |
+| `file()` | `--file` | `&str` | File resources to download |
+| `input_format()` | `--input-format` | `InputFormat` | text or stream-json |
+| `include_partial_messages()` | `--include-partial-messages` | - | Partial chunks |
+| `settings()` | `--settings` | `&str` | Settings JSON file |
+
+### Usage Examples
+
+Simple query with model override:
+
+```rust
+let output = QueryCommand::new("explain this error: file not found")
+    .model("sonnet")
+    .execute(&claude)
+    .await?;
+println!("{}", output.stdout);
+```
+
+JSON output with schema validation:
+
+```rust
+let output = QueryCommand::new("generate a user struct")
+    .output_format(OutputFormat::Json)
+    .json_schema(r#"{"type":"object","properties":{"id":{"type":"integer"}}}"#)
+    .execute(&claude)
+    .await?;
+```
+
+With permissions and tools:
+
+```rust
+let output = QueryCommand::new("implement the feature in TASK.md")
+    .model("opus")
+    .permission_mode(PermissionMode::Plan)
+    .allowed_tools(["Bash", "Read", "Edit", "Write"])
+    .max_budget_usd(1.0)
+    .execute(&claude)
+    .await?;
+```
+
+Session management:
+
+```rust
+// Start new session
+let output = QueryCommand::new("analyze the codebase")
+    .session_id("my-session")
+    .execute(&claude)
+    .await?;
+
+// Resume later
+let output = QueryCommand::new("what did we find?")
+    .resume("my-session")
+    .execute(&claude)
+    .await?;
+```
+
+## Streaming NDJSON Events
+
+For real-time output, use `stream_query()`:
+
+```rust
+use claude_wrapper::streaming::stream_query;
+
+let output = stream_query(&claude, &cmd, |event| {
+    if event.is_result() {
+        println!("Result: {}", event.result_text().unwrap_or(""));
+    }
+    if event.is_error() {
+        eprintln!("Error: {}", event.error().unwrap_or(""));
+    }
+}).await?;
+```
+
+## MCP Server Commands
+
+### List Servers
+
+```rust
+let output = McpListCommand::new()
+    .execute(&claude)
+    .await?;
+println!("{}", output.stdout);
+```
+
+### Add HTTP Server
+
+```rust
+McpAddCommand::new("sentry", "https://mcp.sentry.dev/mcp")
+    .transport("http")
+    .execute(&claude)
+    .await?;
+```
+
+### Add Stdio Server
+
+```rust
+McpAddCommand::new("my-tool", "npx")
+    .server_args(["my-mcp-server"])
+    .env("API_KEY", "secret")
+    .execute(&claude)
+    .await?;
+```
+
+### Add from JSON
+
+```rust
+McpAddJsonCommand::new("config.json")
+    .execute(&claude)
+    .await?;
+```
+
+### Remove Server
+
+```rust
+McpRemoveCommand::new("old-server")
+    .execute(&claude)
+    .await?;
+```
+
+## MCP Config Builder
+
+Generate `.mcp.json` files programmatically:
+
+```rust
+use claude_wrapper::McpConfigBuilder;
+
+McpConfigBuilder::new()
+    .http_server("hub", "http://127.0.0.1:9090")
+    .stdio_server("tool", "npx", ["my-server"])
+    .write_to("/tmp/my-project/.mcp.json")?;
+```
+
+Also supports:
+- `env()` - Environment variables for servers
+- `environment_file()` - Load from env file
+
+## Plugin Management
+
+```rust
+// List plugins
+PluginListCommand::new().execute(&claude).await?;
+
+// Install plugin
+PluginInstallCommand::new("my-plugin")
+    .execute(&claude)
+    .await?;
+
+// Enable plugin
+PluginEnableCommand::new("my-plugin")
+    .execute(&claude)
+    .await?;
+
+// Update plugin
+PluginUpdateCommand::new("my-plugin")
+    .execute(&claude)
+    .await?;
+```
+
+## Other Commands
+
+```rust
+// Check auth
+AuthStatusCommand::new().execute(&claude).await?;
+
+// Get version
+VersionCommand::new().execute(&claude).await?;
+
+// Health check
+DoctorCommand::new().execute(&claude).await?;
+
+// List agents
+AgentsListCommand::new().execute(&claude).await?;
+```
+
+## Escape Hatch: RawCommand
+
+For unsupported options, use `RawCommand`:
+
+```rust
+let output = RawCommand::new()
+    .arg("custom-subcommand")
+    .arg("--unsupported-flag")
+    .arg("value")
+    .execute(&claude)
+    .await?;
+```
+
+## Error Handling
+
+All commands return `Result<T>`, where errors are typed with `thiserror`:
+
+```rust
+use claude_wrapper::Error;
+
+match QueryCommand::new("test").execute(&claude).await {
+    Ok(output) => println!("{}", output.stdout),
+    Err(Error::ProcessError(e)) => eprintln!("Process failed: {}", e),
+    Err(Error::InvalidUtf8) => eprintln!("Output not valid UTF-8"),
+    Err(e) => eprintln!("Other error: {}", e),
+}
+```
+
+## Features
+
+Optional Cargo features (all enabled by default):
+
+- `json` - JSON output parsing via serde_json
+- `tempfile` - Temporary file support for MCP config generation
+
+## Testing
+
+Requires the `claude` CLI binary to be installed:
+
+```bash
+cargo test --lib --all-features
+cargo test --test integration -- --ignored  # requires `claude` binary
+```
+
+## License
+
+MIT OR Apache-2.0


### PR DESCRIPTION
## Summary

Added 5 project-specific skills to the built-in registry. These skills embed claude-wrapper workspace knowledge and standards, making it easier to automate common tasks.

### New Skills

- **project_pre_push**: Pre-push checklist for the 3-crate workspace (format, lint, unit tests, integration tests, docs build, doc tests). Runs checks in order and stops on first failure.

- **project_release**: Release readiness checks for all 3 crates in dependency order (claude-pool → claude-pool-server → claude-wrapper). Tests pre-commit checks, docs build, doc tests, and dry-run publish for each crate.

- **project_review**: Reviews code/PR changes against claude-wrapper standards (Rust 2024, MSRV 1.90, error handling patterns, doc comments, builder pattern, conventional commits, workspace structure).

- **project_implement**: Context-aware implementation skill that includes workspace structure, MSRV, edition, design patterns, conventions, and the pre-push checklist. Takes a feature description or issue number.

- **project_pr**: PR creation guidance that follows claude-wrapper conventions (conventional commits, issue linking, branch naming, no merges, no generated signatures).

### Key Features

- All skills are namespaced with  prefix to avoid conflicts with built-in skills
- Each skill includes relevant project context (3-crate structure, MSRV, patterns, standards)
- Workspace-level tasks have no arguments; task-specific skills take targeted arguments
- Tests updated to verify all 11 skills (6 built-in + 5 project-specific)

Closes #37