### PR TITLE
docs: update READMEs for release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ claude-pool-server -n 4 --budget-usd 10.0 --model sonnet
 
 ## Features
 
-- **claude-wrapper**: Type-safe CLI wrapper with full option coverage (28 options), MCP server management, plugin management, streaming NDJSON events
+- **claude-wrapper**: Type-safe CLI wrapper with full option coverage (28 options), MCP server management, plugin management, streaming NDJSON events, session management
 - **claude-pool**: Multi-slot coordination, synchronous/async task execution, parallel fan-out, sequential chains with failure policies, budget control, shared context injection, optional worktree isolation, reusable skills registry
 - **claude-pool-server**: Standalone MCP server binary, configurable via CLI flags, full pool tool exposure, MCP resources for state inspection
 
@@ -124,13 +124,7 @@ cargo install claude-pool-server
 
 ## Status
 
-**Production-ready.** All three crates are actively maintained with comprehensive test coverage (85+ tests).
-
-### Latest Releases
-
-- **claude-wrapper** v0.2.0 - Full CLI surface, streaming, all subcommands
-- **claude-pool** v0.1.0 - Slot pool, chains, skills, worktree isolation
-- **claude-pool-server** v0.1.0 - MCP server with all tools and resources
+**Production-ready.** All three crates are actively maintained with comprehensive test coverage (168+ lib tests, plus integration and doc tests).
 
 ### Implemented
 

--- a/crates/claude-pool-server/README.md
+++ b/crates/claude-pool-server/README.md
@@ -38,9 +38,12 @@ Or run directly without installing:
 cargo run -p claude-pool-server -- -n 4 --budget-usd 10.0
 ```
 
-### Future options
+### Homebrew
 
-Homebrew and Docker distributions are planned but not yet available. For now, `cargo install` is the recommended approach. Docker will make more sense once HTTP transport lands ([#73](https://github.com/joshrotenberg/claude-wrapper/issues/73)).
+```bash
+brew tap joshrotenberg/brew
+brew install claude-pool-server
+```
 
 ## Quick Start
 

--- a/crates/claude-pool/README.md
+++ b/crates/claude-pool/README.md
@@ -215,22 +215,32 @@ All tasks run concurrently. Returns when all complete (or timeout).
 Execute steps in order, with control over failures:
 
 ```rust
-use claude_pool::{ChainStep, StepFailurePolicy};
+use claude_pool::{ChainStep, StepAction, StepFailurePolicy};
 
 let steps = vec![
-    ChainStep::new("analyze the error").with_policy(StepFailurePolicy::Abort),
-    ChainStep::new("write a fix").with_policy(StepFailurePolicy::Retry(2)),
-    ChainStep::new("write tests").with_policy(StepFailurePolicy::Skip),
+    ChainStep {
+        name: "analyze".into(),
+        action: StepAction::Prompt { prompt: "analyze the error".into() },
+        config: None,
+        failure_policy: StepFailurePolicy::default(),
+        output_vars: Default::default(),
+    },
+    ChainStep {
+        name: "fix".into(),
+        action: StepAction::Prompt { prompt: "write a fix based on {previous_output}".into() },
+        config: None,
+        failure_policy: StepFailurePolicy { retries: 2, recovery_prompt: None },
+        output_vars: Default::default(),
+    },
 ];
 
-let result = execute_chain(&pool, steps, ChainOptions::default()).await?;
-println!("Chain result: {}", result.final_output);
+let task_id = pool.submit_chain(steps, &skills, ChainOptions::default()).await?;
+let result = pool.result(&task_id).await?;
 ```
 
 Failure policies:
-- **Abort** - Stop chain on failure
-- **Retry(n)** - Retry up to N times
-- **Skip** - Skip this step, continue
+- **retries** - Number of retries before failing (default: 0)
+- **recovery_prompt** - Optional prompt to run on failure instead of aborting
 
 Access chain progress:
 ```rust
@@ -245,27 +255,31 @@ for step in progress.steps {
 Register reusable task patterns with argument validation:
 
 ```rust
-use claude_pool::{Skill, SkillArgument, SkillRegistry};
+use claude_pool::{Skill, SkillArgument, SkillRegistry, SkillSource};
 
 let mut registry = SkillRegistry::new();
-registry.register(Skill {
-    name: "code_review".to_string(),
-    description: "Review code for bugs and style".to_string(),
-    prompt: "Review the code at {path} for {criteria}".to_string(),
-    arguments: vec![
-        SkillArgument {
-            name: "path".to_string(),
-            description: "File to review".to_string(),
-            required: true,
-        },
-        SkillArgument {
-            name: "criteria".to_string(),
-            description: "What to focus on (bugs, style, performance)".to_string(),
-            required: false,
-        },
-    ],
-    config: None,
-});
+registry.register(
+    Skill {
+        name: "code_review".to_string(),
+        description: "Review code for bugs and style".to_string(),
+        prompt: "Review the code at {path} for {criteria}".to_string(),
+        arguments: vec![
+            SkillArgument {
+                name: "path".to_string(),
+                description: "File to review".to_string(),
+                required: true,
+            },
+            SkillArgument {
+                name: "criteria".to_string(),
+                description: "What to focus on (bugs, style, performance)".to_string(),
+                required: false,
+            },
+        ],
+        config: None,
+        scope: Default::default(),
+    },
+    SkillSource::Runtime,
+);
 ```
 
 Skills can be triggered via the MCP server or called programmatically.

--- a/crates/claude-wrapper/README.md
+++ b/crates/claude-wrapper/README.md
@@ -153,7 +153,7 @@ let output = QueryCommand::new("implement the feature in TASK.md")
     .await?;
 ```
 
-Session management:
+Session management (low-level):
 
 ```rust
 // Start new session
@@ -167,6 +167,26 @@ let output = QueryCommand::new("what did we find?")
     .resume("my-session")
     .execute(&claude)
     .await?;
+```
+
+Session management (type-safe):
+
+```rust
+use claude_wrapper::Session;
+
+// Create from a previous query result
+let mut session = Session::from_result(&claude, &result);
+
+// Auto-resumes the session
+let next = session.query("what did we find?").execute().await?;
+
+// Fork to branch the conversation
+let mut forked = session.fork();
+let alt = forked.query("try a different approach").execute().await?;
+
+// Track cumulative cost and turns
+println!("Total cost: ${}", session.cumulative_cost_usd());
+println!("Total turns: {}", session.cumulative_turns());
 ```
 
 ## Streaming NDJSON Events
@@ -309,8 +329,10 @@ use claude_wrapper::Error;
 
 match QueryCommand::new("test").execute(&claude).await {
     Ok(output) => println!("{}", output.stdout),
-    Err(Error::ProcessError(e)) => eprintln!("Process failed: {}", e),
-    Err(Error::InvalidUtf8) => eprintln!("Output not valid UTF-8"),
+    Err(Error::CommandFailed { stderr, exit_code, .. }) => {
+        eprintln!("Command failed (exit {}): {}", exit_code, stderr);
+    }
+    Err(Error::Timeout { .. }) => eprintln!("Command timed out"),
     Err(e) => eprintln!("Other error: {}", e),
 }
 ```


### PR DESCRIPTION
## Summary

- Remove stale hardcoded version numbers from root README
- Update test count from 85+ to 168+
- Fix claude-wrapper error handling example (`Error::ProcessError` -> `Error::CommandFailed`)
- Add `Session` management examples to claude-wrapper README
- Fix claude-pool chain example to use actual struct API (not nonexistent `ChainStep::new()` builder)
- Fix claude-pool skills example to include `SkillSource` param and `scope` field
- Update claude-pool-server installation to show Homebrew tap (replacing "planned but not yet available")

## Test plan

- [ ] README examples match actual public API signatures
- [ ] No broken links