### PR TITLE
fix: capture output in single run instead of re-executing on non-zero exit

### DIFF
--- a/crates/claude-wrapper/src/exec.rs
+++ b/crates/claude-wrapper/src/exec.rs
@@ -82,17 +82,17 @@ pub async fn run_claude_allow_exit_codes(
     let output = run_claude(claude, args).await;
 
     match output {
-        Err(Error::CommandFailed { exit_code, .. }) if allowed_codes.contains(&exit_code) => {
-            // Re-run to get the output without the error — this is a bit wasteful
-            // but keeps the API clean. In practice, we capture before erroring.
-            // TODO: refactor to capture output before checking exit code
-            Ok(CommandOutput {
-                stdout: String::new(),
-                stderr: String::new(),
-                exit_code,
-                success: false,
-            })
-        }
+        Err(Error::CommandFailed {
+            exit_code,
+            stdout,
+            stderr,
+            ..
+        }) if allowed_codes.contains(&exit_code) => Ok(CommandOutput {
+            stdout,
+            stderr,
+            exit_code,
+            success: false,
+        }),
         other => other,
     }
 }


### PR DESCRIPTION
## Summary

Fixes #124.

`run_claude_allow_exit_codes()` was discarding the `stdout`/`stderr` that `run_internal` had already captured, then returning empty strings. The output lives inside the `CommandFailed` error variant — extract it directly instead of losing it.

**Before:**
```rust
Err(Error::CommandFailed { exit_code, .. }) => Ok(CommandOutput {
    stdout: String::new(),  // lost
    stderr: String::new(),  // lost
    exit_code,
    success: false,
})
```

**After:**
```rust
Err(Error::CommandFailed { exit_code, stdout, stderr, .. }) => Ok(CommandOutput {
    stdout,
    stderr,
    exit_code,
    success: false,
})
```

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --lib --all-features` passes (64 tests)
- [ ] `cargo test --test fake_claude --all-features` passes (7 tests)