### PR TITLE
feat: default chain isolation to worktree and add rebase skill

### DIFF
--- a/.claude-pool/skills/rebase_onto_main.json
+++ b/.claude-pool/skills/rebase_onto_main.json
@@ -1,0 +1,8 @@
+{
+  "name": "rebase_onto_main",
+  "description": "Rebase the current branch onto main, resolving conflicts if needed.",
+  "prompt": "Rebase the current branch onto the latest main:\n\n1. `git fetch origin main`\n2. `git rebase origin/main`\n3. If conflicts occur:\n   a. Identify conflicting files\n   b. Resolve conflicts intelligently (keep both sides where appropriate)\n   c. `git add` resolved files\n   d. `git rebase --continue`\n   e. Repeat until rebase completes\n4. Run `cargo check --all-features` to verify compilation\n5. If cargo check fails, fix the issue and amend the relevant commit\n\nReport:\n- Starting commit and branch\n- Number of commits rebased\n- Conflicts resolved (if any), with brief description of each\n- Final cargo check result\n- Final commit SHA",
+  "arguments": [],
+  "config": null,
+  "scope": "task"
+}

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -207,8 +207,8 @@ fn parse_scope(s: &str) -> SkillScope {
 
 fn parse_isolation(s: Option<&str>) -> claude_pool::chain::ChainIsolation {
     match s {
-        Some("worktree") => claude_pool::chain::ChainIsolation::Worktree,
-        _ => claude_pool::chain::ChainIsolation::None,
+        Some("none") => claude_pool::chain::ChainIsolation::None,
+        _ => claude_pool::chain::ChainIsolation::Worktree,
     }
 }
 

--- a/crates/claude-pool/src/chain.rs
+++ b/crates/claude-pool/src/chain.rs
@@ -84,10 +84,10 @@ pub struct StepFailurePolicy {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChainIsolation {
-    /// Use the slot's working directory (default behavior).
-    #[default]
+    /// Use the slot's working directory (no isolation).
     None,
-    /// Create a temporary git worktree shared by all steps in the chain.
+    /// Create a temporary git worktree shared by all steps in the chain (default).
+    #[default]
     Worktree,
 }
 
@@ -608,7 +608,7 @@ mod tests {
     fn chain_options_defaults() {
         let opts = ChainOptions::default();
         assert!(opts.tags.is_empty());
-        assert_eq!(opts.isolation, ChainIsolation::None);
+        assert_eq!(opts.isolation, ChainIsolation::Worktree);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Breaking**: `ChainIsolation` now defaults to `Worktree` instead of `None`. Chains run in isolated worktrees by default, preventing interference between concurrent chains. Pass `isolation: "none"` to opt out.
- Server-side `parse_isolation()` updated to match: unrecognized/missing values now default to worktree.
- Adds `rebase_onto_main` project-local skill (`.claude-pool/skills/`) for use as a chain step to handle rebasing with conflict resolution.

Closes #101

## Test plan

- [x] All 155 unit tests pass (`cargo test --lib --all-features`)
- [ ] Verify chains create worktrees by default when no isolation is specified
- [ ] Verify `isolation: "none"` still skips worktree creation