### PR TITLE
fix: add version specs to workspace deps for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/claude-wrapper"
 
 [workspace.dependencies]
-claude-wrapper = { path = "crates/claude-wrapper" }
-claude-pool = { path = "crates/claude-pool" }
+claude-wrapper = { path = "crates/claude-wrapper", version = "0.2" }
+claude-pool = { path = "crates/claude-pool", version = "0.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"


### PR DESCRIPTION
cargo publish requires all dependencies to have a version specified. The workspace deps for claude-wrapper and claude-pool only had path references, causing release-plz to fail publishing claude-pool and claude-pool-server.

Adds `version = "0.2"` and `version = "0.1"` to the workspace dependency declarations.