### PR TITLE
feat: add scaling CLI flags and document dynamic scaling tools

### DIFF
--- a/crates/claude-pool-server/README.md
+++ b/crates/claude-pool-server/README.md
@@ -101,6 +101,13 @@ After reloading, run a quick smoke test from your Claude session:
 |------|------|-------------|
 | `--budget-usd` | `AMOUNT` | Total budget cap in USD (e.g. 10.0) |
 
+### Scaling Bounds
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--min-slots` | `NUMBER` | 1 | Minimum slots (floor for `pool_scale_down`) |
+| `--max-slots` | `NUMBER` | 16 | Maximum slots (ceiling for `pool_scale_up`) |
+
 ### Advanced Options
 
 | Flag | Type | Description |
@@ -365,6 +372,53 @@ Returns: {
   total_spend: 3.45
 }
 ```
+
+### Dynamic Scaling
+
+Grow or shrink the pool at runtime. Bounded by `--min-slots` and `--max-slots`.
+
+#### pool_scale_up
+
+Add slots to the pool:
+
+```
+@mcp pool_scale_up count: 2
+
+Returns: { success: true, new_slot_count: 6, details: "Scaled up by 2 slots" }
+```
+
+Parameters:
+- `count` (number, required) - Number of slots to add
+
+Fails if the new total would exceed `--max-slots`.
+
+#### pool_scale_down
+
+Remove slots from the pool (idle slots first):
+
+```
+@mcp pool_scale_down count: 2
+
+Returns: { success: true, new_slot_count: 2, details: "Scaled down by 2 slots" }
+```
+
+Parameters:
+- `count` (number, required) - Number of slots to remove
+
+Busy slots are given 30 seconds to finish before removal. Fails if the new total would drop below `--min-slots`.
+
+#### pool_set_target_slots
+
+Set the pool to an exact size, scaling up or down as needed:
+
+```
+@mcp pool_set_target_slots target: 8
+
+Returns: { success: true, new_slot_count: 8, target: 8 }
+```
+
+Parameters:
+- `target` (number, required) - Desired number of slots
 
 ### Skills
 

--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -48,6 +48,14 @@ struct Cli {
     #[arg(short, long, default_value = "plan")]
     permission_mode: String,
 
+    /// Minimum number of slots (floor for scale-down). Default: 1.
+    #[arg(long, default_value = "1")]
+    min_slots: usize,
+
+    /// Maximum number of slots (ceiling for scale-up). Default: 16.
+    #[arg(long, default_value = "16")]
+    max_slots: usize,
+
     /// Enable git worktree isolation for slots.
     #[arg(short = 'w', long)]
     worktree: bool,
@@ -98,6 +106,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         system_prompt: cli.system_prompt,
         permission_mode: Some(parse_permission_mode(&cli.permission_mode)),
         worktree_isolation: cli.worktree,
+        scaling: claude_pool::ScalingConfig {
+            min_slots: cli.min_slots,
+            max_slots: cli.max_slots,
+        },
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary

- Add `--min-slots` and `--max-slots` CLI flags to `claude-pool-server`, wired into `ScalingConfig`
- Document `pool_scale_up`, `pool_scale_down`, `pool_set_target_slots` in the server README
- Add "Scaling Bounds" section to CLI Flags table

The core implementation (`scale_up`, `scale_down`, `set_target_slots` methods + MCP tools + 7 unit tests) was already complete. This PR adds the missing CLI configurability and documentation.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (59 passed)
- [x] `cargo test --doc --all-features` (31 passed)
- [ ] Manual: `claude-pool-server --min-slots 2 --max-slots 8 -n 4` starts correctly
- [ ] Manual: `pool_scale_up` beyond `--max-slots` returns error
- [ ] Manual: `pool_scale_down` below `--min-slots` returns error

Closes #43