### PR TITLE
feat: load project-local skills from directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "dashmap",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -7,6 +7,7 @@ mod prompts;
 mod resources;
 mod tools;
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
@@ -63,6 +64,14 @@ struct Cli {
     /// Disable built-in skills.
     #[arg(long)]
     no_builtins: bool,
+
+    /// Directory to load project-local skill definitions from.
+    #[arg(long, default_value = ".claude-pool/skills")]
+    skills_dir: PathBuf,
+
+    /// Skip loading project-local skills.
+    #[arg(long)]
+    no_project_skills: bool,
 }
 
 fn parse_permission_mode(s: &str) -> claude_pool::PermissionMode {
@@ -122,11 +131,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .map_err(|e| format!("failed to build pool: {e}"))?;
 
-    let skills = if cli.no_builtins {
+    let mut skills = if cli.no_builtins {
         SkillRegistry::new()
     } else {
         SkillRegistry::with_builtins()
     };
+
+    if !cli.no_project_skills {
+        let count = skills.load_from_dir(&cli.skills_dir)?;
+        if count > 0 {
+            tracing::info!(count, dir = %cli.skills_dir.display(), "loaded project skills");
+        }
+    }
 
     let workflows = WorkflowRegistry::with_builtins();
 

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -23,4 +23,5 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+tempfile = "3"
 tokio = { workspace = true }

--- a/crates/claude-pool/src/error.rs
+++ b/crates/claude-pool/src/error.rs
@@ -52,6 +52,10 @@ pub enum Error {
         slot_id: String,
     },
 
+    /// Filesystem I/O error.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
     /// An error from the store backend.
     #[error("store error: {0}")]
     Store(String),

--- a/crates/claude-pool/src/skill.rs
+++ b/crates/claude-pool/src/skill.rs
@@ -5,6 +5,7 @@
 //! then references them by name in `pool/run` or `pool/submit`.
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
@@ -105,6 +106,36 @@ impl SkillRegistry {
     /// Remove a skill by name.
     pub fn remove(&mut self, name: &str) -> Option<Skill> {
         self.skills.remove(name)
+    }
+
+    /// Load skill definitions from JSON files in a directory.
+    ///
+    /// Each `.json` file in the directory is deserialized as a [`Skill`] and
+    /// registered. Skills loaded this way override any existing skill with the
+    /// same name. Files are loaded in sorted order for deterministic behavior.
+    ///
+    /// Returns the number of skills loaded. If the directory does not exist,
+    /// returns `Ok(0)` without error.
+    pub fn load_from_dir(&mut self, dir: &Path) -> crate::Result<usize> {
+        if !dir.is_dir() {
+            return Ok(0);
+        }
+
+        let mut entries: Vec<_> = std::fs::read_dir(dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+
+        let mut count = 0;
+        for entry in entries {
+            let contents = std::fs::read_to_string(entry.path())?;
+            let skill: Skill = serde_json::from_str(&contents)?;
+            self.register(skill);
+            count += 1;
+        }
+
+        Ok(count)
     }
 }
 
@@ -576,6 +607,80 @@ mod tests {
 
         registry.remove("test");
         assert!(registry.list().is_empty());
+    }
+
+    #[test]
+    fn load_from_nonexistent_dir() {
+        let mut registry = SkillRegistry::new();
+        let count = registry
+            .load_from_dir(Path::new("/tmp/does-not-exist-claude-pool-test"))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn load_from_dir_with_json_files() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let skill_json = serde_json::json!({
+            "name": "my_skill",
+            "description": "A test skill",
+            "prompt": "Do {thing}",
+            "arguments": [
+                { "name": "thing", "description": "What to do", "required": true }
+            ],
+            "config": null
+        });
+        std::fs::write(
+            dir.path().join("my_skill.json"),
+            serde_json::to_string_pretty(&skill_json).unwrap(),
+        )
+        .unwrap();
+
+        // Non-json file should be ignored.
+        std::fs::write(dir.path().join("readme.txt"), "not a skill").unwrap();
+
+        let mut registry = SkillRegistry::new();
+        let count = registry.load_from_dir(dir.path()).unwrap();
+        assert_eq!(count, 1);
+
+        let skill = registry.get("my_skill").unwrap();
+        assert_eq!(skill.description, "A test skill");
+        assert_eq!(skill.arguments.len(), 1);
+        assert!(skill.arguments[0].required);
+    }
+
+    #[test]
+    fn project_skills_override_builtins() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let override_json = serde_json::json!({
+            "name": "code_review",
+            "description": "Custom project review",
+            "prompt": "Review with custom rules: {target}",
+            "arguments": [
+                { "name": "target", "description": "What to review", "required": true }
+            ],
+            "config": null
+        });
+        std::fs::write(
+            dir.path().join("code_review.json"),
+            serde_json::to_string_pretty(&override_json).unwrap(),
+        )
+        .unwrap();
+
+        let mut registry = SkillRegistry::with_builtins();
+        assert_eq!(
+            registry.get("code_review").unwrap().description,
+            "Review code for bugs, style issues, and improvements."
+        );
+
+        let count = registry.load_from_dir(dir.path()).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            registry.get("code_review").unwrap().description,
+            "Custom project review"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `SkillRegistry::load_from_dir()` to scan a directory for `*.json` skill definitions
- Add `--skills-dir` and `--no-project-skills` CLI flags to `claude-pool-server`
- Project skills in `.claude-pool/skills/` are loaded at startup and override builtins with the same name
- Add `Error::Io` variant for filesystem errors

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (59 tests, 3 new)
- [x] `cargo test --doc --all-features` (31 tests)
- [ ] Manual: create `.claude-pool/skills/my_skill.json`, verify it loads on startup
- [ ] Manual: verify `--no-project-skills` skips directory scan

Closes #36