### PR TITLE
test: add claude-wrapper integration tests for streaming, timeout, and errors

### DIFF
--- a/crates/claude-wrapper/tests/fake_claude.rs
+++ b/crates/claude-wrapper/tests/fake_claude.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use claude_wrapper::{Claude, ClaudeCommand, QueryCommand};
+use claude_wrapper::{Claude, ClaudeCommand, OutputFormat, QueryCommand};
 
 const FAKE_CLAUDE: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -64,4 +64,89 @@ async fn fake_claude_non_zero_exit_is_error() {
     let result = claude_wrapper::VersionCommand::new().execute(&claude).await;
 
     assert!(result.is_err(), "non-zero exit should be an error");
+}
+
+/// Verify that stream_query fires the handler for each NDJSON event type.
+#[tokio::test]
+async fn streaming_ndjson_parsed_correctly() {
+    use claude_wrapper::streaming::{StreamEvent, stream_query};
+
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "streamed response")]);
+    let cmd = QueryCommand::new("test prompt")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+
+    let mut events: Vec<StreamEvent> = Vec::new();
+    stream_query(&claude, &cmd, |event| events.push(event))
+        .await
+        .expect("streaming should succeed");
+
+    // Fake binary emits exactly three lines: system, assistant, result.
+    assert_eq!(events.len(), 3, "expected 3 events, got {}", events.len());
+    assert_eq!(events[0].event_type(), Some("system"));
+    assert_eq!(events[1].event_type(), Some("assistant"));
+    assert_eq!(events[2].event_type(), Some("result"));
+}
+
+/// Verify that the result event contains the correct session_id, result text,
+/// and cost fields.
+#[tokio::test]
+async fn streaming_extracts_cost_and_session() {
+    use claude_wrapper::streaming::{StreamEvent, stream_query};
+
+    let claude = claude_with_env(&[
+        ("FAKE_CLAUDE_OUTPUT", "test output"),
+        ("FAKE_CLAUDE_SESSION_ID", "test-session-123"),
+    ]);
+    let cmd = QueryCommand::new("test prompt")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+
+    let mut result_event: Option<StreamEvent> = None;
+    stream_query(&claude, &cmd, |event| {
+        if event.is_result() {
+            result_event = Some(event);
+        }
+    })
+    .await
+    .expect("streaming should succeed");
+
+    let result = result_event.expect("should have received a result event");
+    assert_eq!(result.session_id(), Some("test-session-123"));
+    assert_eq!(result.result_text(), Some("test output"));
+    assert_eq!(result.cost_usd(), Some(0.0));
+}
+
+/// Verify that a short timeout fires before the fake binary finishes sleeping.
+#[tokio::test]
+async fn fake_claude_timeout_fires() {
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_DELAY", "5")
+        .timeout_secs(1)
+        .build()
+        .expect("failed to build client");
+
+    let result = claude_wrapper::VersionCommand::new().execute(&claude).await;
+
+    assert!(result.is_err(), "expected a timeout error");
+    let err_str = result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        err_str.contains("timeout") || err_str.contains("timed out"),
+        "expected timeout error, got: {err_str}"
+    );
+}
+
+/// Verify that pointing at a nonexistent binary surfaces an error at execution
+/// time (not at build time).
+#[tokio::test]
+async fn binary_not_found_returns_error() {
+    let claude = Claude::builder()
+        .binary("/nonexistent/binary/fake-claude")
+        .build()
+        .expect("builder should not validate binary existence");
+
+    let result = claude_wrapper::VersionCommand::new().execute(&claude).await;
+
+    assert!(result.is_err(), "should fail when binary does not exist");
 }

--- a/crates/test-helpers/fake-claude.sh
+++ b/crates/test-helpers/fake-claude.sh
@@ -6,6 +6,7 @@
 #   FAKE_CLAUDE_EXIT_CODE   - exit code to return (default: 0)
 #   FAKE_CLAUDE_SESSION_ID  - session_id in JSON output (default: "fake-session-id")
 #   FAKE_CLAUDE_ERROR_MSG   - error message for stderr on non-zero exit
+#   FAKE_CLAUDE_DELAY       - seconds to sleep before any output (default: 0)
 #
 # Output format is selected by --output-format argument:
 #   stream-json  ->  three NDJSON lines (system/assistant/result)
@@ -16,6 +17,12 @@ OUTPUT="${FAKE_CLAUDE_OUTPUT:-fake response}"
 EXIT_CODE="${FAKE_CLAUDE_EXIT_CODE:-0}"
 SESSION_ID="${FAKE_CLAUDE_SESSION_ID:-fake-session-id}"
 ERROR_MSG="${FAKE_CLAUDE_ERROR_MSG:-command failed}"
+DELAY="${FAKE_CLAUDE_DELAY:-0}"
+
+# Optional delay before any output - used to test timeouts.
+if [[ "$DELAY" -gt 0 ]]; then
+    sleep "$DELAY"
+fi
 
 if [[ "$EXIT_CODE" -ne 0 ]]; then
     echo "$ERROR_MSG" >&2


### PR DESCRIPTION
## Summary

Extends `crates/claude-wrapper/tests/fake_claude.rs` with four new tests that exercise previously untested code paths, all using the fake-claude binary (no real claude or auth needed).

### Tests added

| Test | What it covers |
|---|---|
| `streaming_ndjson_parsed_correctly` | `stream_query()` fires handler 3× with correct event types (system/assistant/result) |
| `streaming_extracts_cost_and_session` | Result `StreamEvent` accessors: `session_id()`, `result_text()`, `cost_usd()` |
| `fake_claude_timeout_fires` | `timeout_secs(1)` + `FAKE_CLAUDE_DELAY=5` → `Error::Timeout` |
| `binary_not_found_returns_error` | Bad binary path errors at execution time, not at `build()` |

### Script change

`crates/test-helpers/fake-claude.sh` gains `FAKE_CLAUDE_DELAY` support: sleeps N seconds before any output so timeout tests don't need real I/O latency.

Closes #118

## Test results

```
test result: ok. 7 passed; 0 failed; 0 ignored  (fake_claude)
test result: ok. 64 passed; 0 failed; 0 ignored (lib)
test result: ok. 2 passed;  0 failed; 0 ignored  (worktree_tests)
cargo fmt --all -- --check: clean
cargo clippy --all-targets --all-features -- -D warnings: clean
```