### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.3.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.3.0...v0.3.1) - 2026-03-11
+
+### Added
+
+- add structured failure details to TaskResult ([#155](https://github.com/joshrotenberg/claude-wrapper/pull/155)) ([#159](https://github.com/joshrotenberg/claude-wrapper/pull/159))
+
+### Fixed
+
+- add --verbose when using stream-json output format ([#142](https://github.com/joshrotenberg/claude-wrapper/pull/142))
+- strip CLAUDECODE at startup and surface stderr in pool errors ([#138](https://github.com/joshrotenberg/claude-wrapper/pull/138))
+
 ## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.2.1...v0.3.0) - 2026-03-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-pool"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "claude-pool-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "clap",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "claude-wrapper"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/joshrotenberg/claude-wrapper"
 
 [workspace.dependencies]
 claude-wrapper = { path = "crates/claude-wrapper", version = "0.3" }
-claude-pool = { path = "crates/claude-pool", version = "0.2" }
+claude-pool = { path = "crates/claude-pool", version = "0.3" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/claude-pool-server/CHANGELOG.md
+++ b/crates/claude-pool-server/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-server-v0.2.0...claude-pool-server-v0.3.0) - 2026-03-11
+
+### Added
+
+- add quality gate hooks for task lifecycle ([#183](https://github.com/joshrotenberg/claude-wrapper/pull/183))
+- add ${CLAUDE_SKILL_DIR} substitution and skill directory docs ([#181](https://github.com/joshrotenberg/claude-wrapper/pull/181))
+- align skills with Agent Skills standard ([#162](https://github.com/joshrotenberg/claude-wrapper/pull/162)) ([#179](https://github.com/joshrotenberg/claude-wrapper/pull/179))
+- add auto-delivery messaging and self-claiming task queue (#169, #170) ([#175](https://github.com/joshrotenberg/claude-wrapper/pull/175))
+- add broadcast messaging and slot discovery (#165, #166) ([#172](https://github.com/joshrotenberg/claude-wrapper/pull/172))
+- adopt SKILL.md format and add global skills directory ([#157](https://github.com/joshrotenberg/claude-wrapper/pull/157))
+- implement inter-slot messaging for claude-pool ([#153](https://github.com/joshrotenberg/claude-wrapper/pull/153))
+- add server metadata to pool_status and clone isolation mode ([#151](https://github.com/joshrotenberg/claude-wrapper/pull/151))
+
+### Fixed
+
+- strip CLAUDECODE at startup and surface stderr in pool errors ([#138](https://github.com/joshrotenberg/claude-wrapper/pull/138))
+
+### Other
+
+- establish consistent user-facing vocabulary for pool operations ([#158](https://github.com/joshrotenberg/claude-wrapper/pull/158))
+
 ## [0.2.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-server-v0.1.0...claude-pool-server-v0.2.0) - 2026-03-11
 
 ### Added

--- a/crates/claude-pool-server/Cargo.toml
+++ b/crates/claude-pool-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-pool-server"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/claude-pool/CHANGELOG.md
+++ b/crates/claude-pool/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.2.0...claude-pool-v0.3.0) - 2026-03-11
+
+### Added
+
+- add quality gate hooks for task lifecycle ([#183](https://github.com/joshrotenberg/claude-wrapper/pull/183))
+- add chain workflow and triage skills for claude-pool ([#182](https://github.com/joshrotenberg/claude-wrapper/pull/182))
+- add ${CLAUDE_SKILL_DIR} substitution and skill directory docs ([#181](https://github.com/joshrotenberg/claude-wrapper/pull/181))
+- align skills with Agent Skills standard ([#162](https://github.com/joshrotenberg/claude-wrapper/pull/162)) ([#179](https://github.com/joshrotenberg/claude-wrapper/pull/179))
+- add auto-delivery messaging and self-claiming task queue (#169, #170) ([#175](https://github.com/joshrotenberg/claude-wrapper/pull/175))
+- add pool_dashboard and chain_watcher loop monitoring skills ([#174](https://github.com/joshrotenberg/claude-wrapper/pull/174))
+- session fix, plan-then-execute skill, $ARGUMENTS substitution (#161, #167, #162) ([#173](https://github.com/joshrotenberg/claude-wrapper/pull/173))
+- add broadcast messaging and slot discovery (#165, #166) ([#172](https://github.com/joshrotenberg/claude-wrapper/pull/172))
+- add structured failure details to TaskResult ([#155](https://github.com/joshrotenberg/claude-wrapper/pull/155)) ([#159](https://github.com/joshrotenberg/claude-wrapper/pull/159))
+- adopt SKILL.md format and add global skills directory ([#157](https://github.com/joshrotenberg/claude-wrapper/pull/157))
+- implement inter-slot messaging for claude-pool ([#153](https://github.com/joshrotenberg/claude-wrapper/pull/153))
+- add server metadata to pool_status and clone isolation mode ([#151](https://github.com/joshrotenberg/claude-wrapper/pull/151))
+
+### Fixed
+
+- rewrite coordinator skill prompts for haiku compatibility ([#188](https://github.com/joshrotenberg/claude-wrapper/pull/188))
+- preserve GitHub remote URL in clone isolation ([#154](https://github.com/joshrotenberg/claude-wrapper/pull/154))
+
+### Other
+
+- fix quality gates and skills examples in claude-pool README ([#186](https://github.com/joshrotenberg/claude-wrapper/pull/186))
+- move builtin skills to SKILL.md files ([#178](https://github.com/joshrotenberg/claude-wrapper/pull/178)) ([#180](https://github.com/joshrotenberg/claude-wrapper/pull/180))
+
 ## [0.2.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.1.0...claude-pool-v0.2.0) - 2026-03-11
 
 ### Added

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-pool"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `claude-pool`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `claude-pool-server`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `claude-pool` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TaskResult.failed_command in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:325
  field TaskResult.exit_code in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:329
  field TaskResult.stderr in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:333
  field TaskResult.failed_command in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:325
  field TaskResult.exit_code in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:329
  field TaskResult.stderr in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:333
  field Skill.argument_hint in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:137
  field Skill.skill_dir in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:146
  field Skill.argument_hint in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:137
  field Skill.skill_dir in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:146
  field PoolStatus.pending_review_tasks in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/pool.rs:2069
  field PoolStatus.pending_review_tasks in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/pool.rs:2069
  field TaskRecord.review_required in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:286
  field TaskRecord.max_rejections in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:290
  field TaskRecord.rejection_count in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:294
  field TaskRecord.original_prompt in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:298
  field TaskRecord.review_required in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:286
  field TaskRecord.max_rejections in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:290
  field TaskRecord.rejection_count in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:294
  field TaskRecord.original_prompt in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:298

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant SkillSource::Project 1 -> 2 in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:55
  variant SkillSource::Runtime 2 -> 3 in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:57
  variant SkillSource::Project 1 -> 2 in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:55
  variant SkillSource::Runtime 2 -> 3 in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:57

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant TaskState:PendingReview in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:257
  variant TaskState:PendingReview in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/types.rs:257
  variant ChainIsolation:Clone in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/chain.rs:93
  variant ChainIsolation:Clone in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/chain.rs:93
  variant SkillSource:Global in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:53
  variant SkillSource:Global in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool/src/skill.rs:53
```

### ⚠ `claude-pool-server` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field State.server_info in /tmp/.tmpkeZBxq/claude-wrapper/crates/claude-pool-server/src/lib.rs:59
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-wrapper`

<blockquote>

## [0.3.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.3.0...v0.3.1) - 2026-03-11

### Added

- add structured failure details to TaskResult ([#155](https://github.com/joshrotenberg/claude-wrapper/pull/155)) ([#159](https://github.com/joshrotenberg/claude-wrapper/pull/159))

### Fixed

- add --verbose when using stream-json output format ([#142](https://github.com/joshrotenberg/claude-wrapper/pull/142))
- strip CLAUDECODE at startup and surface stderr in pool errors ([#138](https://github.com/joshrotenberg/claude-wrapper/pull/138))
</blockquote>

## `claude-pool`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.2.0...claude-pool-v0.3.0) - 2026-03-11

### Added

- add quality gate hooks for task lifecycle ([#183](https://github.com/joshrotenberg/claude-wrapper/pull/183))
- add chain workflow and triage skills for claude-pool ([#182](https://github.com/joshrotenberg/claude-wrapper/pull/182))
- add ${CLAUDE_SKILL_DIR} substitution and skill directory docs ([#181](https://github.com/joshrotenberg/claude-wrapper/pull/181))
- align skills with Agent Skills standard ([#162](https://github.com/joshrotenberg/claude-wrapper/pull/162)) ([#179](https://github.com/joshrotenberg/claude-wrapper/pull/179))
- add auto-delivery messaging and self-claiming task queue (#169, #170) ([#175](https://github.com/joshrotenberg/claude-wrapper/pull/175))
- add pool_dashboard and chain_watcher loop monitoring skills ([#174](https://github.com/joshrotenberg/claude-wrapper/pull/174))
- session fix, plan-then-execute skill, $ARGUMENTS substitution (#161, #167, #162) ([#173](https://github.com/joshrotenberg/claude-wrapper/pull/173))
- add broadcast messaging and slot discovery (#165, #166) ([#172](https://github.com/joshrotenberg/claude-wrapper/pull/172))
- add structured failure details to TaskResult ([#155](https://github.com/joshrotenberg/claude-wrapper/pull/155)) ([#159](https://github.com/joshrotenberg/claude-wrapper/pull/159))
- adopt SKILL.md format and add global skills directory ([#157](https://github.com/joshrotenberg/claude-wrapper/pull/157))
- implement inter-slot messaging for claude-pool ([#153](https://github.com/joshrotenberg/claude-wrapper/pull/153))
- add server metadata to pool_status and clone isolation mode ([#151](https://github.com/joshrotenberg/claude-wrapper/pull/151))

### Fixed

- rewrite coordinator skill prompts for haiku compatibility ([#188](https://github.com/joshrotenberg/claude-wrapper/pull/188))
- preserve GitHub remote URL in clone isolation ([#154](https://github.com/joshrotenberg/claude-wrapper/pull/154))

### Other

- fix quality gates and skills examples in claude-pool README ([#186](https://github.com/joshrotenberg/claude-wrapper/pull/186))
- move builtin skills to SKILL.md files ([#178](https://github.com/joshrotenberg/claude-wrapper/pull/178)) ([#180](https://github.com/joshrotenberg/claude-wrapper/pull/180))
</blockquote>

## `claude-pool-server`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-server-v0.2.0...claude-pool-server-v0.3.0) - 2026-03-11

### Added

- add quality gate hooks for task lifecycle ([#183](https://github.com/joshrotenberg/claude-wrapper/pull/183))
- add ${CLAUDE_SKILL_DIR} substitution and skill directory docs ([#181](https://github.com/joshrotenberg/claude-wrapper/pull/181))
- align skills with Agent Skills standard ([#162](https://github.com/joshrotenberg/claude-wrapper/pull/162)) ([#179](https://github.com/joshrotenberg/claude-wrapper/pull/179))
- add auto-delivery messaging and self-claiming task queue (#169, #170) ([#175](https://github.com/joshrotenberg/claude-wrapper/pull/175))
- add broadcast messaging and slot discovery (#165, #166) ([#172](https://github.com/joshrotenberg/claude-wrapper/pull/172))
- adopt SKILL.md format and add global skills directory ([#157](https://github.com/joshrotenberg/claude-wrapper/pull/157))
- implement inter-slot messaging for claude-pool ([#153](https://github.com/joshrotenberg/claude-wrapper/pull/153))
- add server metadata to pool_status and clone isolation mode ([#151](https://github.com/joshrotenberg/claude-wrapper/pull/151))

### Fixed

- strip CLAUDECODE at startup and surface stderr in pool errors ([#138](https://github.com/joshrotenberg/claude-wrapper/pull/138))

### Other

- establish consistent user-facing vocabulary for pool operations ([#158](https://github.com/joshrotenberg/claude-wrapper/pull/158))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).