### PR TITLE
docs: make tool surface and server instructions workflow-agnostic

### DIFF
--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -171,18 +171,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .server_info("claude-pool", env!("CARGO_PKG_VERSION"))
         .instructions(
             "Execution modes: use inline for decisions and interactive work; pool_run for simple \
-             administrative tasks; pool_submit_chain for multi-step workflows (plan/code/review/PR) \
-             to keep conversations responsive; pool_fan_out for parallel tasks; Agent tool for \
-             research requiring MCP tools (GitHub, crates.io). Pool slots have CLI tools (git, \
-             cargo, gh) but not MCP access. Default to inline when uncertain; user can say \
-             \"slotize it.\" \
+             administrative tasks; pool_submit_chain for multi-step workflows to keep conversations \
+             responsive; pool_fan_out for parallel tasks; Agent tool for research requiring MCP \
+             tools. Pool slots have CLI tools (git, cargo, gh) but not MCP access. Default to \
+             inline when uncertain; user can say \"slotize it.\" \
              \
              Task sizing: Single task (pool_run) = one clear action with one clear output; if using \
              \"and\" more than once, use a chain instead. Chain = workflow where steps feed into each \
-             other; natural unit is a deliverable (PR, report, resolved issue); each step should be \
-             independently verifiable (can't describe success of step N without referencing N+1 = \
-             steps too coupled). Fan-out = N independent instances of same work; use if items don't \
-             depend on each other; use chain if they do. \
+             other; natural unit is a deliverable (e.g. a PR, report, or resolved issue); each step \
+             should be independently verifiable (can't describe success of step N without referencing \
+             N+1 = steps too coupled). Fan-out = N independent instances of same work; use if items \
+             don't depend on each other; use chain if they do. \
              \
              Tools: pool_run (synchronous), pool_submit/pool_result (async), pool_fan_out (parallel), \
              pool_chain (synchronous pipeline), pool_submit_chain/pool_chain_result (async pipeline \
@@ -191,8 +190,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              (step config) to fine-tune cost and quality. \
              \
              Model guidance: default to the pool's configured model; override per-task/step with \
-             the model field when needed. Haiku: bounded single tasks (create issue, run checks, \
-             rebase, label), template-driven work, high-volume fan-outs where speed matters. \
+             the model field when needed. Haiku: bounded single tasks (file a ticket, run checks, \
+             rebase, tag), template-driven work, high-volume fan-outs where speed matters. \
              Sonnet: code review needing subtlety, multi-file changes with dependencies, planning \
              steps where quality matters. Opus: large mechanical refactors where one mistake breaks \
              compilation, complex architectural reasoning, tasks where you would want a senior \

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -615,8 +615,8 @@ pub fn pool_invoke_workflow_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -
     ToolBuilder::new("pool_invoke_workflow")
         .title("Invoke Workflow")
         .description(
-            "Submit a preset workflow template (e.g. 'issue_to_pr', 'refactor_and_test', \
-             'review_and_fix') with arguments. Returns a task_id immediately.",
+            "Submit a named workflow template with arguments. Returns a task_id immediately. \
+             Example workflows: 'issue_to_pr', 'refactor_and_test', 'review_and_fix'.",
         )
         .handler(move |input: InvokeWorkflowInput| {
             let state = Arc::clone(&state);

--- a/crates/claude-pool/src/skill.rs
+++ b/crates/claude-pool/src/skill.rs
@@ -296,9 +296,9 @@ pub fn builtin_skills() -> Vec<Skill> {
                      1. Check if the current branch has an upstream. If not, push with \
                         `git push -u origin HEAD`.\n\
                      2. Create the PR with `gh pr create --title \"...\" --body \"...\"`.\n\
-                     3. Do NOT merge the PR.\n\
-                     4. Do NOT include Co-Authored-By or \"Generated with Claude Code\" \
-                        signatures in the PR body.\n\
+                     3. Leave the PR open for the user to merge.\n\
+                     4. Omit Co-Authored-By and \"Generated with Claude Code\" signatures \
+                        (per project convention).\n\
                      5. Report the PR URL when done."
                 .into(),
             arguments: vec![


### PR DESCRIPTION
Reframes tool descriptions and server instructions to describe capabilities rather than prescribe specific workflows. Workflow-specific guidance (GitHub, PRs, etc.) belongs in skills, not the tool surface.

## Changes

- **Server instructions** (`main.rs`): Remove `(plan/code/review/PR)` workflow example from execution modes, remove explicit `(GitHub, crates.io)` MCP names, frame deliverable types as examples with "e.g.", use generic task names ("file a ticket" instead of "create issue")
- **Tool description** (`tools.rs`): `pool_invoke_workflow` leads with what it does, lists workflow names as examples
- **Skill prompt** (`skill.rs`): `create_pr` softens prescriptive "Do NOT" into convention-based language ("Leave the PR open for the user to merge", "Omit ... per project convention")

## What stays the same

- `issue_watcher` and `loop_monitor` skills keep their GitHub-specific workflows (skills are where workflow opinions belong)
- All guidance preserved, just reframed from prescriptive to descriptive

Closes #75