### PR TITLE
feat: pass MCP config to pool slots

### DIFF
--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -82,6 +82,21 @@ struct Cli {
     /// Disable specific skills by name (comma-separated).
     #[arg(long, value_delimiter = ',')]
     disable_skill: Vec<String>,
+
+    /// Path to an .mcp.json file defining MCP servers available to all slots.
+    ///
+    /// The file format is `{"mcpServers": {"name": {...}}}`.
+    /// Servers defined here are passed to slots via `--mcp-config`.
+    #[arg(long, value_name = "PATH")]
+    mcp_config: Option<PathBuf>,
+
+    /// Disable strict MCP config mode.
+    ///
+    /// By default, `--strict-mcp-config` is passed to slots so they only use
+    /// the servers defined in the pool config (not the coordinator's .mcp.json).
+    /// Pass this flag to allow slots to also inherit the coordinator's servers.
+    #[arg(long)]
+    no_strict_mcp_config: bool,
 }
 
 fn parse_permission_mode(s: &str) -> claude_pool::PermissionMode {
@@ -118,6 +133,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
+    // Load MCP servers from --mcp-config file if provided.
+    let mcp_servers = if let Some(ref path) = cli.mcp_config {
+        let contents = std::fs::read_to_string(path)
+            .map_err(|e| format!("failed to read --mcp-config {}: {e}", path.display()))?;
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .map_err(|e| format!("invalid JSON in --mcp-config: {e}"))?;
+        parsed["mcpServers"]
+            .as_object()
+            .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default()
+    } else {
+        std::collections::HashMap::new()
+    };
+
     let config = PoolConfig {
         model: cli.model,
         effort: cli.effort.and_then(|e| parse_effort(&e)),
@@ -129,6 +158,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             min_slots: cli.min_slots,
             max_slots: cli.max_slots,
         },
+        mcp_servers,
+        strict_mcp_config: !cli.no_strict_mcp_config,
         ..Default::default()
     };
 

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -24,6 +24,9 @@ pub struct RunInput {
     pub model: Option<String>,
     /// Effort override for this task (min, low, medium, high, max).
     pub effort: Option<String>,
+    /// Additional MCP servers for this task (merged with global/slot servers).
+    /// Keys are server names, values are server config objects.
+    pub mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -36,6 +39,9 @@ pub struct SubmitInput {
     pub effort: Option<String>,
     /// Tags for grouping/filtering.
     pub tags: Option<Vec<String>>,
+    /// Additional MCP servers for this task (merged with global/slot servers).
+    /// Keys are server names, values are server config objects.
+    pub mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -175,13 +181,18 @@ fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
     }
 }
 
-fn task_config_from(model: Option<String>, effort: Option<String>) -> Option<SlotConfig> {
-    if model.is_none() && effort.is_none() {
+fn task_config_from(
+    model: Option<String>,
+    effort: Option<String>,
+    mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
+) -> Option<SlotConfig> {
+    if model.is_none() && effort.is_none() && mcp_servers.is_none() {
         return None;
     }
     Some(SlotConfig {
         model,
         effort: effort.and_then(|e| parse_effort(&e)),
+        mcp_servers,
         ..Default::default()
     })
 }
@@ -231,7 +242,7 @@ pub fn pool_run_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
         .handler(move |input: RunInput| {
             let state = Arc::clone(&state);
             async move {
-                let config = task_config_from(input.model, input.effort);
+                let config = task_config_from(input.model, input.effort, input.mcp_servers);
                 match state.pool.run_with_config(&input.prompt, config).await {
                     Ok(result) => Ok(CallToolResult::json(serde_json::to_value(&result).unwrap())),
                     Err(e) => Ok(CallToolResult::error(e.to_string())),
@@ -248,7 +259,7 @@ pub fn pool_submit_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
         .handler(move |input: SubmitInput| {
             let state = Arc::clone(&state);
             async move {
-                let config = task_config_from(input.model, input.effort);
+                let config = task_config_from(input.model, input.effort, input.mcp_servers);
                 let tags = input.tags.unwrap_or_default();
                 match state
                     .pool
@@ -529,7 +540,7 @@ fn convert_chain_steps(steps: Vec<ChainStepInput>) -> Vec<claude_pool::ChainStep
                 },
                 _ => claude_pool::StepAction::Prompt { prompt: s.value },
             };
-            let config = task_config_from(s.model, s.effort);
+            let config = task_config_from(s.model, s.effort, None);
             let failure_policy = claude_pool::StepFailurePolicy {
                 retries: s.retries.unwrap_or(0),
                 recovery_prompt: s.recovery_prompt,

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -19,9 +19,9 @@ dashmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tempfile = "3"
 tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
 tokio = { workspace = true }

--- a/crates/claude-pool/src/config.rs
+++ b/crates/claude-pool/src/config.rs
@@ -5,6 +5,8 @@
 //! 2. [`SlotConfig`] — per-slot overrides
 //! 3. [`SlotConfig`] on a task record — per-task overrides
 
+use std::collections::HashMap;
+
 use claude_wrapper::types::{Effort, PermissionMode};
 
 use crate::types::{PoolConfig, SlotConfig};
@@ -20,13 +22,19 @@ pub struct ResolvedConfig {
     pub system_prompt: Option<String>,
     pub allowed_tools: Vec<String>,
     pub effort: Option<Effort>,
+    /// Merged MCP servers from global + slot + task layers.
+    /// Later layers override earlier layers by server name.
+    pub mcp_servers: HashMap<String, serde_json::Value>,
+    /// Whether to pass `--strict-mcp-config` to the CLI.
+    pub strict_mcp_config: bool,
 }
 
 impl ResolvedConfig {
     /// Resolve configuration by layering global, slot, and task configs.
     ///
     /// Later layers override earlier layers for scalar fields.
-    /// List fields (allowed_tools) are merged.
+    /// Map/list fields (allowed_tools, mcp_servers) are merged additively,
+    /// with later layers overriding same-named entries.
     pub fn resolve(global: &PoolConfig, slot: &SlotConfig, task: Option<&SlotConfig>) -> Self {
         let model = task
             .and_then(|t| t.model.clone())
@@ -65,6 +73,20 @@ impl ResolvedConfig {
             allowed_tools.extend(tt.iter().cloned());
         }
 
+        // Merge MCP servers: global base, slot overrides/adds, task overrides/adds.
+        // Same-named servers in later layers replace earlier ones.
+        let mut mcp_servers = global.mcp_servers.clone();
+        if let Some(ref slot_servers) = slot.mcp_servers {
+            mcp_servers.extend(slot_servers.iter().map(|(k, v)| (k.clone(), v.clone())));
+        }
+        if let Some(task_cfg) = task
+            && let Some(ref task_servers) = task_cfg.mcp_servers
+        {
+            mcp_servers.extend(task_servers.iter().map(|(k, v)| (k.clone(), v.clone())));
+        }
+
+        let strict_mcp_config = global.strict_mcp_config;
+
         Self {
             model,
             permission_mode,
@@ -72,6 +94,8 @@ impl ResolvedConfig {
             system_prompt,
             allowed_tools,
             effort,
+            mcp_servers,
+            strict_mcp_config,
         }
     }
 }
@@ -90,6 +114,8 @@ mod tests {
         assert_eq!(resolved.permission_mode, PermissionMode::Plan);
         assert!(resolved.model.is_none());
         assert!(resolved.allowed_tools.is_empty());
+        assert!(resolved.mcp_servers.is_empty());
+        assert!(resolved.strict_mcp_config);
     }
 
     #[test]
@@ -150,5 +176,83 @@ mod tests {
             resolved.allowed_tools,
             vec!["Bash", "Read", "Write", "Edit"]
         );
+    }
+
+    #[test]
+    fn mcp_servers_merge() {
+        let global = PoolConfig {
+            mcp_servers: [(
+                "hub".to_string(),
+                serde_json::json!({"type": "http", "url": "http://global/"}),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        let slot = SlotConfig {
+            mcp_servers: Some(
+                [(
+                    "tool".to_string(),
+                    serde_json::json!({"type": "stdio", "command": "npx"}),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+        let resolved = ResolvedConfig::resolve(&global, &slot, None);
+
+        assert_eq!(resolved.mcp_servers.len(), 2);
+        assert!(resolved.mcp_servers.contains_key("hub"));
+        assert!(resolved.mcp_servers.contains_key("tool"));
+    }
+
+    #[test]
+    fn task_mcp_servers_override_slot() {
+        let global = PoolConfig::default();
+        let slot = SlotConfig {
+            mcp_servers: Some(
+                [(
+                    "hub".to_string(),
+                    serde_json::json!({"type": "http", "url": "http://slot/"}),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+        let task = SlotConfig {
+            mcp_servers: Some(
+                [(
+                    "hub".to_string(),
+                    serde_json::json!({"type": "http", "url": "http://task/"}),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+        let resolved = ResolvedConfig::resolve(&global, &slot, Some(&task));
+
+        assert_eq!(resolved.mcp_servers["hub"]["url"], "http://task/");
+    }
+
+    #[test]
+    fn strict_mcp_config_defaults_true() {
+        let global = PoolConfig::default();
+        let slot = SlotConfig::default();
+        let resolved = ResolvedConfig::resolve(&global, &slot, None);
+        assert!(resolved.strict_mcp_config);
+    }
+
+    #[test]
+    fn strict_mcp_config_can_be_disabled() {
+        let global = PoolConfig {
+            strict_mcp_config: false,
+            ..Default::default()
+        };
+        let slot = SlotConfig::default();
+        let resolved = ResolvedConfig::resolve(&global, &slot, None);
+        assert!(!resolved.strict_mcp_config);
     }
 }

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -153,6 +153,7 @@ impl<S: PoolStore + 'static> PoolBuilder<S> {
                 cost_microdollars: 0,
                 restart_count: 0,
                 worktree_path,
+                mcp_config_path: None,
             };
             inner.store.put_slot(record).await?;
         }
@@ -634,6 +635,21 @@ impl<S: PoolStore + 'static> Pool<S> {
             mgr.cleanup_all(&slot_ids).await?;
         }
 
+        // Clean up per-slot MCP config temp files.
+        for slot_id in &slot_ids {
+            if let Some(slot) = self.inner.store.get_slot(slot_id).await?
+                && let Some(ref path) = slot.mcp_config_path
+                && let Err(e) = std::fs::remove_file(path)
+            {
+                tracing::warn!(
+                    slot_id = %slot_id.0,
+                    path = %path.display(),
+                    error = %e,
+                    "failed to clean up slot MCP config"
+                );
+            }
+        }
+
         Ok(DrainSummary {
             total_cost_microdollars: total_cost,
             total_tasks_completed: total_tasks,
@@ -757,6 +773,7 @@ impl<S: PoolStore + 'static> Pool<S> {
                 cost_microdollars: 0,
                 restart_count: 0,
                 worktree_path,
+                mcp_config_path: None,
             };
             self.inner.store.put_slot(record).await?;
         }
@@ -935,6 +952,60 @@ impl<S: PoolStore + 'static> Pool<S> {
         Ok(())
     }
 
+    /// Ensure a per-slot MCP config temp file exists. Writes a new one on first
+    /// call for a given slot, then reuses the stored path on subsequent calls.
+    ///
+    /// Returns the path to the temp file.
+    async fn ensure_slot_mcp_config(
+        &self,
+        slot_id: &SlotId,
+        servers: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<std::path::PathBuf> {
+        // Check if this slot already has a temp file.
+        if let Some(slot) = self.inner.store.get_slot(slot_id).await?
+            && let Some(ref path) = slot.mcp_config_path
+        {
+            // Re-write the file in case servers changed (task-level overrides).
+            let json = serde_json::to_string_pretty(&serde_json::json!({
+                "mcpServers": servers
+            }))?;
+            std::fs::write(path, json)?;
+            return Ok(path.clone());
+        }
+
+        // First call for this slot — create a new temp file.
+        use std::io::Write as _;
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "mcpServers": servers
+        }))?;
+        let mut file = tempfile::Builder::new()
+            .prefix(&format!("claude-pool-{}-", slot_id.0))
+            .suffix(".mcp.json")
+            .tempfile()?;
+        file.write_all(json.as_bytes())?;
+
+        // Persist the temp file (prevents deletion on drop) and store the path.
+        let path = file
+            .into_temp_path()
+            .keep()
+            .map_err(std::io::Error::other)?
+            .to_path_buf();
+
+        if let Some(mut slot) = self.inner.store.get_slot(slot_id).await? {
+            slot.mcp_config_path = Some(path.clone());
+            self.inner.store.put_slot(slot).await?;
+        }
+
+        tracing::debug!(
+            slot_id = %slot_id.0,
+            path = %path.display(),
+            servers = servers.len(),
+            "created slot MCP config"
+        );
+
+        Ok(path)
+    }
+
     /// Execute a task on a specific slot by invoking the Claude CLI.
     async fn execute_task(
         &self,
@@ -976,6 +1047,19 @@ impl<S: PoolStore + 'static> Pool<S> {
             cmd = cmd.allowed_tools(&resolved.allowed_tools);
         }
 
+        // Write per-slot MCP config if servers are configured.
+        // Reuses an existing temp file if the slot already has one; otherwise
+        // writes a new one and stores the path on the slot record.
+        if !resolved.mcp_servers.is_empty() {
+            let mcp_path = self
+                .ensure_slot_mcp_config(slot_id, &resolved.mcp_servers)
+                .await?;
+            cmd = cmd.mcp_config(mcp_path.to_string_lossy());
+            if resolved.strict_mcp_config {
+                cmd = cmd.strict_mcp_config();
+            }
+        }
+
         // Use worktree working dir if the slot has one, otherwise use default.
         let claude_instance = if let Some(slot) = self.inner.store.get_slot(slot_id).await? {
             // Resume session if the slot has one.
@@ -996,6 +1080,7 @@ impl<S: PoolStore + 'static> Pool<S> {
             slot_id = %slot_id.0,
             model = ?resolved.model,
             effort = ?resolved.effort,
+            mcp_servers = resolved.mcp_servers.len(),
             "executing task"
         );
 

--- a/crates/claude-pool/src/store.rs
+++ b/crates/claude-pool/src/store.rs
@@ -165,6 +165,7 @@ mod tests {
             cost_microdollars: 0,
             restart_count: 0,
             worktree_path: None,
+            mcp_config_path: None,
         };
 
         store.put_slot(record).await.unwrap();

--- a/crates/claude-pool/src/types.rs
+++ b/crates/claude-pool/src/types.rs
@@ -111,6 +111,13 @@ pub struct PoolConfig {
     ///
     /// Only used when [`supervisor_enabled`](Self::supervisor_enabled) is true.
     pub supervisor_interval_secs: u64,
+
+    /// Use `--strict-mcp-config` when passing MCP config to slots.
+    ///
+    /// Prevents slots from inheriting the coordinator's `.mcp.json`, which
+    /// avoids accidental recursive pool calls (a slot invoking `pool_run` on itself).
+    /// Default: `true`.
+    pub strict_mcp_config: bool,
 }
 
 impl Default for PoolConfig {
@@ -133,6 +140,7 @@ impl Default for PoolConfig {
             detect_permission_prompts: true,
             supervisor_enabled: false,
             supervisor_interval_secs: 30,
+            strict_mcp_config: true,
         }
     }
 }
@@ -220,6 +228,13 @@ pub struct SlotRecord {
 
     /// Git worktree path, if worktree isolation is enabled.
     pub worktree_path: Option<String>,
+
+    /// Path to the slot's temp `.mcp.json` file, if MCP servers are configured.
+    ///
+    /// Written once per slot (on first task that needs it) and reused across
+    /// subsequent tasks. Cleaned up on pool drain/shutdown.
+    #[serde(skip)]
+    pub mcp_config_path: Option<std::path::PathBuf>,
 }
 
 // ── Task types ───────────────────────────────────────────────────────


### PR DESCRIPTION
Wires the existing but unused `PoolConfig.mcp_servers` and `SlotConfig.mcp_servers` fields through to actual task execution, so pool slots can access MCP tools (GitHub, crates.io, etc.).

## Changes

**Config resolution** (`config.rs`):
- Add `mcp_servers: HashMap<String, Value>` and `strict_mcp_config: bool` to `ResolvedConfig`
- Merge MCP servers across global -> slot -> task layers (later layers override by server name)
- 4 new unit tests covering merge, override, and strict_mcp_config behavior

**Task execution** (`pool.rs`):
- `ensure_slot_mcp_config()`: writes a per-slot temp `.mcp.json` on first use, rewrites in place for subsequent tasks (handles task-level server overrides)
- `execute_task()`: when resolved MCP servers are non-empty, passes `--mcp-config` and `--strict-mcp-config` to the `QueryCommand`
- `drain()`: cleans up per-slot temp files alongside worktree cleanup

**Types** (`types.rs`):
- `PoolConfig.strict_mcp_config: bool` (default `true`) — prevents slots from inheriting the coordinator's `.mcp.json`
- `SlotRecord.mcp_config_path: Option<PathBuf>` — tracks the temp file for reuse/cleanup

**CLI** (`main.rs`):
- `--mcp-config <PATH>`: load an `.mcp.json` file to define MCP servers for all slots
- `--no-strict-mcp-config`: allow slots to also inherit coordinator's servers

**Tool inputs** (`tools.rs`):
- `pool_run` and `pool_submit` accept optional `mcp_servers` for per-task MCP overrides

**Dependencies** (`Cargo.toml`):
- `tempfile` moved from dev-dependencies to regular dependencies

## Design decisions

- **Per-slot file reuse** over per-task creation: the file is written once per slot, rewritten in place when task-level overrides change the server set, and cleaned up on drain
- **strict_mcp_config defaults true**: avoids recursive pool calls (a slot invoking `pool_run` on itself through inherited coordinator config)
- **Raw JSON write** over `McpConfigBuilder`: simpler since `mcp_servers` values are already `serde_json::Value`

Closes #99