### PR TITLE
feat: live output for running chain steps

### DIFF
--- a/crates/claude-pool/src/chain.rs
+++ b/crates/claude-pool/src/chain.rs
@@ -7,6 +7,8 @@
 //! for async execution via [`Pool::submit_chain`](crate::Pool::submit_chain).
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -115,6 +117,17 @@ pub struct ChainProgress {
     pub current_step: Option<usize>,
     /// Name of the currently running step.
     pub current_step_name: Option<String>,
+    /// Live partial output from the currently running step.
+    ///
+    /// Updated incrementally as streaming output arrives. `None` when
+    /// no step is running (chain completed or not yet started).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_step_partial_output: Option<String>,
+    /// Unix timestamp (seconds) when the current step started.
+    ///
+    /// Callers can compute elapsed time as `now - started_at`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_step_started_at: Option<u64>,
     /// Completed step results so far.
     pub completed_steps: Vec<StepResult>,
     /// Overall status.
@@ -135,6 +148,16 @@ pub enum ChainStatus {
     Cancelled,
 }
 
+/// Callback for receiving partial output chunks during streaming execution.
+pub type OnOutputChunk = Arc<dyn Fn(&str) + Send + Sync>;
+
+fn unix_secs_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 /// Execute a chain of steps against the pool.
 pub async fn execute_chain<S: PoolStore + 'static>(
     pool: &Pool<S>,
@@ -147,7 +170,9 @@ pub async fn execute_chain<S: PoolStore + 'static>(
 /// Execute a chain with optional progress tracking.
 ///
 /// If `chain_task_id` is provided, intermediate progress is stored so callers
-/// can poll for status.
+/// can poll for status. When a chain task ID is present, steps execute with
+/// streaming output so partial results are visible via
+/// [`Pool::chain_progress`](crate::Pool::chain_progress).
 pub async fn execute_chain_with_progress<S: PoolStore + 'static>(
     pool: &Pool<S>,
     skills: &SkillRegistry,
@@ -196,6 +221,8 @@ pub async fn execute_chain_with_progress<S: PoolStore + 'static>(
                 total_steps: steps.len(),
                 current_step: Some(step_idx),
                 current_step_name: Some(step.name.clone()),
+                current_step_partial_output: Some(String::new()),
+                current_step_started_at: Some(unix_secs_now()),
                 completed_steps: step_results.clone(),
                 status: ChainStatus::Running,
             };
@@ -204,8 +231,18 @@ pub async fn execute_chain_with_progress<S: PoolStore + 'static>(
 
         let prompt = render_step_prompt(step, &previous_output, skills)?;
 
+        // Build an output callback that updates chain progress when we have a task ID.
+        let on_output: Option<OnOutputChunk> = chain_task_id.map(|tid| {
+            let pool = pool.clone();
+            let tid = tid.clone();
+            Arc::new(move |chunk: &str| {
+                pool.append_chain_partial_output(&tid, chunk);
+            }) as OnOutputChunk
+        });
+
         let (step_result, step_cost) =
-            execute_step_with_retries(pool, step, &prompt, &previous_output, skills).await;
+            execute_step_with_retries(pool, step, &prompt, &previous_output, skills, on_output)
+                .await;
 
         total_cost += step_cost;
 
@@ -307,6 +344,7 @@ async fn execute_step_with_retries<S: PoolStore + 'static>(
     initial_prompt: &str,
     previous_output: &str,
     skills: &SkillRegistry,
+    on_output: Option<OnOutputChunk>,
 ) -> (std::result::Result<StepResult, String>, u64) {
     let max_attempts = 1 + step.failure_policy.retries;
     let mut total_cost = 0u64;
@@ -323,7 +361,11 @@ async fn execute_step_with_retries<S: PoolStore + 'static>(
             }
         };
 
-        match pool.run_with_config(&prompt, step.config.clone()).await {
+        let result = pool
+            .run_with_config_streaming(&prompt, step.config.clone(), on_output.clone())
+            .await;
+
+        match result {
             Ok(task_result) => {
                 total_cost += task_result.cost_microdollars;
                 if task_result.success {
@@ -363,10 +405,11 @@ async fn execute_step_with_retries<S: PoolStore + 'static>(
 
         tracing::info!(step = %step.name, "attempting recovery prompt");
 
-        match pool
-            .run_with_config(&recovery_prompt, step.config.clone())
-            .await
-        {
+        let result = pool
+            .run_with_config_streaming(&recovery_prompt, step.config.clone(), on_output)
+            .await;
+
+        match result {
             Ok(task_result) => {
                 total_cost += task_result.cost_microdollars;
                 return (
@@ -403,6 +446,8 @@ async fn update_chain_progress_final<S: PoolStore + 'static>(
             total_steps,
             current_step: None,
             current_step_name: None,
+            current_step_partial_output: None,
+            current_step_started_at: None,
             completed_steps: completed_steps.to_vec(),
             status,
         };
@@ -465,11 +510,13 @@ mod tests {
     }
 
     #[test]
-    fn chain_progress_serializes() {
+    fn chain_progress_serializes_with_partial_output() {
         let progress = ChainProgress {
             total_steps: 3,
             current_step: Some(1),
             current_step_name: Some("implement".into()),
+            current_step_partial_output: Some("partial text".into()),
+            current_step_started_at: Some(1700000000),
             completed_steps: vec![StepResult {
                 name: "plan".into(),
                 output: "planned".into(),
@@ -484,6 +531,42 @@ mod tests {
         let json = serde_json::to_string(&progress).unwrap();
         assert!(json.contains("implement"));
         assert!(json.contains("running"));
+        assert!(json.contains("partial text"));
+        assert!(json.contains("1700000000"));
+    }
+
+    #[test]
+    fn chain_progress_omits_none_fields() {
+        let progress = ChainProgress {
+            total_steps: 2,
+            current_step: None,
+            current_step_name: None,
+            current_step_partial_output: None,
+            current_step_started_at: None,
+            completed_steps: vec![],
+            status: ChainStatus::Completed,
+        };
+
+        let json = serde_json::to_string(&progress).unwrap();
+        assert!(!json.contains("current_step_partial_output"));
+        assert!(!json.contains("current_step_started_at"));
+    }
+
+    #[test]
+    fn chain_progress_empty_partial_output_when_step_starts() {
+        let progress = ChainProgress {
+            total_steps: 3,
+            current_step: Some(0),
+            current_step_name: Some("plan".into()),
+            current_step_partial_output: Some(String::new()),
+            current_step_started_at: Some(1700000000),
+            completed_steps: vec![],
+            status: ChainStatus::Running,
+        };
+
+        let json = serde_json::to_string(&progress).unwrap();
+        // Empty string is still serialized (not None).
+        assert!(json.contains("\"current_step_partial_output\":\"\""));
     }
 
     #[test]
@@ -492,6 +575,8 @@ mod tests {
             total_steps: 3,
             current_step: None,
             current_step_name: None,
+            current_step_partial_output: None,
+            current_step_started_at: None,
             completed_steps: vec![
                 StepResult {
                     name: "plan".into(),

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -239,6 +239,54 @@ impl<S: PoolStore + 'static> Pool<S> {
         Ok(task_result)
     }
 
+    /// Run a task with per-task config overrides and optional streaming output.
+    ///
+    /// When `on_output` is `Some`, the task uses streaming execution and calls
+    /// the callback with each text chunk as it arrives. When `None`, behaves
+    /// identically to [`run_with_config`](Self::run_with_config).
+    pub(crate) async fn run_with_config_streaming(
+        &self,
+        prompt: &str,
+        task_config: Option<SlotConfig>,
+        on_output: Option<crate::chain::OnOutputChunk>,
+    ) -> Result<TaskResult> {
+        self.check_shutdown()?;
+        self.check_budget()?;
+
+        let task_id = TaskId(format!("task-{}", new_id()));
+
+        let record = TaskRecord {
+            id: task_id.clone(),
+            prompt: prompt.to_string(),
+            state: TaskState::Pending,
+            slot_id: None,
+            result: None,
+            tags: vec![],
+            config: task_config,
+        };
+        self.inner.store.put_task(record).await?;
+
+        let (slot_id, slot_config) = self.assign_slot(&task_id).await?;
+        let result = self
+            .execute_task_streaming(&task_id, prompt, &slot_id, &slot_config, on_output)
+            .await;
+
+        self.release_slot(&slot_id, &task_id, &result).await?;
+
+        let task_result = result?;
+        let mut task = self
+            .inner
+            .store
+            .get_task(&task_id)
+            .await?
+            .ok_or_else(|| Error::TaskNotFound(task_id.0.clone()))?;
+        task.state = TaskState::Completed;
+        task.result = Some(task_result.clone());
+        self.inner.store.put_task(task).await?;
+
+        Ok(task_result)
+    }
+
     /// Submit a task for async execution, returning the task ID immediately.
     ///
     /// Use [`Pool::result`] to poll for completion.
@@ -453,6 +501,8 @@ impl<S: PoolStore + 'static> Pool<S> {
             total_steps: steps.len(),
             current_step: None,
             current_step_name: None,
+            current_step_partial_output: None,
+            current_step_started_at: None,
             completed_steps: vec![],
             status: crate::chain::ChainStatus::Running,
         };
@@ -593,6 +643,18 @@ impl<S: PoolStore + 'static> Pool<S> {
         self.inner
             .chain_progress
             .insert(task_id.0.clone(), progress);
+    }
+
+    /// Append a text chunk to the current step's partial output.
+    ///
+    /// Called from the streaming output callback during chain execution.
+    /// This is a synchronous DashMap mutation — fast and lock-free.
+    pub(crate) fn append_chain_partial_output(&self, task_id: &TaskId, chunk: &str) {
+        if let Some(mut progress) = self.inner.chain_progress.get_mut(&task_id.0)
+            && let Some(ref mut partial) = progress.current_step_partial_output
+        {
+            partial.push_str(chunk);
+        }
     }
 
     /// Set a shared context value.
@@ -1133,6 +1195,169 @@ impl<S: PoolStore + 'static> Pool<S> {
             cost_microdollars,
             turns_used: query_result.num_turns.unwrap_or(0),
             session_id: Some(query_result.session_id),
+        })
+    }
+
+    /// Execute a task with optional streaming output.
+    ///
+    /// When `on_output` is `Some`, uses streaming execution (`stream-json` format)
+    /// and calls the callback with each text chunk as it arrives. When `None`,
+    /// falls back to the standard `execute_task` path.
+    async fn execute_task_streaming(
+        &self,
+        task_id: &TaskId,
+        prompt: &str,
+        slot_id: &SlotId,
+        slot_config: &SlotConfig,
+        on_output: Option<crate::chain::OnOutputChunk>,
+    ) -> Result<TaskResult> {
+        // If no streaming callback, use the standard non-streaming path.
+        let on_output = match on_output {
+            Some(cb) => cb,
+            None => {
+                return self
+                    .execute_task(task_id, prompt, slot_id, slot_config)
+                    .await;
+            }
+        };
+
+        let task_record = self.inner.store.get_task(task_id).await?;
+        let task_cfg = task_record.as_ref().and_then(|t| t.config.as_ref());
+        let resolved = ResolvedConfig::resolve(&self.inner.config, slot_config, task_cfg);
+
+        let system_prompt = self.build_system_prompt(&resolved, slot_config);
+
+        // Build the query with StreamJson format for streaming.
+        let mut cmd = claude_wrapper::QueryCommand::new(prompt)
+            .output_format(OutputFormat::StreamJson)
+            .permission_mode(resolved.permission_mode);
+
+        if resolved.permission_mode == PermissionMode::BypassPermissions {
+            cmd = cmd.dangerously_skip_permissions();
+        }
+        if let Some(ref model) = resolved.model {
+            cmd = cmd.model(model);
+        }
+        if let Some(max_turns) = resolved.max_turns {
+            cmd = cmd.max_turns(max_turns);
+        }
+        if let Some(ref sp) = system_prompt {
+            cmd = cmd.system_prompt(sp);
+        }
+        if let Some(effort) = resolved.effort {
+            cmd = cmd.effort(effort);
+        }
+        if !resolved.allowed_tools.is_empty() {
+            cmd = cmd.allowed_tools(&resolved.allowed_tools);
+        }
+
+        if !resolved.mcp_servers.is_empty() {
+            let mcp_path = self
+                .ensure_slot_mcp_config(slot_id, &resolved.mcp_servers)
+                .await?;
+            cmd = cmd.mcp_config(mcp_path.to_string_lossy());
+            if resolved.strict_mcp_config {
+                cmd = cmd.strict_mcp_config();
+            }
+        }
+
+        let claude_instance = if let Some(slot) = self.inner.store.get_slot(slot_id).await? {
+            if let Some(ref session_id) = slot.session_id {
+                cmd = cmd.resume(session_id);
+            }
+            if let Some(ref wt_path) = slot.worktree_path {
+                self.inner.claude.with_working_dir(wt_path)
+            } else {
+                self.inner.claude.clone()
+            }
+        } else {
+            self.inner.claude.clone()
+        };
+
+        tracing::debug!(
+            slot_id = %slot_id.0,
+            model = ?resolved.model,
+            effort = ?resolved.effort,
+            mcp_servers = resolved.mcp_servers.len(),
+            "executing task (streaming)"
+        );
+
+        // Collect the final result from stream events.
+        let mut result_text = String::new();
+        let mut session_id = String::new();
+        let mut cost_usd: Option<f64> = None;
+        let mut is_error = false;
+
+        let stream_result = claude_wrapper::streaming::stream_query(
+            &claude_instance,
+            &cmd,
+            |event: claude_wrapper::streaming::StreamEvent| {
+                match event.event_type() {
+                    Some("result") => {
+                        if let Some(text) = event.result_text() {
+                            result_text = text.to_string();
+                        }
+                        if let Some(sid) = event.session_id() {
+                            session_id = sid.to_string();
+                        }
+                        cost_usd = event.cost_usd();
+                        is_error = event
+                            .data
+                            .get("is_error")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                    }
+                    Some("assistant") => {
+                        // Extract text from content blocks in assistant messages.
+                        // Content may be at top level or nested under message.
+                        let content_sources = [
+                            event.data.get("content"),
+                            event.data.get("message").and_then(|m| m.get("content")),
+                        ];
+                        for content in content_sources.into_iter().flatten() {
+                            for block in content.as_array().into_iter().flatten() {
+                                if block.get("type").and_then(|t| t.as_str()) == Some("text")
+                                    && let Some(text) = block.get("text").and_then(|t| t.as_str())
+                                {
+                                    on_output(text);
+                                }
+                            }
+                        }
+                    }
+                    Some("content_block_delta") => {
+                        // Handle incremental text deltas.
+                        if let Some(delta) = event.data.get("delta")
+                            && delta.get("type").and_then(|t| t.as_str()) == Some("text_delta")
+                            && let Some(text) = delta.get("text").and_then(|t| t.as_str())
+                        {
+                            on_output(text);
+                        }
+                    }
+                    _ => {}
+                }
+            },
+        )
+        .await;
+
+        match stream_result {
+            Ok(_) => {}
+            Err(e) if self.inner.config.detect_permission_prompts => {
+                if let Some(detected) = detect_permission_prompt(&e, &slot_id.0) {
+                    return Err(detected);
+                }
+                return Err(e.into());
+            }
+            Err(e) => return Err(e.into()),
+        }
+
+        let cost_microdollars = cost_usd.map(|c| (c * 1_000_000.0) as u64).unwrap_or(0);
+
+        Ok(TaskResult {
+            output: result_text,
+            success: !is_error,
+            cost_microdollars,
+            turns_used: 0,
+            session_id: Some(session_id),
         })
     }
 
@@ -1763,6 +1988,8 @@ mod tests {
                 total_steps: 3,
                 current_step: Some(1),
                 current_step_name: Some("implement".into()),
+                current_step_partial_output: None,
+                current_step_started_at: None,
                 completed_steps: vec![],
                 status: crate::chain::ChainStatus::Running,
             },
@@ -1814,5 +2041,66 @@ mod tests {
         let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
         let result = pool.cancel_chain(&TaskId("nonexistent".into())).await;
         assert!(matches!(result, Err(Error::TaskNotFound(_))));
+    }
+
+    // ── Live output tests ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn append_chain_partial_output_accumulates() {
+        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+
+        let task_id = TaskId("chain-test".into());
+        let progress = crate::chain::ChainProgress {
+            total_steps: 2,
+            current_step: Some(0),
+            current_step_name: Some("plan".into()),
+            current_step_partial_output: Some(String::new()),
+            current_step_started_at: Some(1700000000),
+            completed_steps: vec![],
+            status: crate::chain::ChainStatus::Running,
+        };
+        pool.set_chain_progress(&task_id, progress).await;
+
+        pool.append_chain_partial_output(&task_id, "hello ");
+        pool.append_chain_partial_output(&task_id, "world");
+
+        let progress = pool.chain_progress(&task_id).unwrap();
+        assert_eq!(
+            progress.current_step_partial_output.as_deref(),
+            Some("hello world")
+        );
+    }
+
+    #[tokio::test]
+    async fn append_chain_partial_output_noop_when_none() {
+        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+
+        let task_id = TaskId("chain-test-2".into());
+        // Progress with partial output = None (completed state).
+        let progress = crate::chain::ChainProgress {
+            total_steps: 1,
+            current_step: None,
+            current_step_name: None,
+            current_step_partial_output: None,
+            current_step_started_at: None,
+            completed_steps: vec![],
+            status: crate::chain::ChainStatus::Completed,
+        };
+        pool.set_chain_progress(&task_id, progress).await;
+
+        // Should not panic or create a partial output field.
+        pool.append_chain_partial_output(&task_id, "ignored");
+
+        let progress = pool.chain_progress(&task_id).unwrap();
+        assert!(progress.current_step_partial_output.is_none());
+    }
+
+    #[tokio::test]
+    async fn append_chain_partial_output_noop_for_missing_task() {
+        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+
+        // Should not panic when task doesn't exist.
+        let task_id = TaskId("nonexistent".into());
+        pool.append_chain_partial_output(&task_id, "ignored");
     }
 }


### PR DESCRIPTION
## Summary

- Chain result polling now shows in-progress step output alongside completed steps
- Steps execute with streaming output so partial results are visible via `chain_progress`
- Adds `current_step_partial_output` and `current_step_started_at` to `ChainProgress`
- Adds `run_with_config_streaming` and `execute_task_streaming` for streaming execution
- Incremental text chunks appended via `append_chain_partial_output`

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib --all-features` passes (74 + 59 tests)
- [x] `cargo test --doc --all-features` passes (32 tests)

Closes #94