### PR TITLE
feat: per-chain worktree isolation opt-in

### DIFF
--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -205,6 +205,13 @@ fn parse_scope(s: &str) -> SkillScope {
     }
 }
 
+fn parse_isolation(s: Option<&str>) -> claude_pool::chain::ChainIsolation {
+    match s {
+        Some("worktree") => claude_pool::chain::ChainIsolation::Worktree,
+        _ => claude_pool::chain::ChainIsolation::None,
+    }
+}
+
 fn parse_source(s: &str) -> Option<SkillSource> {
     match s {
         "builtin" => Some(SkillSource::Builtin),
@@ -498,6 +505,8 @@ pub struct SubmitChainInput {
     pub steps: Vec<ChainStepInput>,
     /// Tags for grouping/filtering.
     pub tags: Option<Vec<String>>,
+    /// Isolation mode: "worktree" for per-chain git worktree, or omit for default (none).
+    pub isolation: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -506,6 +515,8 @@ pub struct FanOutChainsInput {
     pub chains: Vec<Vec<ChainStepInput>>,
     /// Tags for grouping/filtering.
     pub tags: Option<Vec<String>>,
+    /// Isolation mode: "worktree" for per-chain git worktree, or omit for default (none).
+    pub isolation: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -630,8 +641,10 @@ pub fn pool_submit_chain_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> T
             let state = Arc::clone(&state);
             async move {
                 let steps = convert_chain_steps(input.steps);
+                let isolation = parse_isolation(input.isolation.as_deref());
                 let options = claude_pool::ChainOptions {
                     tags: input.tags.unwrap_or_default(),
+                    isolation,
                 };
                 let skills = state.skills.read().await;
                 match state.pool.submit_chain(steps, &skills, options).await {
@@ -656,8 +669,10 @@ pub fn pool_fan_out_chains_tool<S: PoolStore + 'static>(state: Arc<State<S>>) ->
             let state = Arc::clone(&state);
             async move {
                 let chains = input.chains.into_iter().map(convert_chain_steps).collect();
+                let isolation = parse_isolation(input.isolation.as_deref());
                 let options = claude_pool::ChainOptions {
                     tags: input.tags.unwrap_or_default(),
+                    isolation,
                 };
                 let skills = state.skills.read().await;
                 match state.pool.fan_out_chains(chains, &skills, options).await {

--- a/crates/claude-pool/src/chain.rs
+++ b/crates/claude-pool/src/chain.rs
@@ -68,12 +68,26 @@ pub struct StepFailurePolicy {
     pub recovery_prompt: Option<String>,
 }
 
+/// Isolation mode for a chain execution.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChainIsolation {
+    /// Use the slot's working directory (default behavior).
+    #[default]
+    None,
+    /// Create a temporary git worktree shared by all steps in the chain.
+    Worktree,
+}
+
 /// Options for chain execution.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ChainOptions {
     /// Tags for the chain task (used when submitted async).
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Isolation mode for this chain.
+    #[serde(default)]
+    pub isolation: ChainIsolation,
 }
 
 /// Result of a single chain step.
@@ -164,7 +178,7 @@ pub async fn execute_chain<S: PoolStore + 'static>(
     skills: &SkillRegistry,
     steps: &[ChainStep],
 ) -> crate::Result<ChainResult> {
-    execute_chain_with_progress(pool, skills, steps, None).await
+    execute_chain_with_progress(pool, skills, steps, None, None).await
 }
 
 /// Execute a chain with optional progress tracking.
@@ -172,12 +186,14 @@ pub async fn execute_chain<S: PoolStore + 'static>(
 /// If `chain_task_id` is provided, intermediate progress is stored so callers
 /// can poll for status. When a chain task ID is present, steps execute with
 /// streaming output so partial results are visible via
-/// [`Pool::chain_progress`](crate::Pool::chain_progress).
+/// [`Pool::chain_progress`](crate::Pool::chain_progress). If `working_dir`
+/// is provided, all steps use that directory instead of the slot's default.
 pub async fn execute_chain_with_progress<S: PoolStore + 'static>(
     pool: &Pool<S>,
     skills: &SkillRegistry,
     steps: &[ChainStep],
     chain_task_id: Option<&TaskId>,
+    working_dir: Option<&std::path::Path>,
 ) -> crate::Result<ChainResult> {
     let mut step_results = Vec::with_capacity(steps.len());
     let mut previous_output = String::new();
@@ -240,9 +256,16 @@ pub async fn execute_chain_with_progress<S: PoolStore + 'static>(
             }) as OnOutputChunk
         });
 
-        let (step_result, step_cost) =
-            execute_step_with_retries(pool, step, &prompt, &previous_output, skills, on_output)
-                .await;
+        let (step_result, step_cost) = execute_step_with_retries(
+            pool,
+            step,
+            &prompt,
+            &previous_output,
+            skills,
+            on_output.clone(),
+            working_dir,
+        )
+        .await;
 
         total_cost += step_cost;
 
@@ -345,6 +368,7 @@ async fn execute_step_with_retries<S: PoolStore + 'static>(
     previous_output: &str,
     skills: &SkillRegistry,
     on_output: Option<OnOutputChunk>,
+    working_dir: Option<&std::path::Path>,
 ) -> (std::result::Result<StepResult, String>, u64) {
     let max_attempts = 1 + step.failure_policy.retries;
     let mut total_cost = 0u64;
@@ -362,7 +386,12 @@ async fn execute_step_with_retries<S: PoolStore + 'static>(
         };
 
         let result = pool
-            .run_with_config_streaming(&prompt, step.config.clone(), on_output.clone())
+            .run_with_config_streaming(
+                &prompt,
+                step.config.clone(),
+                on_output.clone(),
+                working_dir.map(|p| p.to_path_buf()),
+            )
             .await;
 
         match result {
@@ -406,7 +435,12 @@ async fn execute_step_with_retries<S: PoolStore + 'static>(
         tracing::info!(step = %step.name, "attempting recovery prompt");
 
         let result = pool
-            .run_with_config_streaming(&recovery_prompt, step.config.clone(), on_output)
+            .run_with_config_streaming(
+                &recovery_prompt,
+                step.config.clone(),
+                on_output,
+                working_dir.map(|p| p.to_path_buf()),
+            )
             .await;
 
         match result {
@@ -507,6 +541,36 @@ mod tests {
     fn chain_options_defaults() {
         let opts = ChainOptions::default();
         assert!(opts.tags.is_empty());
+        assert_eq!(opts.isolation, ChainIsolation::None);
+    }
+
+    #[test]
+    fn chain_isolation_serde_roundtrip() {
+        let worktree = ChainIsolation::Worktree;
+        let json = serde_json::to_string(&worktree).unwrap();
+        assert_eq!(json, r#""worktree""#);
+
+        let none = ChainIsolation::None;
+        let json = serde_json::to_string(&none).unwrap();
+        assert_eq!(json, r#""none""#);
+
+        let parsed: ChainIsolation = serde_json::from_str(r#""worktree""#).unwrap();
+        assert_eq!(parsed, ChainIsolation::Worktree);
+
+        let parsed: ChainIsolation = serde_json::from_str(r#""none""#).unwrap();
+        assert_eq!(parsed, ChainIsolation::None);
+    }
+
+    #[test]
+    fn chain_options_with_isolation_serializes() {
+        let opts = ChainOptions {
+            tags: vec!["test".into()],
+            isolation: ChainIsolation::Worktree,
+        };
+        let json = serde_json::to_string(&opts).unwrap();
+        let parsed: ChainOptions = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.isolation, ChainIsolation::Worktree);
+        assert_eq!(parsed.tags, vec!["test"]);
     }
 
     #[test]

--- a/crates/claude-pool/src/lib.rs
+++ b/crates/claude-pool/src/lib.rs
@@ -30,7 +30,7 @@ pub mod workflow;
 pub mod worktree;
 
 pub use chain::{
-    ChainOptions, ChainProgress, ChainResult, ChainStatus, ChainStep, StepAction,
+    ChainIsolation, ChainOptions, ChainProgress, ChainResult, ChainStatus, ChainStep, StepAction,
     StepFailurePolicy, StepResult, execute_chain,
 };
 pub use error::{Error, Result};

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -105,17 +105,14 @@ impl<S: PoolStore + 'static> PoolBuilder<S> {
 
     /// Build and initialize the pool, registering slots in the store.
     pub async fn build(self) -> Result<Pool<S>> {
-        // Set up worktree manager if isolation is enabled.
-        let worktree_manager = if self.config.worktree_isolation {
-            let repo_dir = self
-                .claude
-                .working_dir()
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-            Some(crate::worktree::WorktreeManager::new(repo_dir, None))
-        } else {
-            None
-        };
+        // Always create the worktree manager so it's available for
+        // per-chain worktrees even when global worktree_isolation is off.
+        let repo_dir = self
+            .claude
+            .working_dir()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+        let worktree_manager = Some(crate::worktree::WorktreeManager::new(repo_dir, None));
 
         let inner = Arc::new(PoolInner {
             claude: self.claude,
@@ -135,10 +132,14 @@ impl<S: PoolStore + 'static> PoolBuilder<S> {
 
             let slot_id = SlotId(format!("slot-{i}"));
 
-            // Create worktree if isolation is enabled.
-            let worktree_path = if let Some(ref mgr) = inner.worktree_manager {
-                let path = mgr.create(&slot_id).await?;
-                Some(path.to_string_lossy().into_owned())
+            // Create worktree if per-slot isolation is enabled.
+            let worktree_path = if inner.config.worktree_isolation {
+                if let Some(ref mgr) = inner.worktree_manager {
+                    let path = mgr.create(&slot_id).await?;
+                    Some(path.to_string_lossy().into_owned())
+                } else {
+                    None
+                }
             } else {
                 None
             };
@@ -201,54 +202,16 @@ impl<S: PoolStore + 'static> Pool<S> {
         prompt: &str,
         task_config: Option<SlotConfig>,
     ) -> Result<TaskResult> {
-        self.check_shutdown()?;
-        self.check_budget()?;
-
-        let task_id = TaskId(format!("task-{}", new_id()));
-
-        let record = TaskRecord {
-            id: task_id.clone(),
-            prompt: prompt.to_string(),
-            state: TaskState::Pending,
-            slot_id: None,
-            result: None,
-            tags: vec![],
-            config: task_config,
-        };
-        self.inner.store.put_task(record).await?;
-
-        let (slot_id, slot_config) = self.assign_slot(&task_id).await?;
-        let result = self
-            .execute_task(&task_id, prompt, &slot_id, &slot_config)
-            .await;
-
-        self.release_slot(&slot_id, &task_id, &result).await?;
-
-        let task_result = result?;
-        // Update task record with result.
-        let mut task = self
-            .inner
-            .store
-            .get_task(&task_id)
-            .await?
-            .ok_or_else(|| Error::TaskNotFound(task_id.0.clone()))?;
-        task.state = TaskState::Completed;
-        task.result = Some(task_result.clone());
-        self.inner.store.put_task(task).await?;
-
-        Ok(task_result)
+        self.run_with_config_and_dir(prompt, task_config, None)
+            .await
     }
 
-    /// Run a task with per-task config overrides and optional streaming output.
-    ///
-    /// When `on_output` is `Some`, the task uses streaming execution and calls
-    /// the callback with each text chunk as it arrives. When `None`, behaves
-    /// identically to [`run_with_config`](Self::run_with_config).
-    pub(crate) async fn run_with_config_streaming(
+    /// Run a task with per-task config overrides and an optional working directory override.
+    pub async fn run_with_config_and_dir(
         &self,
         prompt: &str,
         task_config: Option<SlotConfig>,
-        on_output: Option<crate::chain::OnOutputChunk>,
+        working_dir: Option<std::path::PathBuf>,
     ) -> Result<TaskResult> {
         self.check_shutdown()?;
         self.check_budget()?;
@@ -268,7 +231,71 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         let (slot_id, slot_config) = self.assign_slot(&task_id).await?;
         let result = self
-            .execute_task_streaming(&task_id, prompt, &slot_id, &slot_config, on_output)
+            .execute_task(
+                &task_id,
+                prompt,
+                &slot_id,
+                &slot_config,
+                working_dir.as_deref(),
+            )
+            .await;
+
+        self.release_slot(&slot_id, &task_id, &result).await?;
+
+        let task_result = result?;
+        // Update task record with result.
+        let mut task = self
+            .inner
+            .store
+            .get_task(&task_id)
+            .await?
+            .ok_or_else(|| Error::TaskNotFound(task_id.0.clone()))?;
+        task.state = TaskState::Completed;
+        task.result = Some(task_result.clone());
+        self.inner.store.put_task(task).await?;
+
+        Ok(task_result)
+    }
+
+    /// Run a task with per-task config overrides, optional streaming output,
+    /// and an optional working directory override.
+    ///
+    /// When `on_output` is `Some`, the task uses streaming execution and calls
+    /// the callback with each text chunk as it arrives. When `None`, behaves
+    /// identically to [`run_with_config_and_dir`](Self::run_with_config_and_dir).
+    pub(crate) async fn run_with_config_streaming(
+        &self,
+        prompt: &str,
+        task_config: Option<SlotConfig>,
+        on_output: Option<crate::chain::OnOutputChunk>,
+        working_dir: Option<std::path::PathBuf>,
+    ) -> Result<TaskResult> {
+        self.check_shutdown()?;
+        self.check_budget()?;
+
+        let task_id = TaskId(format!("task-{}", new_id()));
+
+        let record = TaskRecord {
+            id: task_id.clone(),
+            prompt: prompt.to_string(),
+            state: TaskState::Pending,
+            slot_id: None,
+            result: None,
+            tags: vec![],
+            config: task_config,
+        };
+        self.inner.store.put_task(record).await?;
+
+        let (slot_id, slot_config) = self.assign_slot(&task_id).await?;
+        let result = self
+            .execute_task_streaming(
+                &task_id,
+                prompt,
+                &slot_id,
+                &slot_config,
+                on_output,
+                working_dir.as_deref(),
+            )
             .await;
 
         self.release_slot(&slot_id, &task_id, &result).await?;
@@ -330,7 +357,7 @@ impl<S: PoolStore + 'static> Pool<S> {
             match pool.assign_slot(&tid).await {
                 Ok((slot_id, slot_config)) => {
                     let result = pool
-                        .execute_task(&tid, &prompt, &slot_id, &slot_config)
+                        .execute_task(&tid, &prompt, &slot_id, &slot_config, None)
                         .await;
 
                     let _ = pool.release_slot(&slot_id, &tid, &result).await;
@@ -485,6 +512,8 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         let task_id = TaskId(format!("chain-{}", new_id()));
 
+        let isolation = options.isolation;
+
         let record = TaskRecord {
             id: task_id.clone(),
             prompt: format!("chain: {} steps", steps.len()),
@@ -516,12 +545,51 @@ impl<S: PoolStore + 'static> Pool<S> {
             self.inner.store.put_task(task).await?;
         }
 
+        // Create chain worktree if isolation is requested.
+        let chain_working_dir = if isolation == crate::chain::ChainIsolation::Worktree {
+            if let Some(ref mgr) = self.inner.worktree_manager {
+                match mgr.create_for_chain(&task_id).await {
+                    Ok(path) => Some(path),
+                    Err(e) => {
+                        tracing::warn!(
+                            task_id = %task_id.0,
+                            error = %e,
+                            "failed to create chain worktree, falling back to slot dir"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let pool = self.clone();
         let tid = task_id.clone();
         let skills = skills.clone();
         tokio::spawn(async move {
-            let result =
-                crate::chain::execute_chain_with_progress(&pool, &skills, &steps, Some(&tid)).await;
+            let result = crate::chain::execute_chain_with_progress(
+                &pool,
+                &skills,
+                &steps,
+                Some(&tid),
+                chain_working_dir.as_deref(),
+            )
+            .await;
+
+            // Clean up chain worktree if we created one.
+            if chain_working_dir.is_some()
+                && let Some(ref mgr) = pool.inner.worktree_manager
+                && let Err(e) = mgr.remove_chain(&tid).await
+            {
+                tracing::warn!(
+                    task_id = %tid.0,
+                    error = %e,
+                    "failed to clean up chain worktree"
+                );
+            }
 
             // Store the chain result as the task result.
             if let Some(mut task) = pool.inner.store.get_task(&tid).await.ok().flatten() {
@@ -620,7 +688,10 @@ impl<S: PoolStore + 'static> Pool<S> {
         let steps = workflow.instantiate(&arguments)?;
 
         // Submit the instantiated chain with tags
-        let options = crate::chain::ChainOptions { tags };
+        let options = crate::chain::ChainOptions {
+            tags,
+            ..Default::default()
+        };
         self.submit_chain(steps, skills, options).await
     }
 
@@ -844,10 +915,14 @@ impl<S: PoolStore + 'static> Pool<S> {
             let slot_id = SlotId(format!("slot-{next_id}"));
             next_id += 1;
 
-            // Create worktree if isolation is enabled.
-            let worktree_path = if let Some(ref mgr) = self.inner.worktree_manager {
-                let path = mgr.create(&slot_id).await?;
-                Some(path.to_string_lossy().into_owned())
+            // Create worktree if per-slot isolation is enabled.
+            let worktree_path = if self.inner.config.worktree_isolation {
+                if let Some(ref mgr) = self.inner.worktree_manager {
+                    let path = mgr.create(&slot_id).await?;
+                    Some(path.to_string_lossy().into_owned())
+                } else {
+                    None
+                }
             } else {
                 None
             };
@@ -1102,6 +1177,7 @@ impl<S: PoolStore + 'static> Pool<S> {
         prompt: &str,
         slot_id: &SlotId,
         slot_config: &SlotConfig,
+        override_working_dir: Option<&std::path::Path>,
     ) -> Result<TaskResult> {
         let task_record = self.inner.store.get_task(_task_id).await?;
         let task_cfg = task_record.as_ref().and_then(|t| t.config.as_ref());
@@ -1149,14 +1225,16 @@ impl<S: PoolStore + 'static> Pool<S> {
             }
         }
 
-        // Use worktree working dir if the slot has one, otherwise use default.
+        // Use override working dir, slot worktree, or default.
         let claude_instance = if let Some(slot) = self.inner.store.get_slot(slot_id).await? {
             // Resume session if the slot has one.
             if let Some(ref session_id) = slot.session_id {
                 cmd = cmd.resume(session_id);
             }
 
-            if let Some(ref wt_path) = slot.worktree_path {
+            if let Some(dir) = override_working_dir {
+                self.inner.claude.with_working_dir(dir)
+            } else if let Some(ref wt_path) = slot.worktree_path {
                 self.inner.claude.with_working_dir(wt_path)
             } else {
                 self.inner.claude.clone()
@@ -1210,13 +1288,14 @@ impl<S: PoolStore + 'static> Pool<S> {
         slot_id: &SlotId,
         slot_config: &SlotConfig,
         on_output: Option<crate::chain::OnOutputChunk>,
+        override_working_dir: Option<&std::path::Path>,
     ) -> Result<TaskResult> {
         // If no streaming callback, use the standard non-streaming path.
         let on_output = match on_output {
             Some(cb) => cb,
             None => {
                 return self
-                    .execute_task(task_id, prompt, slot_id, slot_config)
+                    .execute_task(task_id, prompt, slot_id, slot_config, override_working_dir)
                     .await;
             }
         };
@@ -1261,11 +1340,14 @@ impl<S: PoolStore + 'static> Pool<S> {
             }
         }
 
+        // Use override working dir (chain worktree) > slot worktree > default.
         let claude_instance = if let Some(slot) = self.inner.store.get_slot(slot_id).await? {
             if let Some(ref session_id) = slot.session_id {
                 cmd = cmd.resume(session_id);
             }
-            if let Some(ref wt_path) = slot.worktree_path {
+            if let Some(dir) = override_working_dir {
+                self.inner.claude.with_working_dir(dir)
+            } else if let Some(ref wt_path) = slot.worktree_path {
                 self.inner.claude.with_working_dir(wt_path)
             } else {
                 self.inner.claude.clone()
@@ -1827,7 +1909,10 @@ mod tests {
         let pool = Pool::builder(mock_claude()).slots(2).build().await.unwrap();
 
         let skills = crate::skill::SkillRegistry::new();
-        let options = crate::chain::ChainOptions { tags: vec![] };
+        let options = crate::chain::ChainOptions {
+            tags: vec![],
+            ..Default::default()
+        };
 
         // Create two chains, each with one prompt step.
         let chain1 = vec![crate::chain::ChainStep {

--- a/crates/claude-pool/src/worktree.rs
+++ b/crates/claude-pool/src/worktree.rs
@@ -7,7 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
-use crate::types::SlotId;
+use crate::types::{SlotId, TaskId};
 
 /// Manages git worktrees for pool slots.
 #[derive(Debug)]
@@ -152,6 +152,104 @@ impl WorktreeManager {
     pub fn repo_dir(&self) -> &Path {
         &self.repo_dir
     }
+
+    /// Create a worktree for a chain execution.
+    ///
+    /// Creates a git worktree at `{base_dir}/chains/{task_id}` branched from
+    /// the current HEAD.
+    pub async fn create_for_chain(&self, task_id: &TaskId) -> Result<PathBuf> {
+        let worktree_path = self.chain_worktree_path(task_id);
+
+        // Ensure chains directory exists.
+        let chains_dir = self.base_dir.join("chains");
+        tokio::fs::create_dir_all(&chains_dir)
+            .await
+            .map_err(|e| Error::Store(format!("failed to create chains dir: {e}")))?;
+
+        // Remove existing worktree if it exists (stale from previous run).
+        if worktree_path.exists() {
+            self.remove_chain(task_id).await?;
+        }
+
+        let branch_name = format!("claude-pool/chain/{}", task_id.0);
+        let output = tokio::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                &branch_name,
+                worktree_path.to_str().unwrap_or_default(),
+                "HEAD",
+            ])
+            .current_dir(&self.repo_dir)
+            .output()
+            .await
+            .map_err(|e| Error::Store(format!("failed to create chain worktree: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::Store(format!(
+                "git worktree add failed for chain: {stderr}"
+            )));
+        }
+
+        tracing::info!(
+            task_id = %task_id.0,
+            path = %worktree_path.display(),
+            "created chain worktree"
+        );
+
+        Ok(worktree_path)
+    }
+
+    /// Remove a chain's worktree and its branch.
+    pub async fn remove_chain(&self, task_id: &TaskId) -> Result<()> {
+        let worktree_path = self.chain_worktree_path(task_id);
+
+        if worktree_path.exists() {
+            let output = tokio::process::Command::new("git")
+                .args([
+                    "worktree",
+                    "remove",
+                    "--force",
+                    worktree_path.to_str().unwrap_or_default(),
+                ])
+                .current_dir(&self.repo_dir)
+                .output()
+                .await
+                .map_err(|e| Error::Store(format!("failed to remove chain worktree: {e}")))?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                tracing::warn!(
+                    task_id = %task_id.0,
+                    error = %stderr,
+                    "failed to remove chain worktree, cleaning up manually"
+                );
+                let _ = tokio::fs::remove_dir_all(&worktree_path).await;
+            }
+        }
+
+        // Clean up the branch.
+        let branch_name = format!("claude-pool/chain/{}", task_id.0);
+        let _ = tokio::process::Command::new("git")
+            .args(["branch", "-D", &branch_name])
+            .current_dir(&self.repo_dir)
+            .output()
+            .await;
+
+        tracing::debug!(
+            task_id = %task_id.0,
+            "removed chain worktree"
+        );
+
+        Ok(())
+    }
+
+    /// Get the worktree path for a chain (may not exist yet).
+    pub fn chain_worktree_path(&self, task_id: &TaskId) -> PathBuf {
+        self.base_dir.join("chains").join(&task_id.0)
+    }
 }
 
 #[cfg(test)]
@@ -170,5 +268,15 @@ mod tests {
         let mgr = WorktreeManager::new("/repo", None);
         let expected = std::env::temp_dir().join("claude-pool").join("worktrees");
         assert_eq!(mgr.base_dir(), expected);
+    }
+
+    #[test]
+    fn chain_worktree_path_construction() {
+        let mgr = WorktreeManager::new("/repo", Some(PathBuf::from("/tmp/wt")));
+        let task_id = TaskId("chain-abc123".into());
+        assert_eq!(
+            mgr.chain_worktree_path(&task_id),
+            PathBuf::from("/tmp/wt/chains/chain-abc123")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `ChainIsolation` enum (`none`/`worktree`) and `isolation` field to `ChainOptions`
- Add `create_for_chain`/`remove_chain` methods to `WorktreeManager` (chain worktrees at `{base_dir}/chains/{task_id}`)
- Add `run_with_config_and_dir` to `Pool` and thread `override_working_dir` through `execute_task` (priority: chain worktree > slot worktree > default)
- `WorktreeManager` now always created (not gated on global `worktree_isolation` flag) so per-chain isolation works independently
- Worktree lifecycle in `submit_chain`: create before spawn, cleanup after chain completes (success or failure)
- Add `isolation` parameter to `pool_submit_chain` and `pool_fan_out_chains` MCP tools
- 3 new chain tests, 1 new worktree test

Closes #104

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib --all-features` passes (131 tests)
- [x] `cargo test --doc --all-features` passes (32 tests)
- [ ] Integration test with real git repo: submit 2-step chain with `isolation: "worktree"`, verify worktree exists during execution, removed after