### PR TITLE
feat: add global flag helpers to ClaudeBuilder

### DIFF
--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -383,6 +383,40 @@ impl ClaudeBuilder {
         self
     }
 
+    /// Enable verbose output for all commands (`--verbose`).
+    #[must_use]
+    pub fn verbose(mut self) -> Self {
+        self.global_args.push("--verbose".into());
+        self
+    }
+
+    /// Enable debug output for all commands (`--debug`).
+    #[must_use]
+    pub fn debug(mut self) -> Self {
+        self.global_args.push("--debug".into());
+        self
+    }
+
+    /// Suppress non-essential output for all commands (`--quiet`).
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.global_args.push("--quiet".into());
+        self
+    }
+
+    /// Control color output for all commands.
+    ///
+    /// Passes `--color` when `enabled` is `true`, `--no-color` when `false`.
+    #[must_use]
+    pub fn color(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.global_args.push("--color".into());
+        } else {
+            self.global_args.push("--no-color".into());
+        }
+        self
+    }
+
     /// Set a default retry policy for all commands.
     ///
     /// Individual commands can override this via their own retry settings.
@@ -455,5 +489,57 @@ mod tests {
             .unwrap();
 
         assert_eq!(claude.global_args, vec!["--verbose"]);
+    }
+
+    #[test]
+    fn test_builder_verbose() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .verbose()
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--verbose".to_string()));
+    }
+
+    #[test]
+    fn test_builder_debug() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .debug()
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--debug".to_string()));
+    }
+
+    #[test]
+    fn test_builder_quiet() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .quiet()
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--quiet".to_string()));
+    }
+
+    #[test]
+    fn test_builder_color_enabled() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .color(true)
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--color".to_string()));
+        assert!(!claude.global_args.contains(&"--no-color".to_string()));
+    }
+
+    #[test]
+    fn test_builder_color_disabled() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .color(false)
+            .build()
+            .unwrap();
+        assert!(claude.global_args.contains(&"--no-color".to_string()));
+        assert!(!claude.global_args.contains(&"--color".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

Adds four convenience methods to `ClaudeBuilder` that push commonly-needed global flags into `global_args`, matching the existing `.arg()` escape-hatch pattern:

| Method | Flag emitted |
|---|---|
| `.verbose()` | `--verbose` |
| `.debug()` | `--debug` |
| `.quiet()` | `--quiet` |
| `.color(true)` | `--color` |
| `.color(false)` | `--no-color` |

Unit tests verify each flag appears in `global_args` and that `color`/`no-color` are mutually exclusive.

Closes #123

## Test results

```
test result: ok. 69 passed; 0 failed; 0 ignored  (+5 new tests)
cargo fmt --all -- --check: clean
cargo clippy --all-targets --all-features -- -D warnings: clean
```