### PR TITLE
fix: strip CLAUDECODE at startup and surface stderr in pool errors

### DIFF
--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -4,6 +4,7 @@
 //! over stdio or HTTP transport.
 
 use std::path::PathBuf;
+
 use std::sync::Arc;
 
 use clap::Parser;
@@ -137,6 +138,15 @@ fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Strip CLAUDECODE so child `claude` processes don't refuse to start.
+    // When launched as an MCP server from within Claude Code, the server
+    // inherits this variable, causing slots to fail with "Claude Code cannot
+    // be launched inside another Claude Code session."
+    // SAFETY: called before any threads are spawned.
+    unsafe {
+        std::env::remove_var("CLAUDECODE");
+    }
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()

--- a/crates/claude-wrapper/src/error.rs
+++ b/crates/claude-wrapper/src/error.rs
@@ -8,7 +8,7 @@ pub enum Error {
     NotFound,
 
     /// A claude command failed with a non-zero exit code.
-    #[error("claude command failed: {command} (exit code {exit_code}){}", working_dir.as_ref().map(|d| format!(" (in {})", d.display())).unwrap_or_default())]
+    #[error("claude command failed: {command} (exit code {exit_code}){}{}", working_dir.as_ref().map(|d| format!(" (in {})", d.display())).unwrap_or_default(), if stderr.is_empty() { String::new() } else { format!("\nstderr: {stderr}") })]
     CommandFailed {
         command: String,
         exit_code: i32,


### PR DESCRIPTION
Closes #136. Closes #137.

- Strip CLAUDECODE env var at pool server startup so slots launched from within Claude Code sessions work correctly
- Include stderr in `CommandFailed` error Display so users see the actual error (e.g. invalid model ID) instead of just "exit code 1"

Found by [@jonahchoppy](https://github.com/jonahchoppy) while setting up claude-pool-server on his project.