### PR TITLE
feat: add skill management tools (list/get/add/remove/save)

### DIFF
--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -12,13 +12,19 @@ use std::sync::Arc;
 
 use clap::Parser;
 use claude_pool::{InMemoryStore, Pool, PoolConfig, PoolStore, SkillRegistry, WorkflowRegistry};
+use tokio::sync::RwLock;
 use tower_mcp::{McpRouter, StdioTransport};
 
 /// Shared state accessible by all tool/resource handlers.
 pub struct State<S: PoolStore> {
+    /// The pool instance.
     pub pool: Pool<S>,
-    pub skills: SkillRegistry,
+    /// Thread-safe skill registry (mutated by skill management tools).
+    pub skills: Arc<RwLock<SkillRegistry>>,
+    /// Workflow registry.
     pub workflows: WorkflowRegistry,
+    /// Directory for persisting project-local skills.
+    pub skills_dir: PathBuf,
 }
 
 /// MCP server for managing a pool of Claude CLI slots.
@@ -154,18 +160,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!(disabled = ?cli.disable_skill, "disabled skills");
     }
 
+    // Build prompts before wrapping skills in RwLock (prompts are static at startup).
+    let prompt_list = prompts::skill_prompts(&skills);
+
     let workflows = WorkflowRegistry::with_builtins();
 
     let state = Arc::new(State {
         pool,
-        skills,
+        skills: Arc::new(RwLock::new(skills)),
         workflows,
+        skills_dir: cli.skills_dir,
     });
 
     let tool_list = tools::all_tools(&state);
     let resource_list = resources::all_resources(&state);
     let template_list = resources::all_templates(&state);
-    let prompt_list = prompts::skill_prompts(&state.skills);
 
     let mut router = McpRouter::new()
         .server_info("claude-pool", env!("CARGO_PKG_VERSION"))
@@ -199,6 +208,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              engineer. Rule of thumb: how much does the task benefit from deeper thinking? \
              \
              Skills available as prompts: code_review, implement, write_tests, refactor, summarize. \
+             Skills management: pool_skill_list (discover), pool_skill_get (inspect), \
+             pool_skill_add (register ephemeral), pool_skill_remove (unregister), \
+             pool_skill_save (persist to disk). \
              \
              Scheduling: use Claude Code's /loop to run tasks on a recurring interval \
              (e.g. `/loop 30m check pool status`). /loop fires while idle (session-only). For \

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -1,8 +1,10 @@
 //! MCP tool definitions for claude-pool.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use claude_pool::PoolStore;
+use claude_pool::skill::{SkillScope, SkillSource};
 use claude_pool::types::SlotConfig;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -97,6 +99,70 @@ pub struct SetTargetSlotsInput {
     pub target: usize,
 }
 
+// ── Skill management input schemas ──────────────────────────────────
+
+/// Input for listing skills with optional filters.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SkillListInput {
+    /// Filter by scope: "task", "coordinator", "chain".
+    pub scope: Option<String>,
+    /// Filter by source: "builtin", "project", "runtime".
+    pub source: Option<String>,
+}
+
+/// Input for getting a skill by name.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SkillGetInput {
+    /// Skill name.
+    pub name: String,
+}
+
+/// Argument definition for a skill being added.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SkillArgumentInput {
+    /// Argument name (used as `{name}` placeholder in the prompt template).
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Whether this argument is required.
+    #[serde(default)]
+    pub required: bool,
+}
+
+/// Input for adding a new skill at runtime.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SkillAddInput {
+    /// Unique skill name.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Prompt template. Use `{arg_name}` placeholders for arguments.
+    pub prompt: String,
+    /// Argument definitions.
+    #[serde(default)]
+    pub arguments: Vec<SkillArgumentInput>,
+    /// Where this skill runs: "task" (default), "coordinator", "chain".
+    pub scope: Option<String>,
+    /// Per-skill config overrides as JSON (model, effort, etc.).
+    pub config: Option<serde_json::Value>,
+}
+
+/// Input for removing a skill by name.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SkillRemoveInput {
+    /// Skill name to remove.
+    pub name: String,
+}
+
+/// Input for saving a skill to disk.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SkillSaveInput {
+    /// Skill name to save.
+    pub name: String,
+    /// Directory to save to. Defaults to the configured skills_dir.
+    pub dir: Option<String>,
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
@@ -118,6 +184,23 @@ fn task_config_from(model: Option<String>, effort: Option<String>) -> Option<Slo
         effort: effort.and_then(|e| parse_effort(&e)),
         ..Default::default()
     })
+}
+
+fn parse_scope(s: &str) -> SkillScope {
+    match s {
+        "coordinator" => SkillScope::Coordinator,
+        "chain" => SkillScope::Chain,
+        _ => SkillScope::Task,
+    }
+}
+
+fn parse_source(s: &str) -> Option<SkillSource> {
+    match s {
+        "builtin" => Some(SkillSource::Builtin),
+        "project" => Some(SkillSource::Project),
+        "runtime" => Some(SkillSource::Runtime),
+        _ => None,
+    }
 }
 
 // ── Tool builders ────────────────────────────────────────────────────
@@ -468,7 +551,8 @@ pub fn pool_skill_run_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool
         .handler(move |input: SkillRunInput| {
             let state = Arc::clone(&state);
             async move {
-                let skill = match state.skills.get(&input.skill) {
+                let registry = state.skills.read().await;
+                let skill = match registry.get(&input.skill) {
                     Some(s) => s.clone(),
                     None => {
                         return Ok(CallToolResult::error(format!(
@@ -477,6 +561,7 @@ pub fn pool_skill_run_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool
                         )));
                     }
                 };
+                drop(registry);
 
                 let prompt = match skill.render(&input.arguments) {
                     Ok(p) => p,
@@ -513,7 +598,8 @@ pub fn pool_chain_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
             let state = Arc::clone(&state);
             async move {
                 let steps = convert_chain_steps(input.steps);
-                match claude_pool::execute_chain(&state.pool, &state.skills, &steps).await {
+                let skills = state.skills.read().await;
+                match claude_pool::execute_chain(&state.pool, &skills, &steps).await {
                     Ok(result) => Ok(CallToolResult::json(serde_json::to_value(&result).unwrap())),
                     Err(e) => Ok(CallToolResult::error(e.to_string())),
                 }
@@ -536,7 +622,8 @@ pub fn pool_submit_chain_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> T
                 let options = claude_pool::ChainOptions {
                     tags: input.tags.unwrap_or_default(),
                 };
-                match state.pool.submit_chain(steps, &state.skills, options).await {
+                let skills = state.skills.read().await;
+                match state.pool.submit_chain(steps, &skills, options).await {
                     Ok(task_id) => Ok(CallToolResult::json(
                         serde_json::json!({ "task_id": task_id.0 }),
                     )),
@@ -561,11 +648,8 @@ pub fn pool_fan_out_chains_tool<S: PoolStore + 'static>(state: Arc<State<S>>) ->
                 let options = claude_pool::ChainOptions {
                     tags: input.tags.unwrap_or_default(),
                 };
-                match state
-                    .pool
-                    .fan_out_chains(chains, &state.skills, options)
-                    .await
-                {
+                let skills = state.skills.read().await;
+                match state.pool.fan_out_chains(chains, &skills, options).await {
                     Ok(task_ids) => Ok(CallToolResult::json(serde_json::json!({
                         "task_ids": task_ids.iter().map(|id| &id.0).collect::<Vec<_>>()
                     }))),
@@ -621,12 +705,13 @@ pub fn pool_invoke_workflow_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -
         .handler(move |input: InvokeWorkflowInput| {
             let state = Arc::clone(&state);
             async move {
+                let skills = state.skills.read().await;
                 match state
                     .pool
                     .submit_workflow(
                         &input.workflow,
                         input.arguments,
-                        &state.skills,
+                        &skills,
                         &state.workflows,
                         input.tags.unwrap_or_default(),
                     )
@@ -707,6 +792,223 @@ pub fn pool_set_target_slots_tool<S: PoolStore + 'static>(state: Arc<State<S>>) 
         .build()
 }
 
+// ── Skill management tools ──────────────────────────────────────────
+
+/// List registered skills with optional scope/source filters.
+pub fn pool_skill_list_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_skill_list")
+        .title("List Skills")
+        .description("List registered skills with optional scope/source filters.")
+        .read_only()
+        .handler(move |input: SkillListInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let registry = state.skills.read().await;
+                let scope_filter = input.scope.as_deref().map(parse_scope);
+                let source_filter = input.source.as_deref().and_then(parse_source);
+
+                let mut results: Vec<_> = registry
+                    .list_registered()
+                    .into_iter()
+                    .filter(|rs| {
+                        if let Some(scope) = scope_filter
+                            && rs.skill.scope != scope
+                        {
+                            return false;
+                        }
+                        if let Some(source) = source_filter
+                            && rs.source != source
+                        {
+                            return false;
+                        }
+                        true
+                    })
+                    .map(|rs| {
+                        serde_json::json!({
+                            "name": rs.skill.name,
+                            "description": rs.skill.description,
+                            "scope": rs.skill.scope.to_string(),
+                            "source": rs.source.to_string(),
+                        })
+                    })
+                    .collect();
+                results.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+                Ok(CallToolResult::json(serde_json::json!(results)))
+            }
+        })
+        .build()
+}
+
+/// Get full details of a skill by name, including prompt template.
+pub fn pool_skill_get_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_skill_get")
+        .title("Get Skill Details")
+        .description("Get full details of a skill by name, including prompt template.")
+        .read_only()
+        .handler(move |input: SkillGetInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let registry = state.skills.read().await;
+                match registry.get_registered(&input.name) {
+                    Some(rs) => {
+                        let response = serde_json::json!({
+                            "name": rs.skill.name,
+                            "description": rs.skill.description,
+                            "prompt": rs.skill.prompt,
+                            "arguments": rs.skill.arguments.iter().map(|a| serde_json::json!({
+                                "name": a.name,
+                                "description": a.description,
+                                "required": a.required,
+                            })).collect::<Vec<_>>(),
+                            "scope": rs.skill.scope.to_string(),
+                            "source": rs.source.to_string(),
+                            "config": rs.skill.config,
+                        });
+                        Ok(CallToolResult::json(response))
+                    }
+                    None => Ok(CallToolResult::error(format!(
+                        "skill not found: {}",
+                        input.name
+                    ))),
+                }
+            }
+        })
+        .build()
+}
+
+/// Register a skill at runtime. Ephemeral unless saved with pool_skill_save.
+pub fn pool_skill_add_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_skill_add")
+        .title("Add Skill")
+        .description(
+            "Register a skill at runtime. Ephemeral (lost on restart) unless saved \
+             with pool_skill_save. Overwrites any existing skill with the same name.",
+        )
+        .handler(move |input: SkillAddInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let scope = input.scope.as_deref().map(parse_scope).unwrap_or_default();
+                let arguments = input
+                    .arguments
+                    .into_iter()
+                    .map(|a| claude_pool::SkillArgument {
+                        name: a.name,
+                        description: a.description,
+                        required: a.required,
+                    })
+                    .collect();
+                let config: Option<SlotConfig> =
+                    input.config.and_then(|v| serde_json::from_value(v).ok());
+                let skill = claude_pool::Skill {
+                    name: input.name.clone(),
+                    description: input.description,
+                    prompt: input.prompt,
+                    arguments,
+                    config,
+                    scope,
+                };
+                let mut registry = state.skills.write().await;
+                let overwritten = registry.get(&input.name).is_some();
+                registry.register(skill, SkillSource::Runtime);
+                Ok(CallToolResult::json(serde_json::json!({
+                    "name": input.name,
+                    "overwritten": overwritten,
+                    "source": "runtime",
+                })))
+            }
+        })
+        .build()
+}
+
+/// Remove a skill by name. Runtime-only, does not delete files.
+pub fn pool_skill_remove_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_skill_remove")
+        .title("Remove Skill")
+        .description("Remove a skill by name. Runtime-only, does not delete files on disk.")
+        .handler(move |input: SkillRemoveInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let mut registry = state.skills.write().await;
+                match registry.remove(&input.name) {
+                    Some(_) => Ok(CallToolResult::json(serde_json::json!({
+                        "removed": input.name,
+                    }))),
+                    None => Ok(CallToolResult::error(format!(
+                        "skill not found: {}",
+                        input.name
+                    ))),
+                }
+            }
+        })
+        .build()
+}
+
+/// Persist a skill to the project skills directory as JSON.
+pub fn pool_skill_save_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_skill_save")
+        .title("Save Skill to Disk")
+        .description(
+            "Persist a skill to the project skills directory as JSON. \
+             Creates/overwrites {dir}/{name}.json.",
+        )
+        .handler(move |input: SkillSaveInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let skill = {
+                    let registry = state.skills.read().await;
+                    match registry.get(&input.name) {
+                        Some(s) => s.clone(),
+                        None => {
+                            return Ok(CallToolResult::error(format!(
+                                "skill not found: {}",
+                                input.name
+                            )));
+                        }
+                    }
+                };
+
+                let dir = input
+                    .dir
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| state.skills_dir.clone());
+
+                if let Err(e) = std::fs::create_dir_all(&dir) {
+                    return Ok(CallToolResult::error(format!(
+                        "failed to create directory {}: {e}",
+                        dir.display()
+                    )));
+                }
+
+                let path = dir.join(format!("{}.json", input.name));
+                let json = match serde_json::to_string_pretty(&skill) {
+                    Ok(j) => j,
+                    Err(e) => return Ok(CallToolResult::error(format!("serialize error: {e}"))),
+                };
+
+                if let Err(e) = std::fs::write(&path, &json) {
+                    return Ok(CallToolResult::error(format!(
+                        "failed to write {}: {e}",
+                        path.display()
+                    )));
+                }
+
+                // Update source to Project since it's now persisted.
+                {
+                    let mut registry = state.skills.write().await;
+                    if let Some(existing) = registry.get(&input.name).cloned() {
+                        registry.register(existing, SkillSource::Project);
+                    }
+                }
+
+                Ok(CallToolResult::json(serde_json::json!({
+                    "saved": input.name,
+                    "path": path.display().to_string(),
+                })))
+            }
+        })
+        .build()
+}
+
 pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
     vec![
         pool_status_tool(Arc::clone(state)),
@@ -730,5 +1032,10 @@ pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
         context_delete_tool(Arc::clone(state)),
         context_list_tool(Arc::clone(state)),
         pool_configure_slot_tool(Arc::clone(state)),
+        pool_skill_list_tool(Arc::clone(state)),
+        pool_skill_get_tool(Arc::clone(state)),
+        pool_skill_add_tool(Arc::clone(state)),
+        pool_skill_remove_tool(Arc::clone(state)),
+        pool_skill_save_tool(Arc::clone(state)),
     ]
 }

--- a/crates/claude-pool/src/lib.rs
+++ b/crates/claude-pool/src/lib.rs
@@ -34,7 +34,7 @@ pub use chain::{
 };
 pub use error::{Error, Result};
 pub use pool::{DrainSummary, Pool, PoolBuilder, PoolStatus};
-pub use skill::{Skill, SkillArgument, SkillRegistry, SkillScope};
+pub use skill::{RegisteredSkill, Skill, SkillArgument, SkillRegistry, SkillScope, SkillSource};
 pub use store::{InMemoryStore, PoolStore};
 pub use types::*;
 pub use workflow::{Workflow, WorkflowArgument, WorkflowRegistry};

--- a/crates/claude-pool/src/skill.rs
+++ b/crates/claude-pool/src/skill.rs
@@ -11,6 +11,37 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::SlotConfig;
 
+/// How a skill was registered in the registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillSource {
+    /// Ships with the pool binary.
+    Builtin,
+    /// Loaded from a `.claude-pool/skills/` JSON file.
+    Project,
+    /// Added at runtime via `pool_skill_add`.
+    Runtime,
+}
+
+impl std::fmt::Display for SkillSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Builtin => write!(f, "builtin"),
+            Self::Project => write!(f, "project"),
+            Self::Runtime => write!(f, "runtime"),
+        }
+    }
+}
+
+/// A skill paired with its registration source.
+#[derive(Debug, Clone)]
+pub struct RegisteredSkill {
+    /// The skill definition.
+    pub skill: Skill,
+    /// How this skill was registered.
+    pub source: SkillSource,
+}
+
 /// Where a skill is intended to run.
 ///
 /// Advisory only — the pool does not enforce scope. Coordinators and agents
@@ -104,7 +135,7 @@ impl Skill {
 /// Registry of available skills.
 #[derive(Debug, Clone, Default)]
 pub struct SkillRegistry {
-    skills: HashMap<String, Skill>,
+    skills: HashMap<String, RegisteredSkill>,
 }
 
 impl SkillRegistry {
@@ -117,29 +148,40 @@ impl SkillRegistry {
     pub fn with_builtins() -> Self {
         let mut registry = Self::new();
         for skill in builtin_skills() {
-            registry.register(skill);
+            registry.register(skill, SkillSource::Builtin);
         }
         registry
     }
 
-    /// Register a skill.
-    pub fn register(&mut self, skill: Skill) {
-        self.skills.insert(skill.name.clone(), skill);
+    /// Register a skill with a given source.
+    pub fn register(&mut self, skill: Skill, source: SkillSource) {
+        self.skills
+            .insert(skill.name.clone(), RegisteredSkill { skill, source });
     }
 
     /// Look up a skill by name.
     pub fn get(&self, name: &str) -> Option<&Skill> {
+        self.skills.get(name).map(|rs| &rs.skill)
+    }
+
+    /// Look up a registered skill (with source metadata) by name.
+    pub fn get_registered(&self, name: &str) -> Option<&RegisteredSkill> {
         self.skills.get(name)
     }
 
     /// List all registered skills.
     pub fn list(&self) -> Vec<&Skill> {
+        self.skills.values().map(|rs| &rs.skill).collect()
+    }
+
+    /// List all registered skills with source metadata.
+    pub fn list_registered(&self) -> Vec<&RegisteredSkill> {
         self.skills.values().collect()
     }
 
-    /// Remove a skill by name.
+    /// Remove a skill by name. Returns the removed skill if found.
     pub fn remove(&mut self, name: &str) -> Option<Skill> {
-        self.skills.remove(name)
+        self.skills.remove(name).map(|rs| rs.skill)
     }
 
     /// Remove multiple skills by name.
@@ -151,14 +193,19 @@ impl SkillRegistry {
 
     /// List skills filtered by scope.
     pub fn list_by_scope(&self, scope: SkillScope) -> Vec<&Skill> {
-        self.skills.values().filter(|s| s.scope == scope).collect()
+        self.skills
+            .values()
+            .filter(|rs| rs.skill.scope == scope)
+            .map(|rs| &rs.skill)
+            .collect()
     }
 
     /// Load skill definitions from JSON files in a directory.
     ///
     /// Each `.json` file in the directory is deserialized as a [`Skill`] and
-    /// registered. Skills loaded this way override any existing skill with the
-    /// same name. Files are loaded in sorted order for deterministic behavior.
+    /// registered with [`SkillSource::Project`]. Skills loaded this way
+    /// override any existing skill with the same name. Files are loaded in
+    /// sorted order for deterministic behavior.
     ///
     /// Returns the number of skills loaded. If the directory does not exist,
     /// returns `Ok(0)` without error.
@@ -177,7 +224,7 @@ impl SkillRegistry {
         for entry in entries {
             let contents = std::fs::read_to_string(entry.path())?;
             let skill: Skill = serde_json::from_str(&contents)?;
-            self.register(skill);
+            self.register(skill, SkillSource::Project);
             count += 1;
         }
 
@@ -504,14 +551,17 @@ mod tests {
         let mut registry = SkillRegistry::new();
         assert!(registry.list().is_empty());
 
-        registry.register(Skill {
-            name: "test".into(),
-            description: "A test skill".into(),
-            prompt: "do {thing}".into(),
-            arguments: vec![],
-            config: None,
-            scope: SkillScope::Task,
-        });
+        registry.register(
+            Skill {
+                name: "test".into(),
+                description: "A test skill".into(),
+                prompt: "do {thing}".into(),
+                arguments: vec![],
+                config: None,
+                scope: SkillScope::Task,
+            },
+            SkillSource::Runtime,
+        );
 
         assert_eq!(registry.list().len(), 1);
         assert!(registry.get("test").is_some());
@@ -648,5 +698,89 @@ mod tests {
 
         let serialized = serde_json::to_value(scope).unwrap();
         assert_eq!(serialized, "coordinator");
+    }
+
+    #[test]
+    fn source_tracking() {
+        let registry = SkillRegistry::with_builtins();
+        let rs = registry.get_registered("code_review").unwrap();
+        assert_eq!(rs.source, SkillSource::Builtin);
+    }
+
+    #[test]
+    fn list_registered_includes_source() {
+        let mut registry = SkillRegistry::new();
+        registry.register(
+            Skill {
+                name: "a".into(),
+                description: "A".into(),
+                prompt: "do a".into(),
+                arguments: vec![],
+                config: None,
+                scope: SkillScope::Task,
+            },
+            SkillSource::Builtin,
+        );
+        registry.register(
+            Skill {
+                name: "b".into(),
+                description: "B".into(),
+                prompt: "do b".into(),
+                arguments: vec![],
+                config: None,
+                scope: SkillScope::Task,
+            },
+            SkillSource::Runtime,
+        );
+
+        let all = registry.list_registered();
+        assert_eq!(all.len(), 2);
+
+        let builtin = registry.get_registered("a").unwrap();
+        assert_eq!(builtin.source, SkillSource::Builtin);
+
+        let runtime = registry.get_registered("b").unwrap();
+        assert_eq!(runtime.source, SkillSource::Runtime);
+    }
+
+    #[test]
+    fn project_skills_have_project_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_json = serde_json::json!({
+            "name": "proj_skill",
+            "description": "Project skill",
+            "prompt": "do {thing}",
+            "arguments": [
+                { "name": "thing", "description": "What", "required": true }
+            ]
+        });
+        std::fs::write(
+            dir.path().join("proj_skill.json"),
+            serde_json::to_string_pretty(&skill_json).unwrap(),
+        )
+        .unwrap();
+
+        let mut registry = SkillRegistry::new();
+        registry.load_from_dir(dir.path()).unwrap();
+
+        let rs = registry.get_registered("proj_skill").unwrap();
+        assert_eq!(rs.source, SkillSource::Project);
+    }
+
+    #[test]
+    fn source_serde_roundtrip() {
+        let json = serde_json::json!("runtime");
+        let source: SkillSource = serde_json::from_value(json).unwrap();
+        assert_eq!(source, SkillSource::Runtime);
+
+        let serialized = serde_json::to_value(source).unwrap();
+        assert_eq!(serialized, "runtime");
+    }
+
+    #[test]
+    fn source_display() {
+        assert_eq!(SkillSource::Builtin.to_string(), "builtin");
+        assert_eq!(SkillSource::Project.to_string(), "project");
+        assert_eq!(SkillSource::Runtime.to_string(), "runtime");
     }
 }


### PR DESCRIPTION
Adds 5 MCP tools for runtime skill management:

- pool_skill_list: list skills with scope/source filters
- pool_skill_get: inspect full skill details
- pool_skill_add: register ephemeral runtime skills
- pool_skill_remove: remove skills at runtime
- pool_skill_save: persist skills to .claude-pool/skills/

Also adds SkillSource tracking (builtin/project/runtime) and thread-safe SkillRegistry.

Closes #92