### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.2.1...v0.3.0) - 2026-03-11
+
+### Added
+
+- add Session management abstraction ([#133](https://github.com/joshrotenberg/claude-wrapper/pull/133))
+- add --json support to AgentsCommand and DoctorCommand ([#129](https://github.com/joshrotenberg/claude-wrapper/pull/129))
+- fix cost tracking by matching CLI's total_cost_usd field ([#106](https://github.com/joshrotenberg/claude-wrapper/pull/106))
+
+### Other
+
+- update READMEs for release readiness ([#135](https://github.com/joshrotenberg/claude-wrapper/pull/135))
+- add claude-wrapper integration tests for streaming, timeout, and errors ([#120](https://github.com/joshrotenberg/claude-wrapper/pull/120))
+- add fake-claude binary and integration test infrastructure ([#119](https://github.com/joshrotenberg/claude-wrapper/pull/119))
+
 ## [0.2.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.2.0...v0.2.1) - 2026-03-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-pool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "claude-wrapper",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "claude-pool-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "clap",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "claude-wrapper"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/claude-wrapper"
 
 [workspace.dependencies]
-claude-wrapper = { path = "crates/claude-wrapper", version = "0.2" }
-claude-pool = { path = "crates/claude-pool", version = "0.1" }
+claude-wrapper = { path = "crates/claude-wrapper", version = "0.3" }
+claude-pool = { path = "crates/claude-pool", version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/claude-pool-server/CHANGELOG.md
+++ b/crates/claude-pool-server/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-server-v0.1.0...claude-pool-server-v0.2.0) - 2026-03-11
+
+### Added
+
+- add Session management abstraction ([#133](https://github.com/joshrotenberg/claude-wrapper/pull/133))
+- default chain isolation to worktree and add rebase skill ([#114](https://github.com/joshrotenberg/claude-wrapper/pull/114))
+- structured inter-step context for chains ([#112](https://github.com/joshrotenberg/claude-wrapper/pull/112))
+- add HTTP transport for claude-pool-server ([#111](https://github.com/joshrotenberg/claude-wrapper/pull/111))
+- per-chain worktree isolation opt-in ([#104](https://github.com/joshrotenberg/claude-wrapper/pull/104)) ([#109](https://github.com/joshrotenberg/claude-wrapper/pull/109))
+- add chain cancellation (pool_cancel_chain) ([#107](https://github.com/joshrotenberg/claude-wrapper/pull/107))
+- pass MCP config to pool slots ([#100](https://github.com/joshrotenberg/claude-wrapper/pull/100))
+- add skill management tools (list/get/add/remove/save) ([#98](https://github.com/joshrotenberg/claude-wrapper/pull/98))
+- [**breaking**] add skill scopes and extract project-specific skills ([#93](https://github.com/joshrotenberg/claude-wrapper/pull/93))
+- load project-local skills from .claude-pool/skills/ directory ([#87](https://github.com/joshrotenberg/claude-wrapper/pull/87))
+- add --min-slots/--max-slots CLI flags and document dynamic scaling ([#91](https://github.com/joshrotenberg/claude-wrapper/pull/91))
+
+### Other
+
+- update READMEs for release readiness ([#135](https://github.com/joshrotenberg/claude-wrapper/pull/135))
+- add claude-pool-server tool handler tests ([#126](https://github.com/joshrotenberg/claude-wrapper/pull/126))
+- make tool surface and server instructions workflow-agnostic ([#96](https://github.com/joshrotenberg/claude-wrapper/pull/96))
+- add model selection heuristics to server instructions ([#89](https://github.com/joshrotenberg/claude-wrapper/pull/89))
+- add installation and deployment guidance ([#84](https://github.com/joshrotenberg/claude-wrapper/pull/84))
+
 ## [0.1.0](https://github.com/joshrotenberg/claude-wrapper/releases/tag/claude-pool-server-v0.1.0) - 2026-03-10
 
 ### Added

--- a/crates/claude-pool-server/Cargo.toml
+++ b/crates/claude-pool-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-pool-server"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/claude-pool/CHANGELOG.md
+++ b/crates/claude-pool/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.1.0...claude-pool-v0.2.0) - 2026-03-11
+
+### Added
+
+- add Session management abstraction ([#133](https://github.com/joshrotenberg/claude-wrapper/pull/133))
+- add --json support to AgentsCommand and DoctorCommand ([#129](https://github.com/joshrotenberg/claude-wrapper/pull/129))
+- default chain isolation to worktree and add rebase skill ([#114](https://github.com/joshrotenberg/claude-wrapper/pull/114))
+- structured inter-step context for chains ([#112](https://github.com/joshrotenberg/claude-wrapper/pull/112))
+- per-chain worktree isolation opt-in ([#104](https://github.com/joshrotenberg/claude-wrapper/pull/104)) ([#109](https://github.com/joshrotenberg/claude-wrapper/pull/109))
+- live output for running chain steps ([#108](https://github.com/joshrotenberg/claude-wrapper/pull/108))
+- add chain cancellation (pool_cancel_chain) ([#107](https://github.com/joshrotenberg/claude-wrapper/pull/107))
+- fix cost tracking by matching CLI's total_cost_usd field ([#106](https://github.com/joshrotenberg/claude-wrapper/pull/106))
+- pass MCP config to pool slots ([#100](https://github.com/joshrotenberg/claude-wrapper/pull/100))
+- add supervisor loop for slot health monitoring ([#97](https://github.com/joshrotenberg/claude-wrapper/pull/97))
+- add skill management tools (list/get/add/remove/save) ([#98](https://github.com/joshrotenberg/claude-wrapper/pull/98))
+- [**breaking**] add skill scopes and extract project-specific skills ([#93](https://github.com/joshrotenberg/claude-wrapper/pull/93))
+- load project-local skills from .claude-pool/skills/ directory ([#87](https://github.com/joshrotenberg/claude-wrapper/pull/87))
+- add built-in create_pr skill ([#90](https://github.com/joshrotenberg/claude-wrapper/pull/90))
+- detect permission prompts in pool slot stderr ([#88](https://github.com/joshrotenberg/claude-wrapper/pull/88))
+
+### Other
+
+- update READMEs for release readiness ([#135](https://github.com/joshrotenberg/claude-wrapper/pull/135))
+- add claude-pool integration tests for pool lifecycle, chains, and supervisor ([#127](https://github.com/joshrotenberg/claude-wrapper/pull/127))
+- add fake-claude binary and integration test infrastructure ([#119](https://github.com/joshrotenberg/claude-wrapper/pull/119))
+- make tool surface and server instructions workflow-agnostic ([#96](https://github.com/joshrotenberg/claude-wrapper/pull/96))
+
 ## [0.1.0](https://github.com/joshrotenberg/claude-wrapper/releases/tag/claude-pool-v0.1.0) - 2026-03-10
 
 ### Added

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-pool"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `claude-pool`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `claude-pool-server`: 0.1.0 -> 0.2.0 (✓ API compatible changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field QueryResult.num_turns in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-wrapper/src/types.rs:194
  field QueryResult.num_turns in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-wrapper/src/types.rs:194

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field working_dir of variant Error::CommandFailed in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-wrapper/src/error.rs:17
  field working_dir of variant Error::Io in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-wrapper/src/error.rs:26
  field working_dir of variant Error::CommandFailed in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-wrapper/src/error.rs:17
  field working_dir of variant Error::Io in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-wrapper/src/error.rs:26

--- failure unit_struct_changed_kind: unit struct changed kind ---

Description:
A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
        ref: https://github.com/rust-lang/cargo/pull/10871
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/unit_struct_changed_kind.ron

Failed in:
  struct DoctorCommand in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-wrapper/src/command/doctor.rs:21
  struct DoctorCommand in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-wrapper/src/command/doctor.rs:21
```

### ⚠ `claude-pool` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ChainStep.output_vars in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:46
  field ChainStep.output_vars in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:46
  field ChainProgress.current_step_partial_output in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:151
  field ChainProgress.current_step_started_at in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:156
  field ChainProgress.current_step_partial_output in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:151
  field ChainProgress.current_step_started_at in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:156
  field ChainOptions.isolation in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:102
  field ChainOptions.isolation in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:102
  field SlotRecord.mcp_config_path in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/types.rs:237
  field SlotRecord.mcp_config_path in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/types.rs:237
  field ResolvedConfig.mcp_servers in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/config.rs:27
  field ResolvedConfig.strict_mcp_config in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/config.rs:29
  field Skill.scope in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/skill.rs:95
  field Skill.scope in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/skill.rs:95
  field StepResult.skipped in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:121
  field StepResult.skipped in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:121
  field PoolConfig.supervisor_enabled in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/types.rs:108
  field PoolConfig.supervisor_interval_secs in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/types.rs:113
  field PoolConfig.strict_mcp_config in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/types.rs:120
  field PoolConfig.supervisor_enabled in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/types.rs:108
  field PoolConfig.supervisor_interval_secs in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/types.rs:113
  field PoolConfig.strict_mcp_config in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/types.rs:120

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ChainStatus:Cancelled in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:174
  variant ChainStatus:Cancelled in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:174
  variant Error:PermissionPromptDetected in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/error.rs:46
  variant Error:Io in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/error.rs:57
  variant Error:PermissionPromptDetected in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/error.rs:46
  variant Error:Io in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/error.rs:57

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  claude_pool::chain::execute_chain_with_progress now takes 5 parameters instead of 4, in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/chain.rs:225

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  claude_pool::skill::SkillRegistry::register now takes 2 parameters instead of 1, in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/skill.rs:157
  claude_pool::SkillRegistry::register now takes 2 parameters instead of 1, in /tmp/.tmpGWoCKX/claude-wrapper/crates/claude-pool/src/skill.rs:157
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-wrapper`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.2.1...v0.3.0) - 2026-03-11

### Added

- add Session management abstraction ([#133](https://github.com/joshrotenberg/claude-wrapper/pull/133))
- add --json support to AgentsCommand and DoctorCommand ([#129](https://github.com/joshrotenberg/claude-wrapper/pull/129))
- fix cost tracking by matching CLI's total_cost_usd field ([#106](https://github.com/joshrotenberg/claude-wrapper/pull/106))

### Other

- update READMEs for release readiness ([#135](https://github.com/joshrotenberg/claude-wrapper/pull/135))
- add claude-wrapper integration tests for streaming, timeout, and errors ([#120](https://github.com/joshrotenberg/claude-wrapper/pull/120))
- add fake-claude binary and integration test infrastructure ([#119](https://github.com/joshrotenberg/claude-wrapper/pull/119))
</blockquote>

## `claude-pool`

<blockquote>

## [0.2.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.1.0...claude-pool-v0.2.0) - 2026-03-11

### Added

- add Session management abstraction ([#133](https://github.com/joshrotenberg/claude-wrapper/pull/133))
- add --json support to AgentsCommand and DoctorCommand ([#129](https://github.com/joshrotenberg/claude-wrapper/pull/129))
- default chain isolation to worktree and add rebase skill ([#114](https://github.com/joshrotenberg/claude-wrapper/pull/114))
- structured inter-step context for chains ([#112](https://github.com/joshrotenberg/claude-wrapper/pull/112))
- per-chain worktree isolation opt-in ([#104](https://github.com/joshrotenberg/claude-wrapper/pull/104)) ([#109](https://github.com/joshrotenberg/claude-wrapper/pull/109))
- live output for running chain steps ([#108](https://github.com/joshrotenberg/claude-wrapper/pull/108))
- add chain cancellation (pool_cancel_chain) ([#107](https://github.com/joshrotenberg/claude-wrapper/pull/107))
- fix cost tracking by matching CLI's total_cost_usd field ([#106](https://github.com/joshrotenberg/claude-wrapper/pull/106))
- pass MCP config to pool slots ([#100](https://github.com/joshrotenberg/claude-wrapper/pull/100))
- add supervisor loop for slot health monitoring ([#97](https://github.com/joshrotenberg/claude-wrapper/pull/97))
- add skill management tools (list/get/add/remove/save) ([#98](https://github.com/joshrotenberg/claude-wrapper/pull/98))
- [**breaking**] add skill scopes and extract project-specific skills ([#93](https://github.com/joshrotenberg/claude-wrapper/pull/93))
- load project-local skills from .claude-pool/skills/ directory ([#87](https://github.com/joshrotenberg/claude-wrapper/pull/87))
- add built-in create_pr skill ([#90](https://github.com/joshrotenberg/claude-wrapper/pull/90))
- detect permission prompts in pool slot stderr ([#88](https://github.com/joshrotenberg/claude-wrapper/pull/88))

### Other

- update READMEs for release readiness ([#135](https://github.com/joshrotenberg/claude-wrapper/pull/135))
- add claude-pool integration tests for pool lifecycle, chains, and supervisor ([#127](https://github.com/joshrotenberg/claude-wrapper/pull/127))
- add fake-claude binary and integration test infrastructure ([#119](https://github.com/joshrotenberg/claude-wrapper/pull/119))
- make tool surface and server instructions workflow-agnostic ([#96](https://github.com/joshrotenberg/claude-wrapper/pull/96))
</blockquote>

## `claude-pool-server`

<blockquote>

## [0.2.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-server-v0.1.0...claude-pool-server-v0.2.0) - 2026-03-11

### Added

- add Session management abstraction ([#133](https://github.com/joshrotenberg/claude-wrapper/pull/133))
- default chain isolation to worktree and add rebase skill ([#114](https://github.com/joshrotenberg/claude-wrapper/pull/114))
- structured inter-step context for chains ([#112](https://github.com/joshrotenberg/claude-wrapper/pull/112))
- add HTTP transport for claude-pool-server ([#111](https://github.com/joshrotenberg/claude-wrapper/pull/111))
- per-chain worktree isolation opt-in ([#104](https://github.com/joshrotenberg/claude-wrapper/pull/104)) ([#109](https://github.com/joshrotenberg/claude-wrapper/pull/109))
- add chain cancellation (pool_cancel_chain) ([#107](https://github.com/joshrotenberg/claude-wrapper/pull/107))
- pass MCP config to pool slots ([#100](https://github.com/joshrotenberg/claude-wrapper/pull/100))
- add skill management tools (list/get/add/remove/save) ([#98](https://github.com/joshrotenberg/claude-wrapper/pull/98))
- [**breaking**] add skill scopes and extract project-specific skills ([#93](https://github.com/joshrotenberg/claude-wrapper/pull/93))
- load project-local skills from .claude-pool/skills/ directory ([#87](https://github.com/joshrotenberg/claude-wrapper/pull/87))
- add --min-slots/--max-slots CLI flags and document dynamic scaling ([#91](https://github.com/joshrotenberg/claude-wrapper/pull/91))

### Other

- update READMEs for release readiness ([#135](https://github.com/joshrotenberg/claude-wrapper/pull/135))
- add claude-pool-server tool handler tests ([#126](https://github.com/joshrotenberg/claude-wrapper/pull/126))
- make tool surface and server instructions workflow-agnostic ([#96](https://github.com/joshrotenberg/claude-wrapper/pull/96))
- add model selection heuristics to server instructions ([#89](https://github.com/joshrotenberg/claude-wrapper/pull/89))
- add installation and deployment guidance ([#84](https://github.com/joshrotenberg/claude-wrapper/pull/84))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).