### PR TITLE
feat: chain cancellation (pool_cancel_chain)

### DIFF
--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -706,6 +706,32 @@ pub fn pool_chain_result_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> T
         .build()
 }
 
+/// Cancel a running chain, skipping remaining steps.
+pub fn pool_cancel_chain_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_cancel_chain")
+        .title("Cancel Chain")
+        .description(
+            "Cancel a running chain submitted with pool_submit_chain or pool_fan_out_chains. \
+             The current step finishes before cancellation takes effect. Remaining steps are \
+             skipped (marked skipped=true). Use pool_chain_result to confirm, then pool_result \
+             to retrieve partial output.",
+        )
+        .handler(move |input: TaskIdInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let task_id = claude_pool::TaskId(input.task_id.clone());
+                match state.pool.cancel_chain(&task_id).await {
+                    Ok(()) => Ok(CallToolResult::json(serde_json::json!({
+                        "status": "cancellation_requested",
+                        "task_id": input.task_id,
+                    }))),
+                    Err(e) => Ok(CallToolResult::error(e.to_string())),
+                }
+            }
+        })
+        .build()
+}
+
 pub fn pool_invoke_workflow_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
     ToolBuilder::new("pool_invoke_workflow")
         .title("Invoke Workflow")
@@ -1034,6 +1060,7 @@ pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
         pool_submit_chain_tool(Arc::clone(state)),
         pool_fan_out_chains_tool(Arc::clone(state)),
         pool_chain_result_tool(Arc::clone(state)),
+        pool_cancel_chain_tool(Arc::clone(state)),
         pool_invoke_workflow_tool(Arc::clone(state)),
         pool_scale_up_tool(Arc::clone(state)),
         pool_scale_down_tool(Arc::clone(state)),

--- a/crates/claude-pool/src/chain.rs
+++ b/crates/claude-pool/src/chain.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::pool::Pool;
 use crate::skill::SkillRegistry;
 use crate::store::PoolStore;
-use crate::types::{SlotConfig, TaskId};
+use crate::types::{SlotConfig, TaskId, TaskState};
 
 /// A step in a chain pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -88,6 +88,9 @@ pub struct StepResult {
     /// Number of retries used.
     #[serde(default)]
     pub retries_used: u32,
+    /// Whether this step was skipped due to chain cancellation.
+    #[serde(default)]
+    pub skipped: bool,
 }
 
 /// Result of a full chain execution.
@@ -128,6 +131,8 @@ pub enum ChainStatus {
     Completed,
     /// A step failed and the chain stopped.
     Failed,
+    /// Chain was cancelled; remaining steps were skipped.
+    Cancelled,
 }
 
 /// Execute a chain of steps against the pool.
@@ -154,6 +159,37 @@ pub async fn execute_chain_with_progress<S: PoolStore + 'static>(
     let mut total_cost = 0u64;
 
     for (step_idx, step) in steps.iter().enumerate() {
+        // Check for cancellation before starting each step.
+        if let Some(task_id) = chain_task_id
+            && let Ok(Some(task)) = pool.store().get_task(task_id).await
+            && task.state == TaskState::Cancelled
+        {
+            for s in &steps[step_idx..] {
+                step_results.push(StepResult {
+                    name: s.name.clone(),
+                    output: String::new(),
+                    success: false,
+                    cost_microdollars: 0,
+                    retries_used: 0,
+                    skipped: true,
+                });
+            }
+            update_chain_progress_final(
+                pool,
+                Some(task_id),
+                steps.len(),
+                &step_results,
+                ChainStatus::Cancelled,
+            )
+            .await;
+            return Ok(ChainResult {
+                final_output: previous_output,
+                steps: step_results,
+                total_cost_microdollars: total_cost,
+                success: false,
+            });
+        }
+
         // Update progress in the store if we have a task ID.
         if let Some(task_id) = chain_task_id {
             let progress = ChainProgress {
@@ -202,6 +238,7 @@ pub async fn execute_chain_with_progress<S: PoolStore + 'static>(
                     success: false,
                     cost_microdollars: 0,
                     retries_used: step.failure_policy.retries,
+                    skipped: false,
                 });
                 update_chain_progress_final(
                     pool,
@@ -297,6 +334,7 @@ async fn execute_step_with_retries<S: PoolStore + 'static>(
                             success: true,
                             cost_microdollars: total_cost,
                             retries_used: attempt,
+                            skipped: false,
                         }),
                         total_cost,
                     );
@@ -338,6 +376,7 @@ async fn execute_step_with_retries<S: PoolStore + 'static>(
                         success: task_result.success,
                         cost_microdollars: total_cost,
                         retries_used: max_attempts,
+                        skipped: false,
                     }),
                     total_cost,
                 );
@@ -401,6 +440,7 @@ mod tests {
                 success: true,
                 cost_microdollars: 1000,
                 retries_used: 0,
+                skipped: false,
             }],
             final_output: "done".into(),
             total_cost_microdollars: 1000,
@@ -436,6 +476,7 @@ mod tests {
                 success: true,
                 cost_microdollars: 500,
                 retries_used: 0,
+                skipped: false,
             }],
             status: ChainStatus::Running,
         };
@@ -443,5 +484,53 @@ mod tests {
         let json = serde_json::to_string(&progress).unwrap();
         assert!(json.contains("implement"));
         assert!(json.contains("running"));
+    }
+
+    #[test]
+    fn cancelled_status_serializes() {
+        let progress = ChainProgress {
+            total_steps: 3,
+            current_step: None,
+            current_step_name: None,
+            completed_steps: vec![
+                StepResult {
+                    name: "plan".into(),
+                    output: "planned".into(),
+                    success: true,
+                    cost_microdollars: 500,
+                    retries_used: 0,
+                    skipped: false,
+                },
+                StepResult {
+                    name: "implement".into(),
+                    output: String::new(),
+                    success: false,
+                    cost_microdollars: 0,
+                    retries_used: 0,
+                    skipped: true,
+                },
+                StepResult {
+                    name: "review".into(),
+                    output: String::new(),
+                    success: false,
+                    cost_microdollars: 0,
+                    retries_used: 0,
+                    skipped: true,
+                },
+            ],
+            status: ChainStatus::Cancelled,
+        };
+
+        let json = serde_json::to_string(&progress).unwrap();
+        assert!(json.contains("cancelled"));
+        assert!(json.contains("\"skipped\":true"));
+    }
+
+    #[test]
+    fn skipped_defaults_to_false_on_deserialize() {
+        let json =
+            r#"{"name":"s","output":"o","success":true,"cost_microdollars":0,"retries_used":0}"#;
+        let result: StepResult = serde_json::from_str(json).unwrap();
+        assert!(!result.skipped);
     }
 }

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -366,6 +366,33 @@ impl<S: PoolStore + 'static> Pool<S> {
         }
     }
 
+    /// Cancel a running chain, skipping remaining steps.
+    ///
+    /// Sets the chain's task state to `Cancelled`. The currently-executing step
+    /// (if any) runs to completion; remaining steps are then skipped. Partial
+    /// results are available via [`Pool::result`] once the chain finishes.
+    pub async fn cancel_chain(&self, task_id: &TaskId) -> Result<()> {
+        let mut task = self
+            .inner
+            .store
+            .get_task(task_id)
+            .await?
+            .ok_or_else(|| Error::TaskNotFound(task_id.0.clone()))?;
+
+        match task.state {
+            TaskState::Running | TaskState::Pending => {
+                task.state = TaskState::Cancelled;
+                self.inner.store.put_task(task).await?;
+                // Optimistically update in-flight progress status.
+                if let Some(mut progress) = self.inner.chain_progress.get_mut(&task_id.0) {
+                    progress.status = crate::chain::ChainStatus::Cancelled;
+                }
+                Ok(())
+            }
+            _ => Ok(()), // already terminal or already cancelled
+        }
+    }
+
     /// Execute tasks in parallel across available slots, collecting all results.
     ///
     /// Queues excess prompts until a slot becomes idle. Returns once all
@@ -1708,5 +1735,84 @@ mod tests {
             extract_tool_name("Claude wants to use Bash, proceed?"),
             "Bash"
         );
+    }
+
+    // ── Chain cancellation tests ────────────────────────────────────
+
+    #[tokio::test]
+    async fn cancel_chain_marks_task_cancelled() {
+        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+
+        // Manually insert a running chain task.
+        let task_id = TaskId("chain-test-1".into());
+        let record = TaskRecord {
+            id: task_id.clone(),
+            prompt: "chain: 3 steps".into(),
+            state: TaskState::Running,
+            slot_id: None,
+            result: None,
+            tags: vec![],
+            config: None,
+        };
+        pool.store().put_task(record).await.unwrap();
+
+        // Also set up chain progress.
+        pool.set_chain_progress(
+            &task_id,
+            crate::chain::ChainProgress {
+                total_steps: 3,
+                current_step: Some(1),
+                current_step_name: Some("implement".into()),
+                completed_steps: vec![],
+                status: crate::chain::ChainStatus::Running,
+            },
+        )
+        .await;
+
+        // Cancel it.
+        pool.cancel_chain(&task_id).await.unwrap();
+
+        // Task should be cancelled.
+        let task = pool.store().get_task(&task_id).await.unwrap().unwrap();
+        assert_eq!(task.state, TaskState::Cancelled);
+
+        // Progress should show cancelled.
+        let progress = pool.chain_progress(&task_id).unwrap();
+        assert_eq!(progress.status, crate::chain::ChainStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn cancel_chain_noop_for_completed() {
+        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+
+        let task_id = TaskId("chain-done".into());
+        let record = TaskRecord {
+            id: task_id.clone(),
+            prompt: "chain: 1 steps".into(),
+            state: TaskState::Completed,
+            slot_id: None,
+            result: Some(TaskResult {
+                output: "done".into(),
+                success: true,
+                cost_microdollars: 100,
+                turns_used: 0,
+                session_id: None,
+            }),
+            tags: vec![],
+            config: None,
+        };
+        pool.store().put_task(record).await.unwrap();
+
+        // Should be a no-op.
+        pool.cancel_chain(&task_id).await.unwrap();
+        let task = pool.store().get_task(&task_id).await.unwrap().unwrap();
+        assert_eq!(task.state, TaskState::Completed);
+    }
+
+    #[tokio::test]
+    async fn cancel_chain_not_found() {
+        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+        let result = pool.cancel_chain(&TaskId("nonexistent".into())).await;
+        assert!(matches!(result, Err(Error::TaskNotFound(_))));
     }
 }


### PR DESCRIPTION
## Summary

- Add `pool_cancel_chain` MCP tool that marks a running chain as cancelled
- Remaining unstarted steps are skipped with `skipped: true` in results
- Returns partial results with completed and skipped step status
- Adds `Cancelled` variant to `ChainStatus` and `skipped` field to `StepResult`

## Test plan

- [x] Unit tests for cancellation flag propagation (`cancel_chain_marks_task_cancelled`)
- [x] Unit tests for no-op on completed chains (`cancel_chain_noop_for_completed`)
- [x] Unit tests for not-found error (`cancel_chain_not_found`)
- [x] Serialization tests for `Cancelled` status and `skipped` field
- [x] Backward compatibility test (`skipped` defaults to false on deserialize)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib --all-features` passes (74 + 59 tests)
- [x] `cargo test --doc --all-features` passes (32 tests)

Closes #103