### PR TITLE
fix: detect repo root for worktree isolation

### DIFF
--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -105,6 +105,13 @@ struct Cli {
     /// header with a valid token. When omitted, authentication is disabled.
     #[arg(long, value_delimiter = ',')]
     http_token: Vec<String>,
+
+    /// Working directory for pool operations.
+    ///
+    /// Defaults to the git repository root detected via `git rev-parse --show-toplevel`.
+    /// Required for worktree isolation to function correctly.
+    #[arg(long)]
+    working_dir: Option<PathBuf>,
 }
 
 fn parse_permission_mode(s: &str) -> claude_pool::PermissionMode {
@@ -171,7 +178,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
 
-    let claude = claude_wrapper::Claude::builder().build()?;
+    // Resolve working directory: explicit flag > git repo root > current dir.
+    let working_dir = if let Some(dir) = cli.working_dir {
+        dir
+    } else {
+        match std::process::Command::new("git")
+            .args(["rev-parse", "--show-toplevel"])
+            .output()
+        {
+            Ok(output) if output.status.success() => {
+                PathBuf::from(String::from_utf8_lossy(&output.stdout).trim())
+            }
+            _ => {
+                tracing::warn!(
+                    "not inside a git repository; worktree isolation will not work. \
+                     Use --working-dir to set a repo path explicitly."
+                );
+                std::env::current_dir().unwrap_or_default()
+            }
+        }
+    };
+    tracing::info!(working_dir = %working_dir.display(), "resolved working directory");
+
+    let claude = claude_wrapper::Claude::builder()
+        .working_dir(&working_dir)
+        .build()?;
 
     let pool = Pool::builder_with_store(claude, InMemoryStore::new())
         .slots(cli.slots)

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -105,14 +105,34 @@ impl<S: PoolStore + 'static> PoolBuilder<S> {
 
     /// Build and initialize the pool, registering slots in the store.
     pub async fn build(self) -> Result<Pool<S>> {
-        // Always create the worktree manager so it's available for
-        // per-chain worktrees even when global worktree_isolation is off.
+        // Resolve repo directory from Claude's working_dir or current directory.
         let repo_dir = self
             .claude
             .working_dir()
             .map(|p| p.to_path_buf())
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-        let worktree_manager = Some(crate::worktree::WorktreeManager::new(repo_dir, None));
+
+        // Validate repo_dir is a git repo. Hard error when global worktree
+        // isolation is on; soft warning otherwise (per-chain isolation may
+        // still request worktrees).
+        let worktree_manager = match crate::worktree::WorktreeManager::new_validated(
+            &repo_dir, None,
+        )
+        .await
+        {
+            Ok(mgr) => Some(mgr),
+            Err(e) => {
+                if self.config.worktree_isolation {
+                    return Err(e);
+                }
+                tracing::warn!(
+                    repo_dir = %repo_dir.display(),
+                    error = %e,
+                    "worktree manager unavailable; per-chain worktree isolation will fall back to shared CWD"
+                );
+                None
+            }
+        };
 
         let inner = Arc::new(PoolInner {
             claude: self.claude,

--- a/crates/claude-pool/src/worktree.rs
+++ b/crates/claude-pool/src/worktree.rs
@@ -31,6 +31,36 @@ impl WorktreeManager {
         Self { base_dir, repo_dir }
     }
 
+    /// Create a worktree manager after verifying the repo directory is a git repository.
+    ///
+    /// Returns an error if `repo_dir` is not inside a git working tree.
+    pub async fn new_validated(
+        repo_dir: impl Into<PathBuf>,
+        base_dir: Option<PathBuf>,
+    ) -> Result<Self> {
+        let repo_dir = repo_dir.into();
+        let output = tokio::process::Command::new("git")
+            .args(["rev-parse", "--is-inside-work-tree"])
+            .current_dir(&repo_dir)
+            .output()
+            .await
+            .map_err(|e| {
+                Error::Store(format!(
+                    "failed to check git repo at {}: {e}",
+                    repo_dir.display()
+                ))
+            })?;
+
+        if !output.status.success() {
+            return Err(Error::Store(format!(
+                "worktree isolation requires a git repository, but {} is not inside a git work tree",
+                repo_dir.display()
+            )));
+        }
+
+        Ok(Self::new(repo_dir, base_dir))
+    }
+
     /// Create a worktree for a slot.
     ///
     /// Creates a git worktree at `{base_dir}/{slot_id}` branched from
@@ -255,6 +285,30 @@ impl WorktreeManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn new_validated_rejects_non_repo() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let result = WorktreeManager::new_validated(tmpdir.path(), None).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not inside a git work tree"),
+            "expected git work tree error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn new_validated_accepts_git_repo() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(tmpdir.path())
+            .output()
+            .unwrap();
+        let mgr = WorktreeManager::new_validated(tmpdir.path(), None).await;
+        assert!(mgr.is_ok());
+    }
 
     #[test]
     fn worktree_path_construction() {


### PR DESCRIPTION
Closes #132

## Summary

- Server auto-detects git repo root via `git rev-parse --show-toplevel` at startup and passes it to `Claude::builder().working_dir()` so WorktreeManager gets a valid repo path
- Add `--working-dir` CLI flag to override the auto-detected path
- Add `WorktreeManager::new_validated()` that verifies the repo_dir is inside a git work tree before construction
- Pool builder uses `new_validated()`: hard error when global worktree isolation is enabled and repo is invalid, warning otherwise (per-chain isolation degrades gracefully)

## Test plan

- [x] `new_validated_rejects_non_repo` — verifies error on non-git directory
- [x] `new_validated_accepts_git_repo` — verifies success on initialized git repo
- [x] All existing worktree tests pass (93 pool tests, 71 wrapper tests, 4 server tests)
- [x] `cargo fmt`, `cargo clippy`, `cargo doc` clean