### PR TITLE
test: fake-claude binary and integration test infrastructure

### DIFF
--- a/crates/claude-pool/tests/helpers/mod.rs
+++ b/crates/claude-pool/tests/helpers/mod.rs
@@ -1,0 +1,54 @@
+//! Test helpers for claude-pool integration tests.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Path to the fake-claude.sh script relative to the workspace root.
+pub const FAKE_CLAUDE_SCRIPT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../test-helpers/fake-claude.sh"
+);
+
+/// Return the path to the fake-claude binary.
+pub fn fake_claude_path() -> PathBuf {
+    PathBuf::from(FAKE_CLAUDE_SCRIPT)
+}
+
+/// Create a temporary git repository.
+///
+/// Initialises a bare repo with a single empty commit so that worktree
+/// operations have a HEAD to branch from.
+pub fn temp_git_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+
+    let run = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .status()
+            .expect("git command failed");
+        assert!(status.success(), "git {args:?} failed");
+    };
+
+    run(&["init"]);
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "Test"]);
+
+    // Create an initial commit so HEAD exists.
+    let file = dir.path().join("README.md");
+    std::fs::write(&file, "# test repo\n").expect("write failed");
+    run(&["add", "."]);
+    run(&["commit", "-m", "init"]);
+
+    dir
+}
+
+/// Build a [`claude_wrapper::Claude`] client that points at the fake-claude binary.
+pub fn claude_with_fake_binary(fake_binary: &Path) -> claude_wrapper::Claude {
+    claude_wrapper::Claude::builder()
+        .binary(fake_binary)
+        .build()
+        .expect("failed to build Claude client")
+}

--- a/crates/claude-pool/tests/worktree_tests.rs
+++ b/crates/claude-pool/tests/worktree_tests.rs
@@ -1,0 +1,50 @@
+//! Integration tests for git worktree management.
+
+mod helpers;
+
+use claude_pool::{WorktreeManager, types::SlotId};
+
+/// Create a worktree for a slot, verify the path exists, then remove it and
+/// verify the path is gone.
+#[tokio::test]
+async fn worktree_create_and_remove_round_trip() {
+    let repo = helpers::temp_git_repo();
+    let base_dir = tempfile::tempdir().expect("temp dir");
+
+    let mgr = WorktreeManager::new(repo.path(), Some(base_dir.path().to_path_buf()));
+    let slot_id = SlotId("slot-test-0".into());
+
+    let wt_path = mgr.create(&slot_id).await.expect("worktree create");
+    assert!(wt_path.exists(), "worktree path should exist after create");
+    assert!(
+        wt_path.join(".git").exists(),
+        "worktree should contain a .git file"
+    );
+
+    mgr.remove(&slot_id).await.expect("worktree remove");
+    assert!(
+        !wt_path.exists(),
+        "worktree path should be gone after remove"
+    );
+}
+
+/// Create a chain worktree, verify it exists, then remove it.
+#[tokio::test]
+async fn chain_worktree_create_and_remove_round_trip() {
+    let repo = helpers::temp_git_repo();
+    let base_dir = tempfile::tempdir().expect("temp dir");
+
+    let mgr = WorktreeManager::new(repo.path(), Some(base_dir.path().to_path_buf()));
+    let task_id = claude_pool::types::TaskId("chain-abc123".into());
+
+    let wt_path = mgr
+        .create_for_chain(&task_id)
+        .await
+        .expect("chain worktree create");
+    assert!(wt_path.exists(), "chain worktree path should exist");
+
+    mgr.remove_chain(&task_id)
+        .await
+        .expect("chain worktree remove");
+    assert!(!wt_path.exists(), "chain worktree path should be gone");
+}

--- a/crates/claude-wrapper/tests/fake_claude.rs
+++ b/crates/claude-wrapper/tests/fake_claude.rs
@@ -1,0 +1,67 @@
+//! Tests that use the fake-claude binary instead of the real Claude CLI.
+//!
+//! These tests do not require a real `claude` binary or authentication.
+
+use std::path::PathBuf;
+
+use claude_wrapper::{Claude, ClaudeCommand, QueryCommand};
+
+const FAKE_CLAUDE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../test-helpers/fake-claude.sh"
+);
+
+fn fake_binary() -> PathBuf {
+    PathBuf::from(FAKE_CLAUDE)
+}
+
+/// Build a Claude client backed by the fake binary with optional env overrides.
+fn claude_with_env(pairs: &[(&str, &str)]) -> Claude {
+    let mut builder = Claude::builder().binary(fake_binary());
+    for (k, v) in pairs {
+        builder = builder.env(*k, *v);
+    }
+    builder.build().expect("failed to build Claude client")
+}
+
+/// Verify that the fake binary executes and returns expected plain-text output.
+#[tokio::test]
+async fn fake_claude_basic_execution() {
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "hello from fake")]);
+
+    let output = claude_wrapper::VersionCommand::new()
+        .execute(&claude)
+        .await
+        .expect("fake claude should succeed");
+
+    assert!(output.success);
+    assert!(output.stdout.contains("hello from fake"));
+}
+
+/// Verify that stream-json NDJSON output is parsed correctly by execute_json.
+#[tokio::test]
+async fn fake_claude_stream_json_output() {
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "42")]);
+
+    let result = QueryCommand::new("What is 2+2?")
+        .no_session_persistence()
+        .execute_json(&claude)
+        .await
+        .expect("fake claude json query should succeed");
+
+    assert_eq!(result.result, "42");
+    assert_eq!(result.session_id, "fake-session-id");
+}
+
+/// Verify that a non-zero exit code is surfaced as an error.
+#[tokio::test]
+async fn fake_claude_non_zero_exit_is_error() {
+    let claude = claude_with_env(&[
+        ("FAKE_CLAUDE_EXIT_CODE", "1"),
+        ("FAKE_CLAUDE_ERROR_MSG", "simulated failure"),
+    ]);
+
+    let result = claude_wrapper::VersionCommand::new().execute(&claude).await;
+
+    assert!(result.is_err(), "non-zero exit should be an error");
+}

--- a/crates/test-helpers/fake-claude.sh
+++ b/crates/test-helpers/fake-claude.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fake claude binary for tests.
+#
+# Controlled by environment variables:
+#   FAKE_CLAUDE_OUTPUT      - text to return (default: "fake response")
+#   FAKE_CLAUDE_EXIT_CODE   - exit code to return (default: 0)
+#   FAKE_CLAUDE_SESSION_ID  - session_id in JSON output (default: "fake-session-id")
+#   FAKE_CLAUDE_ERROR_MSG   - error message for stderr on non-zero exit
+#
+# Output format is selected by --output-format argument:
+#   stream-json  ->  three NDJSON lines (system/assistant/result)
+#   json         ->  single JSON object matching QueryResult
+#   (none/other) ->  plain text
+
+OUTPUT="${FAKE_CLAUDE_OUTPUT:-fake response}"
+EXIT_CODE="${FAKE_CLAUDE_EXIT_CODE:-0}"
+SESSION_ID="${FAKE_CLAUDE_SESSION_ID:-fake-session-id}"
+ERROR_MSG="${FAKE_CLAUDE_ERROR_MSG:-command failed}"
+
+if [[ "$EXIT_CODE" -ne 0 ]]; then
+    echo "$ERROR_MSG" >&2
+    exit "$EXIT_CODE"
+fi
+
+# Parse --output-format value from args
+OUTPUT_FORMAT=""
+args=("$@")
+for i in "${!args[@]}"; do
+    if [[ "${args[$i]}" == "--output-format" ]]; then
+        OUTPUT_FORMAT="${args[$((i+1))]}"
+        break
+    fi
+    if [[ "${args[$i]}" == --output-format=* ]]; then
+        OUTPUT_FORMAT="${args[$i]#--output-format=}"
+        break
+    fi
+done
+
+if [[ "$OUTPUT_FORMAT" == "stream-json" ]]; then
+    # Emit NDJSON matching real claude's stream-json format.
+    printf '{"type":"system","subtype":"init","session_id":"%s","tools":[],"mcp_servers":[]}\n' "$SESSION_ID"
+    printf '{"type":"assistant","message":{"id":"msg_fake","type":"message","role":"assistant","content":[{"type":"text","text":"%s"}],"model":"claude-fake","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":5,"output_tokens":3}},"session_id":"%s"}\n' "$OUTPUT" "$SESSION_ID"
+    printf '{"type":"result","subtype":"success","result":"%s","session_id":"%s","cost_usd":0.0,"total_cost_usd":0.0,"num_turns":1,"is_error":false}\n' "$OUTPUT" "$SESSION_ID"
+elif [[ "$OUTPUT_FORMAT" == "json" ]]; then
+    # Emit a single JSON object matching QueryResult.
+    printf '{"result":"%s","session_id":"%s","total_cost_usd":0.0,"num_turns":1,"is_error":false}\n' "$OUTPUT" "$SESSION_ID"
+else
+    # Plain text.
+    printf '%s\n' "$OUTPUT"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- **`crates/test-helpers/fake-claude.sh`** — shell script fake-claude binary controlled by env vars (`FAKE_CLAUDE_OUTPUT`, `FAKE_CLAUDE_EXIT_CODE`, `FAKE_CLAUDE_SESSION_ID`, `FAKE_CLAUDE_ERROR_MSG`); emits plain text, `--output-format json` single-object, or `--output-format stream-json` NDJSON
- **`crates/claude-wrapper/tests/fake_claude.rs`** — three tests using the fake binary: basic execution, JSON output parsing via `execute_json`, non-zero exit code surfaced as error
- **`crates/claude-pool/tests/helpers/mod.rs`** — shared helpers: `temp_git_repo()`, `fake_claude_path()`, `claude_with_fake_binary()`
- **`crates/claude-pool/tests/worktree_tests.rs`** — two round-trip tests: slot worktree create/remove, chain worktree create/remove

No real `claude` binary or auth required for any of these tests.

Closes #115

## Test plan

- [ ] `cargo test --test fake_claude` — all 3 pass without real claude
- [ ] `cargo test --test worktree_tests -p claude-pool` — both worktree tests pass
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean