### PR TITLE
test: add claude-pool-server tool handler tests

### DIFF
--- a/crates/claude-pool-server/Cargo.toml
+++ b/crates/claude-pool-server/Cargo.toml
@@ -12,6 +12,10 @@ readme = "README.md"
 keywords = ["claude", "mcp", "pool", "server"]
 categories = ["development-tools"]
 
+[lib]
+name = "claude_pool_server"
+path = "src/lib.rs"
+
 [[bin]]
 name = "claude-pool-server"
 path = "src/main.rs"
@@ -31,6 +35,12 @@ tracing-subscriber = { workspace = true }
 [dependencies.axum]
 version = "0.8"
 optional = true
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true }
+serde_json = { workspace = true }
+tower-mcp = { workspace = true, features = ["testing"] }
 
 [features]
 default = []

--- a/crates/claude-pool-server/src/lib.rs
+++ b/crates/claude-pool-server/src/lib.rs
@@ -1,0 +1,29 @@
+//! Library interface for claude-pool-server.
+//!
+//! Exposes [`State`] and the tool/resource builders so that integration tests
+//! (and downstream embedders) can construct a router without going through the
+//! binary entry point.
+
+pub mod prompts;
+pub mod resources;
+pub mod tools;
+
+pub mod auth;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use claude_pool::{Pool, PoolStore, SkillRegistry, WorkflowRegistry};
+use tokio::sync::RwLock;
+
+/// Shared state accessible by all tool/resource handlers.
+pub struct State<S: PoolStore> {
+    /// The pool instance.
+    pub pool: Pool<S>,
+    /// Thread-safe skill registry (mutated by skill management tools).
+    pub skills: Arc<RwLock<SkillRegistry>>,
+    /// Workflow registry.
+    pub workflows: WorkflowRegistry,
+    /// Directory for persisting project-local skills.
+    pub skills_dir: PathBuf,
+}

--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -3,30 +3,14 @@
 //! Manages a pool of Claude CLI slots, exposed as an MCP server
 //! over stdio or HTTP transport.
 
-mod auth;
-mod prompts;
-mod resources;
-mod tools;
-
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
-use claude_pool::{InMemoryStore, Pool, PoolConfig, PoolStore, SkillRegistry, WorkflowRegistry};
+use claude_pool::{InMemoryStore, Pool, PoolConfig, SkillRegistry, WorkflowRegistry};
+use claude_pool_server::{State, prompts, resources, tools};
 use tokio::sync::RwLock;
 use tower_mcp::{McpRouter, StdioTransport};
-
-/// Shared state accessible by all tool/resource handlers.
-pub struct State<S: PoolStore> {
-    /// The pool instance.
-    pub pool: Pool<S>,
-    /// Thread-safe skill registry (mutated by skill management tools).
-    pub skills: Arc<RwLock<SkillRegistry>>,
-    /// Workflow registry.
-    pub workflows: WorkflowRegistry,
-    /// Directory for persisting project-local skills.
-    pub skills_dir: PathBuf,
-}
 
 /// MCP server for managing a pool of Claude CLI slots.
 #[derive(Parser)]
@@ -290,7 +274,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             let addr = format!("{}:{}", cli.bind, cli.port);
 
-            let tokens = auth::BearerTokens::new(cli.http_token);
+            let tokens = claude_pool_server::auth::BearerTokens::new(cli.http_token);
             if tokens.is_empty() {
                 tracing::warn!(
                     "HTTP transport started without authentication -- use --http-token for production"
@@ -314,7 +298,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Build an axum application with optional bearer token authentication.
 #[cfg(feature = "http")]
-fn build_http_app(router: McpRouter, tokens: auth::BearerTokens) -> axum::Router {
+fn build_http_app(
+    router: McpRouter,
+    tokens: claude_pool_server::auth::BearerTokens,
+) -> axum::Router {
     use tower_mcp::HttpTransport;
 
     let transport = HttpTransport::new(router).disable_origin_validation();
@@ -334,7 +321,7 @@ fn build_http_app(router: McpRouter, tokens: auth::BearerTokens) -> axum::Router
 async fn bearer_auth_middleware(
     req: axum::extract::Request,
     next: axum::middleware::Next,
-    tokens: auth::BearerTokens,
+    tokens: claude_pool_server::auth::BearerTokens,
 ) -> axum::response::Response {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;

--- a/crates/claude-pool-server/tests/tool_handler_tests.rs
+++ b/crates/claude-pool-server/tests/tool_handler_tests.rs
@@ -1,0 +1,195 @@
+//! Integration tests for claude-pool-server MCP tool handlers.
+//!
+//! Each test builds a `State<InMemoryStore>` backed by the fake-claude binary,
+//! registers all tools on an `McpRouter`, and drives them through `TestClient`
+//! — the same JSON-RPC path a real MCP client would use.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use claude_pool::{
+    InMemoryStore, Pool, PoolConfig, ScalingConfig, SkillRegistry, WorkflowRegistry,
+};
+use claude_pool_server::{State, tools};
+use serde_json::json;
+use tokio::sync::RwLock;
+use tower_mcp::McpRouter;
+
+const FAKE_CLAUDE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../test-helpers/fake-claude.sh"
+);
+
+/// Build a test `State` with the given slot count, backed by the fake claude binary.
+async fn test_state(slots: usize) -> Arc<State<InMemoryStore>> {
+    let claude = claude_wrapper::Claude::builder()
+        .binary(PathBuf::from(FAKE_CLAUDE))
+        .build()
+        .expect("failed to build Claude client");
+
+    let config = PoolConfig {
+        scaling: ScalingConfig {
+            min_slots: 1,
+            max_slots: 16,
+        },
+        ..Default::default()
+    };
+
+    let pool = Pool::builder_with_store(claude, InMemoryStore::new())
+        .slots(slots)
+        .config(config)
+        .build()
+        .await
+        .expect("failed to build pool");
+
+    Arc::new(State {
+        pool,
+        skills: Arc::new(RwLock::new(SkillRegistry::with_builtins())),
+        workflows: WorkflowRegistry::with_builtins(),
+        skills_dir: PathBuf::from(".claude-pool/skills"),
+    })
+}
+
+/// Build a `TestClient` with all pool tools registered.
+async fn test_client(slots: usize) -> tower_mcp::TestClient {
+    let state = test_state(slots).await;
+    let tool_list = tools::all_tools(&state);
+    let router = McpRouter::new()
+        .server_info("test-pool", "0.0.0")
+        .tools(tool_list);
+    let mut client = tower_mcp::TestClient::from_router(router);
+    client.initialize().await;
+    client
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// pool_status returns a JSON object with slot count information.
+#[tokio::test]
+async fn tool_pool_status_returns_slot_info() {
+    let mut client = test_client(2).await;
+
+    let status = client.call_tool_json("pool_status", json!({})).await;
+
+    assert_eq!(
+        status["total_slots"].as_u64(),
+        Some(2),
+        "total_slots should be 2"
+    );
+    assert!(
+        status["idle_slots"].is_number(),
+        "idle_slots should be present"
+    );
+    assert!(
+        status["total_spend_microdollars"].is_number(),
+        "total_spend_microdollars should be present"
+    );
+}
+
+/// context_set followed by context_get returns the same value.
+#[tokio::test]
+async fn tool_context_set_and_get_round_trip() {
+    let mut client = test_client(1).await;
+
+    // Set a value.
+    let set_result = client
+        .call_tool(
+            "context_set",
+            json!({"key": "project", "value": "claude-wrapper"}),
+        )
+        .await;
+    assert!(!set_result.is_error, "context_set should not error");
+    assert_eq!(set_result.first_text(), Some("ok"));
+
+    // Get it back.
+    let get_result = client
+        .call_tool("context_get", json!({"key": "project"}))
+        .await;
+    assert!(!get_result.is_error, "context_get should not error");
+    assert_eq!(get_result.first_text(), Some("claude-wrapper"));
+}
+
+/// context_list shows all keys that were set.
+#[tokio::test]
+async fn tool_context_list_shows_all_keys() {
+    let mut client = test_client(1).await;
+
+    // Set two entries.
+    client
+        .call_tool("context_set", json!({"key": "alpha", "value": "1"}))
+        .await;
+    client
+        .call_tool("context_set", json!({"key": "beta", "value": "2"}))
+        .await;
+
+    let list = client.call_tool_json("context_list", json!({})).await;
+
+    assert_eq!(
+        list["alpha"].as_str(),
+        Some("1"),
+        "alpha key should be present"
+    );
+    assert_eq!(
+        list["beta"].as_str(),
+        Some("2"),
+        "beta key should be present"
+    );
+}
+
+/// pool_scale_up increases the slot count.
+#[tokio::test]
+async fn tool_pool_scale_up_increases_slot_count() {
+    let mut client = test_client(2).await;
+
+    let result = client
+        .call_tool_json("pool_scale_up", json!({"count": 1}))
+        .await;
+
+    assert_eq!(
+        result["success"].as_bool(),
+        Some(true),
+        "scale_up should succeed"
+    );
+    assert_eq!(
+        result["new_slot_count"].as_u64(),
+        Some(3),
+        "new_slot_count should be 3"
+    );
+}
+
+/// pool_scale_down reduces the slot count.
+#[tokio::test]
+async fn tool_pool_scale_down_reduces_slot_count() {
+    let mut client = test_client(3).await;
+
+    let result = client
+        .call_tool_json("pool_scale_down", json!({"count": 1}))
+        .await;
+
+    assert_eq!(
+        result["success"].as_bool(),
+        Some(true),
+        "scale_down should succeed"
+    );
+    assert_eq!(
+        result["new_slot_count"].as_u64(),
+        Some(2),
+        "new_slot_count should be 2"
+    );
+}
+
+/// context_get returns an error result (not a panic) when key is missing.
+#[tokio::test]
+async fn tool_context_get_missing_key_returns_error_result() {
+    let mut client = test_client(1).await;
+
+    let result = client
+        .call_tool("context_get", json!({"key": "no_such_key"}))
+        .await;
+
+    assert!(result.is_error, "missing key should return an error result");
+    assert!(
+        result.all_text().contains("no_such_key"),
+        "error message should include the key name"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `[lib]` target to `claude-pool-server` so integration tests can import `State` and the tool builders directly, then implements 6 tests that drive handlers through the full JSON-RPC path via `tower_mcp::TestClient` — the same path a real MCP client uses.

### Structural changes

- **`Cargo.toml`**: Added `[lib]` target (`src/lib.rs`) and `tower-mcp` with `testing` feature in `[dev-dependencies]`
- **`src/lib.rs`**: New file exporting `State<S>` and re-exporting `tools`, `resources`, `prompts`, `auth` modules
- **`src/main.rs`**: Removed duplicate `State` definition, now imports from the library crate

### Tests added (`tests/tool_handler_tests.rs`)

| Test | What it verifies |
|---|---|
| `tool_pool_status_returns_slot_info` | `pool_status` returns JSON with `total_slots`, `idle_slots`, `total_spend_microdollars` |
| `tool_context_set_and_get_round_trip` | `context_set` + `context_get` preserves the value |
| `tool_context_list_shows_all_keys` | `context_list` returns all set keys |
| `tool_pool_scale_up_increases_slot_count` | `pool_scale_up` increments and reports new count |
| `tool_pool_scale_down_reduces_slot_count` | `pool_scale_down` decrements and reports new count |
| `tool_context_get_missing_key_returns_error_result` | Missing key returns `is_error: true` with key name in message |

All tests use the fake-claude binary — no real `claude` or auth required.

Closes #116

## Test results

```
test result: ok. 6 passed; 0 failed; 0 ignored  (tool_handler_tests)
test result: ok. 64 passed; 0 failed; 0 ignored (lib)
cargo fmt --all -- --check: clean
cargo clippy --all-targets --all-features -- -D warnings: clean
```