### PR TITLE
feat: add server metadata and clone isolation mode

### DIFF
--- a/crates/claude-pool-server/build.rs
+++ b/crates/claude-pool-server/build.rs
@@ -1,0 +1,13 @@
+//! Build script to capture git commit hash.
+
+fn main() {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output();
+
+    let hash = output
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+}

--- a/crates/claude-pool-server/src/lib.rs
+++ b/crates/claude-pool-server/src/lib.rs
@@ -14,7 +14,36 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use claude_pool::{Pool, PoolStore, SkillRegistry, WorkflowRegistry};
+use serde::Serialize;
 use tokio::sync::RwLock;
+
+/// Server version and metadata information.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerInfo {
+    /// Server version from Cargo.toml.
+    pub version: String,
+    /// Git commit hash (short form).
+    pub commit: String,
+    /// Default model for slots.
+    pub model: Option<String>,
+    /// Permission mode for slots.
+    pub permission_mode: String,
+    /// Total number of slots.
+    pub slots: usize,
+}
+
+impl ServerInfo {
+    /// Create a new ServerInfo instance.
+    pub fn new(model: Option<String>, permission_mode: String, slots: usize) -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            commit: env!("GIT_HASH").to_string(),
+            model,
+            permission_mode,
+            slots,
+        }
+    }
+}
 
 /// Shared state accessible by all tool/resource handlers.
 pub struct State<S: PoolStore> {
@@ -26,4 +55,6 @@ pub struct State<S: PoolStore> {
     pub workflows: WorkflowRegistry,
     /// Directory for persisting project-local skills.
     pub skills_dir: PathBuf,
+    /// Server metadata.
+    pub server_info: ServerInfo,
 }

--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -173,7 +173,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let config = PoolConfig {
-        model: cli.model,
+        model: cli.model.clone(),
         effort: cli.effort.and_then(|e| parse_effort(&e)),
         budget_microdollars: cli.budget_usd.map(|b| (b * 1_000_000.0) as u64),
         system_prompt: cli.system_prompt,
@@ -245,11 +245,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let workflows = WorkflowRegistry::with_builtins();
 
+    let server_info = claude_pool_server::ServerInfo::new(
+        cli.model.clone(),
+        cli.permission_mode.clone(),
+        cli.slots,
+    );
+
     let state = Arc::new(State {
         pool,
         skills: Arc::new(RwLock::new(skills)),
         workflows,
         skills_dir: cli.skills_dir,
+        server_info,
     });
 
     let tool_list = tools::all_tools(&state);

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -208,6 +208,7 @@ fn parse_scope(s: &str) -> SkillScope {
 fn parse_isolation(s: Option<&str>) -> claude_pool::chain::ChainIsolation {
     match s {
         Some("none") => claude_pool::chain::ChainIsolation::None,
+        Some("clone") => claude_pool::chain::ChainIsolation::Clone,
         _ => claude_pool::chain::ChainIsolation::Worktree,
     }
 }
@@ -226,13 +227,23 @@ fn parse_source(s: &str) -> Option<SkillSource> {
 pub fn pool_status_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
     ToolBuilder::new("pool_status")
         .title("Pool Status")
-        .description("Get pool status: slots, tasks in flight, budget")
+        .description("Get pool status: slots, tasks in flight, budget, server metadata")
         .read_only()
         .no_params_handler(move || {
             let state = Arc::clone(&state);
             async move {
                 match state.pool.status().await {
-                    Ok(status) => Ok(CallToolResult::json(serde_json::to_value(&status).unwrap())),
+                    Ok(status) => {
+                        let mut response = serde_json::to_value(&status).unwrap();
+                        let response_obj = response.as_object_mut().unwrap();
+                        let server_obj = serde_json::to_value(&state.server_info).unwrap();
+                        if let Some(server_map) = server_obj.as_object() {
+                            for (key, value) in server_map.iter() {
+                                response_obj.insert(format!("server_{key}"), value.clone());
+                            }
+                        }
+                        Ok(CallToolResult::json(response))
+                    }
                     Err(e) => Ok(CallToolResult::error(e.to_string())),
                 }
             }

--- a/crates/claude-pool-server/tests/tool_handler_tests.rs
+++ b/crates/claude-pool-server/tests/tool_handler_tests.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use claude_pool::{
     InMemoryStore, Pool, PoolConfig, ScalingConfig, SkillRegistry, WorkflowRegistry,
 };
-use claude_pool_server::{State, tools};
+use claude_pool_server::{ServerInfo, State, tools};
 use serde_json::json;
 use tokio::sync::RwLock;
 use tower_mcp::McpRouter;
@@ -47,6 +47,7 @@ async fn test_state(slots: usize) -> Arc<State<InMemoryStore>> {
         skills: Arc::new(RwLock::new(SkillRegistry::with_builtins())),
         workflows: WorkflowRegistry::with_builtins(),
         skills_dir: PathBuf::from(".claude-pool/skills"),
+        server_info: ServerInfo::new(None, "plan".to_string(), slots),
     })
 }
 

--- a/crates/claude-pool/src/chain.rs
+++ b/crates/claude-pool/src/chain.rs
@@ -89,6 +89,8 @@ pub enum ChainIsolation {
     /// Create a temporary git worktree shared by all steps in the chain (default).
     #[default]
     Worktree,
+    /// Create a full clone with `git clone --local --shared` for complete isolation.
+    Clone,
 }
 
 /// Options for chain execution.

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -565,25 +565,43 @@ impl<S: PoolStore + 'static> Pool<S> {
             self.inner.store.put_task(task).await?;
         }
 
-        // Create chain worktree if isolation is requested.
-        let chain_working_dir = if isolation == crate::chain::ChainIsolation::Worktree {
-            if let Some(ref mgr) = self.inner.worktree_manager {
-                match mgr.create_for_chain(&task_id).await {
-                    Ok(path) => Some(path),
-                    Err(e) => {
-                        tracing::warn!(
-                            task_id = %task_id.0,
-                            error = %e,
-                            "failed to create chain worktree, falling back to slot dir"
-                        );
-                        None
+        // Create chain working directory based on isolation mode.
+        let chain_working_dir = match isolation {
+            crate::chain::ChainIsolation::Worktree => {
+                if let Some(ref mgr) = self.inner.worktree_manager {
+                    match mgr.create_for_chain(&task_id).await {
+                        Ok(path) => Some(path),
+                        Err(e) => {
+                            tracing::warn!(
+                                task_id = %task_id.0,
+                                error = %e,
+                                "failed to create chain worktree, falling back to slot dir"
+                            );
+                            None
+                        }
                     }
+                } else {
+                    None
                 }
-            } else {
-                None
             }
-        } else {
-            None
+            crate::chain::ChainIsolation::Clone => {
+                if let Some(ref mgr) = self.inner.worktree_manager {
+                    match mgr.create_clone_for_chain(&task_id).await {
+                        Ok(path) => Some(path),
+                        Err(e) => {
+                            tracing::warn!(
+                                task_id = %task_id.0,
+                                error = %e,
+                                "failed to create chain clone, falling back to slot dir"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                }
+            }
+            crate::chain::ChainIsolation::None => None,
         };
 
         let pool = self.clone();
@@ -599,16 +617,31 @@ impl<S: PoolStore + 'static> Pool<S> {
             )
             .await;
 
-            // Clean up chain worktree if we created one.
+            // Clean up chain isolation based on the mode used.
             if chain_working_dir.is_some()
                 && let Some(ref mgr) = pool.inner.worktree_manager
-                && let Err(e) = mgr.remove_chain(&tid).await
             {
-                tracing::warn!(
-                    task_id = %tid.0,
-                    error = %e,
-                    "failed to clean up chain worktree"
-                );
+                match isolation {
+                    crate::chain::ChainIsolation::Worktree => {
+                        if let Err(e) = mgr.remove_chain(&tid).await {
+                            tracing::warn!(
+                                task_id = %tid.0,
+                                error = %e,
+                                "failed to clean up chain worktree"
+                            );
+                        }
+                    }
+                    crate::chain::ChainIsolation::Clone => {
+                        if let Err(e) = mgr.remove_clone(&tid).await {
+                            tracing::warn!(
+                                task_id = %tid.0,
+                                error = %e,
+                                "failed to clean up chain clone"
+                            );
+                        }
+                    }
+                    crate::chain::ChainIsolation::None => {}
+                }
             }
 
             // Store the chain result as the task result.

--- a/crates/claude-pool/src/worktree.rs
+++ b/crates/claude-pool/src/worktree.rs
@@ -280,6 +280,71 @@ impl WorktreeManager {
     pub fn chain_worktree_path(&self, task_id: &TaskId) -> PathBuf {
         self.base_dir.join("chains").join(&task_id.0)
     }
+
+    /// Create a full clone for a chain execution using `git clone --local --shared`.
+    ///
+    /// Creates a clone at `{base_dir}/clones/{task_id}` with no shared .git directory.
+    pub async fn create_clone_for_chain(&self, task_id: &TaskId) -> Result<PathBuf> {
+        let clone_path = self.clone_path(task_id);
+
+        let clones_dir = self.base_dir.join("clones");
+        tokio::fs::create_dir_all(&clones_dir)
+            .await
+            .map_err(|e| Error::Store(format!("failed to create clones dir: {e}")))?;
+
+        if clone_path.exists() {
+            self.remove_clone(task_id).await?;
+        }
+
+        let output = tokio::process::Command::new("git")
+            .args([
+                "clone",
+                "--local",
+                "--shared",
+                self.repo_dir.to_str().unwrap_or_default(),
+                clone_path.to_str().unwrap_or_default(),
+            ])
+            .output()
+            .await
+            .map_err(|e| Error::Store(format!("failed to create chain clone: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::Store(format!(
+                "git clone failed for chain: {stderr}"
+            )));
+        }
+
+        tracing::info!(
+            task_id = %task_id.0,
+            path = %clone_path.display(),
+            "created chain clone"
+        );
+
+        Ok(clone_path)
+    }
+
+    /// Remove a chain's clone directory.
+    pub async fn remove_clone(&self, task_id: &TaskId) -> Result<()> {
+        let clone_path = self.clone_path(task_id);
+
+        if clone_path.exists() {
+            tokio::fs::remove_dir_all(&clone_path).await.map_err(|e| {
+                Error::Store(format!(
+                    "failed to remove chain clone at {}: {e}",
+                    clone_path.display()
+                ))
+            })?;
+        }
+
+        tracing::debug!(task_id = %task_id.0, "removed chain clone");
+        Ok(())
+    }
+
+    /// Get the clone path for a chain (may not exist yet).
+    pub fn clone_path(&self, task_id: &TaskId) -> PathBuf {
+        self.base_dir.join("clones").join(&task_id.0)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- `pool_status` now includes server metadata: version, git commit hash, model, permission mode, slot count
- Git commit hash captured at build time via `build.rs`
- Adds `Clone` as third `ChainIsolation` mode alongside `None` and `Worktree`
- Uses `git clone --local --shared` for full isolation with no shared `.git` directory
- Zero lock contention under parallel chain load

## Why combined

These are prerequisites for testing chain isolation properly -- we need server metadata to verify which binary is running, and clone isolation to prevent chains from stepping on each other (which happened with `isolation: "none"`).

Closes #145
Closes #113