### PR TITLE
docs: add multi-worker coordination guidance

### DIFF
--- a/crates/claude-pool-server/README.md
+++ b/crates/claude-pool-server/README.md
@@ -497,6 +497,37 @@ Consider:
 
 `--worktree` adds overhead but enables safe parallel file edits.
 
+## Multi-Worker Coordination
+
+When running parallel chains or multiple workers on the same repo, coordination prevents conflicts and ensures clean handoffs.
+
+### Enable Worktree Isolation
+
+For any workflow that chains multiple steps across different workers (e.g. plan → code → review → PR), **always use worktree isolation**:
+
+```bash
+claude-pool-server -n 4 --worktree
+```
+
+Each worker gets an isolated git worktree. Without this, concurrent `git checkout` and `git branch` operations interfere with each other, causing PRs to land on wrong branches and requiring manual cleanup.
+
+### Branch Best Practices
+
+When chains create PRs, follow these patterns:
+
+1. **Fresh main** - Fetch `origin/main` at chain start, branch from it (not stale local main)
+2. **Issue reference** - Include issue number in branch name: `feat/add-foo-#42`
+3. **Clear scope** - One issue per chain. Parallel chains on different issues won't conflict
+
+### Conflict Handling
+
+When parallel PRs edit the same files, Git flags them as conflicting:
+- Second PR to merge needs a rebase
+- Recovery: Run `git rebase origin/main` and resolve conflicts
+- Consider monitoring with `/loop 3m check PR conflicts` to surface issues early
+
+For strategies beyond worktree isolation (conflict awareness, branch automation, recovery prompts), see issue [#34](https://github.com/joshrotenberg/claude-wrapper/issues/34).
+
 ## License
 
 MIT OR Apache-2.0


### PR DESCRIPTION
## Summary

Added practical guidance for coordinating multiple workers running in parallel, addressing issue #34.

## Changes

**New section:** "Multi-Worker Coordination" in `crates/claude-pool-server/README.md` (+31 lines)

### Content

- **Worktree Isolation** - Enable with `--worktree` flag to prevent concurrent git operations from interfering with each other when parallel chains modify code
- **Branch Best Practices** - Fresh main, issue numbers in branch names, one issue per chain to avoid conflicts
- **Conflict Handling** - Recovery strategies (rebase, monitoring) for when parallel PRs touch the same files
- **Reference to #34** - Links to deeper patterns for tier-2+ strategies (branch automation, conflict awareness, recovery prompts)

## Tier 1 Pattern

This documents the essential tier-1 pattern (worktree isolation) that enables safe parallel workflows. See issue #34 for tier-2+ coordination strategies.

Closes #34