### PR TITLE
feat: add verbose/debug/quiet/color global flag helpers to ClaudeBuilder

### DIFF
--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -1968,6 +1968,7 @@ mod tests {
             exit_code: 1,
             stdout: String::new(),
             stderr: "Allow Bash tool? (y/n)".into(),
+            working_dir: None,
         };
         let result = detect_permission_prompt(&err, "slot-1");
         assert!(result.is_some());
@@ -1990,6 +1991,7 @@ mod tests {
             exit_code: 1,
             stdout: String::new(),
             stderr: "Claude wants to use Edit tool.".into(),
+            working_dir: None,
         };
         let result = detect_permission_prompt(&err, "slot-2");
         assert!(result.is_some());
@@ -2008,6 +2010,7 @@ mod tests {
             exit_code: 1,
             stdout: String::new(),
             stderr: "some unrelated error output".into(),
+            working_dir: None,
         };
         assert!(detect_permission_prompt(&err, "slot-1").is_none());
     }
@@ -2019,6 +2022,7 @@ mod tests {
             exit_code: 1,
             stdout: String::new(),
             stderr: String::new(),
+            working_dir: None,
         };
         assert!(detect_permission_prompt(&err, "slot-1").is_none());
     }

--- a/crates/claude-wrapper/examples/supervised_worker.rs
+++ b/crates/claude-wrapper/examples/supervised_worker.rs
@@ -123,6 +123,7 @@ async fn run_supervised(
                 exit_code: 1,
                 stdout: String::new(),
                 stderr: format!("max restarts ({}) exceeded", config.max_restarts),
+                working_dir: None,
             });
         }
 
@@ -140,6 +141,7 @@ async fn run_supervised(
                     "budget exhausted: ${:.4} >= ${:.4}",
                     state.total_cost, config.total_budget_usd
                 ),
+                working_dir: None,
             });
         }
 

--- a/crates/claude-wrapper/src/command/agents.rs
+++ b/crates/claude-wrapper/src/command/agents.rs
@@ -23,6 +23,7 @@ use crate::exec::{self, CommandOutput};
 #[derive(Debug, Clone, Default)]
 pub struct AgentsCommand {
     setting_sources: Option<String>,
+    json: bool,
 }
 
 impl AgentsCommand {
@@ -37,6 +38,13 @@ impl AgentsCommand {
         self.setting_sources = Some(sources.into());
         self
     }
+
+    /// Output as JSON.
+    #[must_use]
+    pub fn json(mut self) -> Self {
+        self.json = true;
+        self
+    }
 }
 
 impl ClaudeCommand for AgentsCommand {
@@ -44,6 +52,9 @@ impl ClaudeCommand for AgentsCommand {
 
     fn args(&self) -> Vec<String> {
         let mut args = vec!["agents".to_string()];
+        if self.json {
+            args.push("--json".to_string());
+        }
         if let Some(ref sources) = self.setting_sources {
             args.push("--setting-sources".to_string());
             args.push(sources.clone());
@@ -74,5 +85,11 @@ mod tests {
             ClaudeCommand::args(&cmd),
             vec!["agents", "--setting-sources", "user,project"]
         );
+    }
+
+    #[test]
+    fn test_agents_json_flag() {
+        let cmd = AgentsCommand::new().json();
+        assert_eq!(ClaudeCommand::args(&cmd), vec!["agents", "--json"]);
     }
 }

--- a/crates/claude-wrapper/src/command/doctor.rs
+++ b/crates/claude-wrapper/src/command/doctor.rs
@@ -18,12 +18,21 @@ use crate::exec::{self, CommandOutput};
 /// # }
 /// ```
 #[derive(Debug, Clone, Default)]
-pub struct DoctorCommand;
+pub struct DoctorCommand {
+    json: bool,
+}
 
 impl DoctorCommand {
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    /// Output as JSON.
+    #[must_use]
+    pub fn json(mut self) -> Self {
+        self.json = true;
+        self
     }
 }
 
@@ -31,7 +40,11 @@ impl ClaudeCommand for DoctorCommand {
     type Output = CommandOutput;
 
     fn args(&self) -> Vec<String> {
-        vec!["doctor".to_string()]
+        let mut args = vec!["doctor".to_string()];
+        if self.json {
+            args.push("--json".to_string());
+        }
+        args
     }
 
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
@@ -47,5 +60,11 @@ mod tests {
     fn test_doctor_args() {
         let cmd = DoctorCommand::new();
         assert_eq!(cmd.args(), vec!["doctor"]);
+    }
+
+    #[test]
+    fn test_doctor_json_flag() {
+        let cmd = DoctorCommand::new().json();
+        assert_eq!(cmd.args(), vec!["doctor", "--json"]);
     }
 }

--- a/crates/claude-wrapper/src/error.rs
+++ b/crates/claude-wrapper/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 /// Errors returned by claude-wrapper operations.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -6,20 +8,22 @@ pub enum Error {
     NotFound,
 
     /// A claude command failed with a non-zero exit code.
-    #[error("claude command failed: {command} (exit code {exit_code})")]
+    #[error("claude command failed: {command} (exit code {exit_code}){}", working_dir.as_ref().map(|d| format!(" (in {})", d.display())).unwrap_or_default())]
     CommandFailed {
         command: String,
         exit_code: i32,
         stdout: String,
         stderr: String,
+        working_dir: Option<PathBuf>,
     },
 
     /// An I/O error occurred while spawning or communicating with the process.
-    #[error("io error: {message}")]
+    #[error("io error: {message}{}", working_dir.as_ref().map(|d| format!(" (in {})", d.display())).unwrap_or_default())]
     Io {
         message: String,
         #[source]
         source: std::io::Error,
+        working_dir: Option<PathBuf>,
     },
 
     /// The command timed out.
@@ -48,6 +52,7 @@ impl From<std::io::Error> for Error {
         Self::Io {
             message: e.to_string(),
             source: e,
+            working_dir: None,
         }
     }
 }

--- a/crates/claude-wrapper/src/exec.rs
+++ b/crates/claude-wrapper/src/exec.rs
@@ -82,17 +82,17 @@ pub async fn run_claude_allow_exit_codes(
     let output = run_claude(claude, args).await;
 
     match output {
-        Err(Error::CommandFailed { exit_code, .. }) if allowed_codes.contains(&exit_code) => {
-            // Re-run to get the output without the error — this is a bit wasteful
-            // but keeps the API clean. In practice, we capture before erroring.
-            // TODO: refactor to capture output before checking exit code
-            Ok(CommandOutput {
-                stdout: String::new(),
-                stderr: String::new(),
-                exit_code,
-                success: false,
-            })
-        }
+        Err(Error::CommandFailed {
+            exit_code,
+            stdout,
+            stderr,
+            ..
+        }) if allowed_codes.contains(&exit_code) => Ok(CommandOutput {
+            stdout,
+            stderr,
+            exit_code,
+            success: false,
+        }),
         other => other,
     }
 }
@@ -121,7 +121,11 @@ async fn run_internal(
         cmd.env(key, value);
     }
 
-    let output = cmd.output().await?;
+    let output = cmd.output().await.map_err(|e| Error::Io {
+        message: format!("failed to spawn claude: {e}"),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -133,6 +137,7 @@ async fn run_internal(
             exit_code,
             stdout,
             stderr,
+            working_dir: working_dir.map(|p| p.to_path_buf()),
         });
     }
 

--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -264,6 +264,7 @@ impl Claude {
         CliVersion::parse_version_output(&output.stdout).map_err(|e| Error::Io {
             message: format!("failed to parse CLI version: {e}"),
             source: std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()),
+            working_dir: None,
         })
     }
 
@@ -383,6 +384,40 @@ impl ClaudeBuilder {
         self
     }
 
+    /// Enable verbose output for all commands (`--verbose`).
+    #[must_use]
+    pub fn verbose(mut self) -> Self {
+        self.global_args.push("--verbose".into());
+        self
+    }
+
+    /// Enable debug output for all commands (`--debug`).
+    #[must_use]
+    pub fn debug(mut self) -> Self {
+        self.global_args.push("--debug".into());
+        self
+    }
+
+    /// Suppress non-essential output for all commands (`--quiet`).
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.global_args.push("--quiet".into());
+        self
+    }
+
+    /// Control color output for all commands.
+    ///
+    /// Passes `--color` when `enabled` is `true`, `--no-color` when `false`.
+    #[must_use]
+    pub fn color(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.global_args.push("--color".into());
+        } else {
+            self.global_args.push("--no-color".into());
+        }
+        self
+    }
+
     /// Set a default retry policy for all commands.
     ///
     /// Individual commands can override this via their own retry settings.
@@ -455,5 +490,57 @@ mod tests {
             .unwrap();
 
         assert_eq!(claude.global_args, vec!["--verbose"]);
+    }
+
+    #[test]
+    fn test_builder_verbose() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .verbose()
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--verbose".to_string()));
+    }
+
+    #[test]
+    fn test_builder_debug() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .debug()
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--debug".to_string()));
+    }
+
+    #[test]
+    fn test_builder_quiet() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .quiet()
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--quiet".to_string()));
+    }
+
+    #[test]
+    fn test_builder_color_enabled() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .color(true)
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--color".to_string()));
+        assert!(!claude.global_args.contains(&"--no-color".to_string()));
+    }
+
+    #[test]
+    fn test_builder_color_disabled() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .color(false)
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--no-color".to_string()));
+        assert!(!claude.global_args.contains(&"--color".to_string()));
     }
 }

--- a/crates/claude-wrapper/src/mcp_config.rs
+++ b/crates/claude-wrapper/src/mcp_config.rs
@@ -181,12 +181,14 @@ impl McpConfigBuilder {
             std::fs::create_dir_all(parent).map_err(|e| crate::error::Error::Io {
                 message: format!("failed to create directory: {}", parent.display()),
                 source: e,
+                working_dir: None,
             })?;
         }
 
         std::fs::write(&path, json).map_err(|e| crate::error::Error::Io {
             message: format!("failed to write MCP config to {}", path.display()),
             source: e,
+            working_dir: None,
         })?;
 
         Ok(path)
@@ -229,12 +231,14 @@ impl McpConfigBuilder {
             .map_err(|e| crate::error::Error::Io {
                 message: "failed to create temp MCP config file".to_string(),
                 source: e,
+                working_dir: None,
             })?;
 
         file.write_all(json.as_bytes())
             .map_err(|e| crate::error::Error::Io {
                 message: "failed to write temp MCP config".to_string(),
                 source: e,
+                working_dir: None,
             })?;
 
         Ok(TempMcpConfig { file })

--- a/crates/claude-wrapper/src/retry.rs
+++ b/crates/claude-wrapper/src/retry.rs
@@ -243,6 +243,7 @@ mod tests {
             exit_code: 1,
             stdout: String::new(),
             stderr: String::new(),
+            working_dir: None,
         };
         assert!(policy.should_retry(&retryable));
 
@@ -251,6 +252,7 @@ mod tests {
             exit_code: 99,
             stdout: String::new(),
             stderr: String::new(),
+            working_dir: None,
         };
         assert!(!policy.should_retry(&not_retryable));
     }

--- a/crates/claude-wrapper/src/streaming.rs
+++ b/crates/claude-wrapper/src/streaming.rs
@@ -111,6 +111,7 @@ where
     let mut child = cmd.spawn().map_err(|e| Error::Io {
         message: format!("failed to spawn claude: {e}"),
         source: e,
+        working_dir: claude.working_dir.clone(),
     })?;
 
     let stdout = child.stdout.take().expect("stdout was piped");
@@ -119,6 +120,7 @@ where
     while let Some(line) = reader.next_line().await.map_err(|e| Error::Io {
         message: "failed to read stdout line".to_string(),
         source: e,
+        working_dir: claude.working_dir.clone(),
     })? {
         if line.trim().is_empty() {
             continue;
@@ -134,6 +136,7 @@ where
     let output = child.wait_with_output().await.map_err(|e| Error::Io {
         message: "failed to wait for claude process".to_string(),
         source: e,
+        working_dir: claude.working_dir.clone(),
     })?;
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -145,6 +148,7 @@ where
             exit_code,
             stdout: String::new(),
             stderr,
+            working_dir: claude.working_dir.clone(),
         });
     }
 

--- a/crates/claude-wrapper/tests/fake_claude.rs
+++ b/crates/claude-wrapper/tests/fake_claude.rs
@@ -150,3 +150,89 @@ async fn binary_not_found_returns_error() {
 
     assert!(result.is_err(), "should fail when binary does not exist");
 }
+
+/// Verify that CommandFailed includes the working directory in its error message.
+#[tokio::test]
+async fn command_failed_includes_working_dir() {
+    use claude_wrapper::Error;
+
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_EXIT_CODE", "1")
+        .env("FAKE_CLAUDE_ERROR_MSG", "oops")
+        .working_dir(dir.path())
+        .build()
+        .expect("failed to build client");
+
+    let result = claude_wrapper::VersionCommand::new().execute(&claude).await;
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::CommandFailed { working_dir, .. } => {
+            assert_eq!(working_dir.as_deref(), Some(dir.path()));
+        }
+        other => panic!("expected CommandFailed, got {other:?}"),
+    }
+}
+
+/// Verify that CommandFailed error message includes the working directory path.
+#[tokio::test]
+async fn command_failed_error_message_includes_working_dir() {
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_EXIT_CODE", "1")
+        .working_dir(dir.path())
+        .build()
+        .expect("failed to build client");
+
+    let result = claude_wrapper::VersionCommand::new().execute(&claude).await;
+
+    let err_str = result.unwrap_err().to_string();
+    assert!(
+        err_str.contains(dir.path().to_str().unwrap()),
+        "error message should include working dir, got: {err_str}"
+    );
+}
+
+/// Verify that spawn failure (nonexistent binary) includes the working directory.
+#[tokio::test]
+async fn io_error_includes_working_dir() {
+    use claude_wrapper::Error;
+
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let claude = Claude::builder()
+        .binary("/nonexistent/binary/fake-claude")
+        .working_dir(dir.path())
+        .build()
+        .expect("builder should not validate binary existence");
+
+    let result = claude_wrapper::VersionCommand::new().execute(&claude).await;
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::Io { working_dir, .. } => {
+            assert_eq!(working_dir.as_deref(), Some(dir.path()));
+        }
+        other => panic!("expected Io, got {other:?}"),
+    }
+}
+
+/// Verify that without a working directory set, working_dir is None in errors.
+#[tokio::test]
+async fn command_failed_without_working_dir_is_none() {
+    use claude_wrapper::Error;
+
+    let claude = claude_with_env(&[("FAKE_CLAUDE_EXIT_CODE", "1")]);
+
+    let result = claude_wrapper::VersionCommand::new().execute(&claude).await;
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::CommandFailed { working_dir, .. } => {
+            assert!(working_dir.is_none());
+        }
+        other => panic!("expected CommandFailed, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `.verbose()`, `.debug()`, `.quiet()` convenience methods to `ClaudeBuilder` that push the corresponding `--verbose`, `--debug`, `--quiet` flags to `global_args`
- Adds `.color(bool)` to control color output, passing `--color` or `--no-color`
- Also adds `working_dir: Option<PathBuf>` to `Error::CommandFailed` and `Error::Io` so error messages include the working directory when set; all construction sites updated
- Adds `.json()` to `AgentsCommand` and `DoctorCommand` matching the pattern in `PluginListCommand`
- Adds 5 builder tests and integration tests verifying `working_dir` appears in error output

Closes #123
Closes #121