### PR TITLE
feat: add clone isolation mode for chains

### DIFF
--- a/crates/claude-pool-server/build.rs
+++ b/crates/claude-pool-server/build.rs
@@ -1,0 +1,13 @@
+//! Build script to capture git commit hash.
+
+fn main() {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output();
+
+    let hash = output
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+}

--- a/crates/claude-pool-server/src/lib.rs
+++ b/crates/claude-pool-server/src/lib.rs
@@ -14,7 +14,36 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use claude_pool::{Pool, PoolStore, SkillRegistry, WorkflowRegistry};
+use serde::Serialize;
 use tokio::sync::RwLock;
+
+/// Server version and metadata information.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerInfo {
+    /// Server version from Cargo.toml.
+    pub version: String,
+    /// Git commit hash (short form).
+    pub commit: String,
+    /// Default model for slots.
+    pub model: Option<String>,
+    /// Permission mode for slots.
+    pub permission_mode: String,
+    /// Total number of slots.
+    pub slots: usize,
+}
+
+impl ServerInfo {
+    /// Create a new ServerInfo instance.
+    pub fn new(model: Option<String>, permission_mode: String, slots: usize) -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            commit: env!("GIT_HASH").to_string(),
+            model,
+            permission_mode,
+            slots,
+        }
+    }
+}
 
 /// Shared state accessible by all tool/resource handlers.
 pub struct State<S: PoolStore> {
@@ -26,4 +55,6 @@ pub struct State<S: PoolStore> {
     pub workflows: WorkflowRegistry,
     /// Directory for persisting project-local skills.
     pub skills_dir: PathBuf,
+    /// Server metadata.
+    pub server_info: ServerInfo,
 }

--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -173,7 +173,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let config = PoolConfig {
-        model: cli.model,
+        model: cli.model.clone(),
         effort: cli.effort.and_then(|e| parse_effort(&e)),
         budget_microdollars: cli.budget_usd.map(|b| (b * 1_000_000.0) as u64),
         system_prompt: cli.system_prompt,
@@ -245,11 +245,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let workflows = WorkflowRegistry::with_builtins();
 
+    let server_info = claude_pool_server::ServerInfo::new(
+        cli.model.clone(),
+        cli.permission_mode.clone(),
+        cli.slots,
+    );
+
     let state = Arc::new(State {
         pool,
         skills: Arc::new(RwLock::new(skills)),
         workflows,
         skills_dir: cli.skills_dir,
+        server_info,
     });
 
     let tool_list = tools::all_tools(&state);

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -223,16 +223,33 @@ fn parse_source(s: &str) -> Option<SkillSource> {
 
 // ── Tool builders ────────────────────────────────────────────────────
 
+/// Get pool status with server metadata.
+///
+/// Returns a combined response including pool status, server version, commit hash,
+/// model, permission mode, and slot information.
 pub fn pool_status_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
     ToolBuilder::new("pool_status")
         .title("Pool Status")
-        .description("Get pool status: slots, tasks in flight, budget")
+        .description("Get pool status: slots, tasks in flight, budget, server metadata")
         .read_only()
         .no_params_handler(move || {
             let state = Arc::clone(&state);
             async move {
                 match state.pool.status().await {
-                    Ok(status) => Ok(CallToolResult::json(serde_json::to_value(&status).unwrap())),
+                    Ok(status) => {
+                        // Merge pool status with server info into a single JSON response
+                        let mut response = serde_json::to_value(&status).unwrap();
+                        let response_obj = response.as_object_mut().unwrap();
+
+                        let server_obj = serde_json::to_value(&state.server_info).unwrap();
+                        if let Some(server_map) = server_obj.as_object() {
+                            for (key, value) in server_map.iter() {
+                                response_obj.insert(format!("server_{key}"), value.clone());
+                            }
+                        }
+
+                        Ok(CallToolResult::json(response))
+                    }
                     Err(e) => Ok(CallToolResult::error(e.to_string())),
                 }
             }

--- a/crates/claude-pool-server/tests/tool_handler_tests.rs
+++ b/crates/claude-pool-server/tests/tool_handler_tests.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use claude_pool::{
     InMemoryStore, Pool, PoolConfig, ScalingConfig, SkillRegistry, WorkflowRegistry,
 };
-use claude_pool_server::{State, tools};
+use claude_pool_server::{ServerInfo, State, tools};
 use serde_json::json;
 use tokio::sync::RwLock;
 use tower_mcp::McpRouter;
@@ -47,6 +47,7 @@ async fn test_state(slots: usize) -> Arc<State<InMemoryStore>> {
         skills: Arc::new(RwLock::new(SkillRegistry::with_builtins())),
         workflows: WorkflowRegistry::with_builtins(),
         skills_dir: PathBuf::from(".claude-pool/skills"),
+        server_info: ServerInfo::new(None, "plan".to_string(), slots),
     })
 }
 
@@ -83,6 +84,25 @@ async fn tool_pool_status_returns_slot_info() {
     assert!(
         status["total_spend_microdollars"].is_number(),
         "total_spend_microdollars should be present"
+    );
+    // Check server metadata is included
+    assert!(
+        status["server_version"].is_string(),
+        "server_version should be present"
+    );
+    assert!(
+        status["server_commit"].is_string(),
+        "server_commit should be present"
+    );
+    assert_eq!(
+        status["server_slots"].as_u64(),
+        Some(2),
+        "server_slots should be 2"
+    );
+    assert_eq!(
+        status["server_permission_mode"].as_str(),
+        Some("plan"),
+        "server_permission_mode should be 'plan'"
     );
 }
 


### PR DESCRIPTION
## Summary

- Adds Clone as third ChainIsolation mode alongside None and Worktree
- Uses git clone --local --shared for fast, space-efficient full isolation
- No shared .git directory means zero lock contention under parallel load
- Cleanup removes the temp directory

Closes #113