### PR TITLE
feat: real cost tracking for pool tasks

### DIFF
--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -1104,7 +1104,7 @@ impl<S: PoolStore + 'static> Pool<S> {
             output: query_result.result,
             success: !query_result.is_error,
             cost_microdollars,
-            turns_used: 0, // TODO: extract from query result when available
+            turns_used: query_result.num_turns.unwrap_or(0),
             session_id: Some(query_result.session_id),
         })
     }

--- a/crates/claude-wrapper/src/types.rs
+++ b/crates/claude-wrapper/src/types.rs
@@ -186,12 +186,65 @@ pub struct QueryResult {
     pub result: String,
     #[serde(default)]
     pub session_id: String,
-    #[serde(default)]
+    #[serde(default, rename = "total_cost_usd", alias = "cost_usd")]
     pub cost_usd: Option<f64>,
     #[serde(default)]
     pub duration_ms: Option<u64>,
     #[serde(default)]
+    pub num_turns: Option<u32>,
+    #[serde(default)]
     pub is_error: bool,
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
+}
+
+#[cfg(all(test, feature = "json"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_result_deserializes_total_cost_usd() {
+        let json =
+            r#"{"result":"hello","session_id":"s1","total_cost_usd":0.042,"is_error":false}"#;
+        let qr: QueryResult = serde_json::from_str(json).unwrap();
+        assert_eq!(qr.cost_usd, Some(0.042));
+    }
+
+    #[test]
+    fn query_result_deserializes_cost_usd_alias() {
+        let json = r#"{"result":"hello","session_id":"s1","cost_usd":0.01,"is_error":false}"#;
+        let qr: QueryResult = serde_json::from_str(json).unwrap();
+        assert_eq!(qr.cost_usd, Some(0.01));
+    }
+
+    #[test]
+    fn query_result_missing_cost_defaults_to_none() {
+        let json = r#"{"result":"hello","session_id":"s1","is_error":false}"#;
+        let qr: QueryResult = serde_json::from_str(json).unwrap();
+        assert_eq!(qr.cost_usd, None);
+    }
+
+    #[test]
+    fn query_result_deserializes_num_turns() {
+        let json = r#"{"result":"done","session_id":"s2","total_cost_usd":0.1,"num_turns":5,"is_error":false}"#;
+        let qr: QueryResult = serde_json::from_str(json).unwrap();
+        assert_eq!(qr.num_turns, Some(5));
+        assert_eq!(qr.cost_usd, Some(0.1));
+    }
+
+    #[test]
+    fn query_result_serializes_as_total_cost_usd() {
+        let qr = QueryResult {
+            result: "ok".into(),
+            session_id: "s1".into(),
+            cost_usd: Some(0.05),
+            duration_ms: None,
+            num_turns: Some(3),
+            is_error: false,
+            extra: Default::default(),
+        };
+        let json = serde_json::to_string(&qr).unwrap();
+        assert!(json.contains("\"total_cost_usd\""));
+        assert!(json.contains("\"num_turns\""));
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `QueryResult.cost_usd` serde field name to match CLI's `total_cost_usd` output (with `cost_usd` alias for backward compatibility)
- Add `num_turns` field to `QueryResult` and propagate through `execute_task` to `TaskResult.turns_used`
- Add 5 unit tests for cost/turns deserialization and serialization

## Root cause

The Claude CLI outputs `"total_cost_usd"` in its JSON response, but `QueryResult.cost_usd` was expecting `"cost_usd"`, so the field always deserialized as `None`. The downstream cost aggregation infrastructure (slot accumulation, `total_spend` atomic, chain cost summation, `pool_status` display) was already correctly wired -- it just never received real values.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (133 tests pass)
- [x] `cargo test --doc --all-features` (31 tests pass)

Closes #102