### PR TITLE
feat: inter-slot messaging for pool communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +92,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -173,10 +188,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -223,6 +262,7 @@ name = "claude-pool"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "claude-wrapper",
  "dashmap",
  "serde",
@@ -269,6 +309,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -352,6 +398,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -600,6 +652,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +799,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1072,6 +1157,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1547,10 +1638,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tower-mcp = { version = "0.8", default-features = false }
 schemars = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -169,6 +169,33 @@ pub struct SkillSaveInput {
     pub dir: Option<String>,
 }
 
+// ── Messaging input schemas ────────────────────────────────────────────
+
+/// Input for sending a message between slots.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SendMessageInput {
+    /// Sender slot ID (e.g., "slot-0").
+    pub from: String,
+    /// Recipient slot ID (e.g., "slot-1").
+    pub to: String,
+    /// Message content.
+    pub content: String,
+}
+
+/// Input for reading messages from a slot's inbox.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReadMessagesInput {
+    /// Slot ID to read messages from (e.g., "slot-0").
+    pub slot_id: String,
+}
+
+/// Input for peeking at messages in a slot's inbox.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PeekMessagesInput {
+    /// Slot ID to peek at messages from (e.g., "slot-0").
+    pub slot_id: String,
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
@@ -1077,6 +1104,59 @@ pub fn pool_skill_save_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Too
         .build()
 }
 
+pub fn pool_send_message_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_send_message")
+        .title("Send Message Between Slots")
+        .description("Send a message from one slot to another. Returns the message ID.")
+        .handler(move |input: SendMessageInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let from = claude_pool::types::SlotId(input.from);
+                let to = claude_pool::types::SlotId(input.to);
+                let message_id = state.pool.send_message(from, to, input.content);
+                Ok(CallToolResult::json(serde_json::json!({
+                    "message_id": message_id,
+                })))
+            }
+        })
+        .build()
+}
+
+pub fn pool_read_messages_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_read_messages")
+        .title("Read Messages from Slot")
+        .description("Drain and read all messages for a slot, removing them from the inbox.")
+        .handler(move |input: ReadMessagesInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let slot_id = claude_pool::types::SlotId(input.slot_id);
+                let messages = state.pool.read_messages(&slot_id);
+                Ok(CallToolResult::json(
+                    serde_json::to_value(&messages).unwrap(),
+                ))
+            }
+        })
+        .build()
+}
+
+pub fn pool_peek_messages_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_peek_messages")
+        .title("Peek Messages from Slot")
+        .description("Read messages from a slot's inbox without removing them.")
+        .read_only()
+        .handler(move |input: PeekMessagesInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let slot_id = claude_pool::types::SlotId(input.slot_id);
+                let messages = state.pool.peek_messages(&slot_id);
+                Ok(CallToolResult::json(
+                    serde_json::to_value(&messages).unwrap(),
+                ))
+            }
+        })
+        .build()
+}
+
 pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
     vec![
         pool_status_tool(Arc::clone(state)),
@@ -1100,6 +1180,9 @@ pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
         context_get_tool(Arc::clone(state)),
         context_delete_tool(Arc::clone(state)),
         context_list_tool(Arc::clone(state)),
+        pool_send_message_tool(Arc::clone(state)),
+        pool_read_messages_tool(Arc::clone(state)),
+        pool_peek_messages_tool(Arc::clone(state)),
         pool_configure_slot_tool(Arc::clone(state)),
         pool_skill_list_tool(Arc::clone(state)),
         pool_skill_get_tool(Arc::clone(state)),

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true }
 tracing = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/claude-pool/src/lib.rs
+++ b/crates/claude-pool/src/lib.rs
@@ -21,6 +21,7 @@
 pub mod chain;
 pub mod config;
 pub mod error;
+pub mod messaging;
 pub mod pool;
 pub mod skill;
 pub mod store;
@@ -34,6 +35,7 @@ pub use chain::{
     StepFailurePolicy, StepResult, execute_chain,
 };
 pub use error::{Error, Result};
+pub use messaging::{Message, MessageBus};
 pub use pool::{DrainSummary, Pool, PoolBuilder, PoolStatus};
 pub use skill::{RegisteredSkill, Skill, SkillArgument, SkillRegistry, SkillScope, SkillSource};
 pub use store::{InMemoryStore, PoolStore};

--- a/crates/claude-pool/src/messaging.rs
+++ b/crates/claude-pool/src/messaging.rs
@@ -1,0 +1,186 @@
+//! Inter-slot messaging for pool communication.
+//!
+//! Provides a message bus for slots to send and receive messages to each other.
+
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+
+use crate::types::SlotId;
+
+/// A message sent from one slot to another.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Message {
+    /// Unique message ID.
+    pub id: String,
+    /// Sender slot ID.
+    pub from: SlotId,
+    /// Recipient slot ID.
+    pub to: SlotId,
+    /// Message content.
+    pub content: String,
+    /// Timestamp when message was created.
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Message bus for inter-slot communication.
+///
+/// Implements a simple inbox-based messaging system where each slot
+/// has a queue of messages addressed to it.
+pub struct MessageBus {
+    /// Inboxes keyed by slot ID, containing vectors of messages.
+    inboxes: DashMap<String, Vec<Message>>,
+}
+
+impl Default for MessageBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MessageBus {
+    /// Create a new message bus.
+    pub fn new() -> Self {
+        Self {
+            inboxes: DashMap::new(),
+        }
+    }
+
+    /// Send a message from one slot to another, returning the message ID.
+    pub fn send(&self, from: SlotId, to: SlotId, content: String) -> String {
+        let message_id = generate_message_id();
+        let to_key = to.0.clone();
+        let message = Message {
+            id: message_id.clone(),
+            from,
+            to,
+            content,
+            timestamp: Utc::now(),
+        };
+
+        self.inboxes.entry(to_key).or_default().push(message);
+
+        message_id
+    }
+
+    /// Read and drain all messages for a slot, returning them in order.
+    pub fn read(&self, slot_id: &SlotId) -> Vec<Message> {
+        self.inboxes
+            .remove(&slot_id.0)
+            .map(|(_, messages)| messages)
+            .unwrap_or_default()
+    }
+
+    /// Peek at all messages for a slot without removing them.
+    pub fn peek(&self, slot_id: &SlotId) -> Vec<Message> {
+        self.inboxes
+            .get(&slot_id.0)
+            .map(|entry| entry.clone())
+            .unwrap_or_default()
+    }
+
+    /// Get the count of messages in a slot's inbox.
+    pub fn count(&self, slot_id: &SlotId) -> usize {
+        self.inboxes
+            .get(&slot_id.0)
+            .map(|entry| entry.len())
+            .unwrap_or(0)
+    }
+}
+
+fn generate_message_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("msg-{nanos:x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_send_and_read() {
+        let bus = MessageBus::new();
+        let slot1 = SlotId("slot-1".to_string());
+        let slot2 = SlotId("slot-2".to_string());
+
+        let msg_id = bus.send(slot1.clone(), slot2.clone(), "hello".to_string());
+        assert!(!msg_id.is_empty());
+
+        let messages = bus.read(&slot2);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].id, msg_id);
+        assert_eq!(messages[0].content, "hello");
+        assert_eq!(messages[0].from, slot1);
+        assert_eq!(messages[0].to, slot2);
+
+        // Verify inbox is empty after read
+        let messages_again = bus.read(&slot2);
+        assert!(messages_again.is_empty());
+    }
+
+    #[test]
+    fn test_send_and_peek() {
+        let bus = MessageBus::new();
+        let slot1 = SlotId("slot-1".to_string());
+        let slot2 = SlotId("slot-2".to_string());
+
+        bus.send(slot1.clone(), slot2.clone(), "hello".to_string());
+
+        let messages = bus.peek(&slot2);
+        assert_eq!(messages.len(), 1);
+
+        // Verify inbox still has message after peek
+        let messages_again = bus.peek(&slot2);
+        assert_eq!(messages_again.len(), 1);
+    }
+
+    #[test]
+    fn test_multiple_senders() {
+        let bus = MessageBus::new();
+        let slot1 = SlotId("slot-1".to_string());
+        let slot2 = SlotId("slot-2".to_string());
+        let slot3 = SlotId("slot-3".to_string());
+
+        bus.send(slot1.clone(), slot3.clone(), "from slot1".to_string());
+        bus.send(slot2.clone(), slot3.clone(), "from slot2".to_string());
+
+        let messages = bus.read(&slot3);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].from, slot1);
+        assert_eq!(messages[1].from, slot2);
+    }
+
+    #[test]
+    fn test_empty_inbox() {
+        let bus = MessageBus::new();
+        let slot1 = SlotId("slot-1".to_string());
+
+        let messages = bus.read(&slot1);
+        assert!(messages.is_empty());
+
+        let messages = bus.peek(&slot1);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_count() {
+        let bus = MessageBus::new();
+        let slot1 = SlotId("slot-1".to_string());
+        let slot2 = SlotId("slot-2".to_string());
+
+        assert_eq!(bus.count(&slot1), 0);
+
+        bus.send(slot1.clone(), slot2.clone(), "msg1".to_string());
+        assert_eq!(bus.count(&slot2), 1);
+
+        bus.send(slot1.clone(), slot2.clone(), "msg2".to_string());
+        assert_eq!(bus.count(&slot2), 2);
+
+        bus.read(&slot2);
+        assert_eq!(bus.count(&slot2), 0);
+    }
+}

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -33,6 +33,7 @@ use claude_wrapper::types::OutputFormat;
 
 use crate::config::ResolvedConfig;
 use crate::error::{Error, Result};
+use crate::messaging::MessageBus;
 use crate::skill::SkillRegistry;
 use crate::store::PoolStore;
 use crate::types::*;
@@ -52,6 +53,8 @@ struct PoolInner<S: PoolStore> {
     worktree_manager: Option<crate::worktree::WorktreeManager>,
     /// In-flight chain progress, keyed by task ID.
     chain_progress: dashmap::DashMap<String, crate::chain::ChainProgress>,
+    /// Message bus for inter-slot communication.
+    message_bus: MessageBus,
 }
 
 /// A pool of Claude CLI slots.
@@ -144,6 +147,7 @@ impl<S: PoolStore + 'static> PoolBuilder<S> {
             assignment_lock: Mutex::new(()),
             worktree_manager,
             chain_progress: dashmap::DashMap::new(),
+            message_bus: MessageBus::default(),
         });
 
         // Register slots in the store.
@@ -805,6 +809,32 @@ impl<S: PoolStore + 'static> Pool<S> {
             .iter()
             .map(|r| (r.key().clone(), r.value().clone()))
             .collect()
+    }
+
+    /// Send a message from one slot to another.
+    ///
+    /// Returns the message ID.
+    pub fn send_message(&self, from: SlotId, to: SlotId, content: String) -> String {
+        self.inner.message_bus.send(from, to, content)
+    }
+
+    /// Read and drain all messages for a slot.
+    ///
+    /// Returns messages in order, removing them from the inbox.
+    pub fn read_messages(&self, slot_id: &SlotId) -> Vec<crate::messaging::Message> {
+        self.inner.message_bus.read(slot_id)
+    }
+
+    /// Peek at all messages for a slot without removing them.
+    ///
+    /// Returns messages in order without draining the inbox.
+    pub fn peek_messages(&self, slot_id: &SlotId) -> Vec<crate::messaging::Message> {
+        self.inner.message_bus.peek(slot_id)
+    }
+
+    /// Get the count of messages in a slot's inbox.
+    pub fn message_count(&self, slot_id: &SlotId) -> usize {
+        self.inner.message_bus.count(slot_id)
     }
 
     /// Gracefully shut down the pool.


### PR DESCRIPTION
## Summary

- Adds `MessageBus` to `claude-pool` with inbox-based inter-slot messaging (`send`, `read`, `peek`, `count`)
- Integrates `MessageBus` into `Pool` with delegate methods
- Exposes 3 MCP tools: `pool_send_message`, `pool_read_messages`, `pool_peek_messages`
- Uses `chrono` for message timestamps and `DashMap` for concurrent inbox access
- 5 unit tests covering send/read, peek, multiple senders, empty inbox, and count

Closes #27

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib --all-features` passes (183 tests, including 5 new messaging tests)
- [ ] Manual verification: send message between slots via MCP tools