### PR TITLE
feat: adopt SKILL.md format and global skills directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "dashmap",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror",
  "tokio",
@@ -281,6 +282,7 @@ dependencies = [
  "clap",
  "claude-pool",
  "claude-wrapper",
+ "dirs",
  "schemars",
  "serde",
  "serde_json",
@@ -369,6 +371,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
 ]
 
 [[package]]
@@ -516,6 +539,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -734,6 +768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +864,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -948,6 +997,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1136,6 +1196,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1489,6 +1562,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ schemars = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
+serde_yaml = "0.9"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/claude-pool-server/Cargo.toml
+++ b/crates/claude-pool-server/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true }
 tower-mcp = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+dirs = "6"
 
 [dependencies.axum]
 version = "0.8"

--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -65,6 +65,10 @@ struct Cli {
     #[arg(long)]
     no_project_skills: bool,
 
+    /// Skip loading global user skills from ~/.claude-pool/skills/.
+    #[arg(long)]
+    no_global_skills: bool,
+
     /// Disable specific skills by name (comma-separated).
     #[arg(long, value_delimiter = ',')]
     disable_skill: Vec<String>,
@@ -227,6 +231,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         SkillRegistry::with_builtins()
     };
 
+    // Load global user skills (~/.claude-pool/skills/) — lower priority than project.
+    if !cli.no_global_skills
+        && let Some(home) = dirs::home_dir()
+    {
+        let global_dir = home.join(".claude-pool").join("skills");
+        let count =
+            skills.load_from_dir_with_source(&global_dir, claude_pool::SkillSource::Global)?;
+        if count > 0 {
+            tracing::info!(count, dir = %global_dir.display(), "loaded global skills");
+        }
+    }
+
+    // Load project skills — highest priority, overrides global and builtin.
     if !cli.no_project_skills {
         let count = skills.load_from_dir(&cli.skills_dir)?;
         if count > 0 {

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -169,6 +169,15 @@ pub struct SkillSaveInput {
     pub dir: Option<String>,
 }
 
+/// Input for ejecting a builtin skill to disk for customization.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SkillEjectInput {
+    /// Skill name to eject (must be a builtin skill).
+    pub name: String,
+    /// Directory to eject to. Defaults to the configured skills_dir.
+    pub dir: Option<String>,
+}
+
 // ── Messaging input schemas ────────────────────────────────────────────
 
 /// Input for sending a message between slots.
@@ -946,6 +955,12 @@ pub fn pool_skill_get_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool
                 let registry = state.skills.read().await;
                 match registry.get_registered(&input.name) {
                     Some(rs) => {
+                        // A skill is "customized" if it's a builtin name but
+                        // loaded from project/global/runtime source.
+                        let customized = rs.source != SkillSource::Builtin
+                            && claude_pool::skill::builtin_skills()
+                                .iter()
+                                .any(|b| b.name == rs.skill.name);
                         let response = serde_json::json!({
                             "name": rs.skill.name,
                             "description": rs.skill.description,
@@ -957,6 +972,7 @@ pub fn pool_skill_get_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool
                             })).collect::<Vec<_>>(),
                             "scope": rs.skill.scope.to_string(),
                             "source": rs.source.to_string(),
+                            "customized": customized,
                             "config": rs.skill.config,
                         });
                         Ok(CallToolResult::json(response))
@@ -1038,13 +1054,13 @@ pub fn pool_skill_remove_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> T
         .build()
 }
 
-/// Persist a skill to the project skills directory as JSON.
+/// Persist a skill to the project skills directory as a SKILL.md folder.
 pub fn pool_skill_save_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
     ToolBuilder::new("pool_skill_save")
         .title("Save Skill to Disk")
         .description(
-            "Persist a skill to the project skills directory as JSON. \
-             Creates/overwrites {dir}/{name}.json.",
+            "Persist a skill to the project skills directory as a SKILL.md folder \
+             (Agent Skills standard). Creates/overwrites {dir}/{name}/SKILL.md.",
         )
         .handler(move |input: SkillSaveInput| {
             let state = Arc::clone(&state);
@@ -1062,25 +1078,23 @@ pub fn pool_skill_save_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Too
                     }
                 };
 
-                let dir = input
+                let base_dir = input
                     .dir
                     .map(PathBuf::from)
                     .unwrap_or_else(|| state.skills_dir.clone());
 
-                if let Err(e) = std::fs::create_dir_all(&dir) {
+                let skill_dir = base_dir.join(&skill.name);
+                if let Err(e) = std::fs::create_dir_all(&skill_dir) {
                     return Ok(CallToolResult::error(format!(
                         "failed to create directory {}: {e}",
-                        dir.display()
+                        skill_dir.display()
                     )));
                 }
 
-                let path = dir.join(format!("{}.json", input.name));
-                let json = match serde_json::to_string_pretty(&skill) {
-                    Ok(j) => j,
-                    Err(e) => return Ok(CallToolResult::error(format!("serialize error: {e}"))),
-                };
+                let skill_md = skill_to_skill_md(&skill);
+                let path = skill_dir.join("SKILL.md");
 
-                if let Err(e) = std::fs::write(&path, &json) {
+                if let Err(e) = std::fs::write(&path, &skill_md) {
                     return Ok(CallToolResult::error(format!(
                         "failed to write {}: {e}",
                         path.display()
@@ -1098,6 +1112,116 @@ pub fn pool_skill_save_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Too
                 Ok(CallToolResult::json(serde_json::json!({
                     "saved": input.name,
                     "path": path.display().to_string(),
+                    "format": "SKILL.md",
+                })))
+            }
+        })
+        .build()
+}
+
+/// Convert a Skill to SKILL.md format (YAML frontmatter + markdown body).
+fn skill_to_skill_md(skill: &claude_pool::Skill) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    out.push_str("---\n");
+    writeln!(out, "name: {}", skill.name).unwrap();
+    writeln!(
+        out,
+        "description: \"{}\"",
+        skill.description.replace('"', "\\\"")
+    )
+    .unwrap();
+
+    let has_metadata = skill.scope != claude_pool::SkillScope::Task
+        || !skill.arguments.is_empty()
+        || skill.config.is_some();
+
+    if has_metadata {
+        out.push_str("metadata:\n");
+        if skill.scope != claude_pool::SkillScope::Task {
+            writeln!(out, "  scope: {}", skill.scope).unwrap();
+        }
+        if !skill.arguments.is_empty() {
+            out.push_str("  arguments:\n");
+            for arg in &skill.arguments {
+                writeln!(out, "    - name: {}", arg.name).unwrap();
+                writeln!(
+                    out,
+                    "      description: \"{}\"",
+                    arg.description.replace('"', "\\\"")
+                )
+                .unwrap();
+                writeln!(out, "      required: {}", arg.required).unwrap();
+            }
+        }
+    }
+
+    out.push_str("---\n\n");
+    out.push_str(&skill.prompt);
+    out.push('\n');
+    out
+}
+
+/// Eject a builtin skill to disk for customization.
+pub fn pool_skill_eject_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_skill_eject")
+        .title("Eject Builtin Skill")
+        .description(
+            "Write a builtin skill to disk as a SKILL.md folder for customization. \
+             The disk version shadows the builtin. Delete the folder to restore the default.",
+        )
+        .handler(move |input: SkillEjectInput| {
+            let state = Arc::clone(&state);
+            async move {
+                // Find the builtin version of the skill.
+                let builtin = claude_pool::skill::builtin_skills()
+                    .into_iter()
+                    .find(|s| s.name == input.name);
+
+                let skill = match builtin {
+                    Some(s) => s,
+                    None => {
+                        return Ok(CallToolResult::error(format!(
+                            "not a builtin skill: {} (only builtins can be ejected)",
+                            input.name
+                        )));
+                    }
+                };
+
+                let base_dir = input
+                    .dir
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| state.skills_dir.clone());
+
+                let skill_dir = base_dir.join(&skill.name);
+                if let Err(e) = std::fs::create_dir_all(&skill_dir) {
+                    return Ok(CallToolResult::error(format!(
+                        "failed to create directory {}: {e}",
+                        skill_dir.display()
+                    )));
+                }
+
+                let skill_md = skill_to_skill_md(&skill);
+                let path = skill_dir.join("SKILL.md");
+
+                if let Err(e) = std::fs::write(&path, &skill_md) {
+                    return Ok(CallToolResult::error(format!(
+                        "failed to write {}: {e}",
+                        path.display()
+                    )));
+                }
+
+                // Re-register as Project source so it shows as customized.
+                {
+                    let mut registry = state.skills.write().await;
+                    registry.register(skill, SkillSource::Project);
+                }
+
+                Ok(CallToolResult::json(serde_json::json!({
+                    "ejected": input.name,
+                    "path": path.display().to_string(),
+                    "hint": "edit the SKILL.md to customize, delete the folder to restore builtin",
                 })))
             }
         })
@@ -1189,5 +1313,6 @@ pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
         pool_skill_add_tool(Arc::clone(state)),
         pool_skill_remove_tool(Arc::clone(state)),
         pool_skill_save_tool(Arc::clone(state)),
+        pool_skill_eject_tool(Arc::clone(state)),
     ]
 }

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -23,6 +23,7 @@ tempfile = "3"
 tokio = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+serde_yaml = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/claude-pool/src/skill.rs
+++ b/crates/claude-pool/src/skill.rs
@@ -17,7 +17,9 @@ use crate::types::SlotConfig;
 pub enum SkillSource {
     /// Ships with the pool binary.
     Builtin,
-    /// Loaded from a `.claude-pool/skills/` JSON file.
+    /// Loaded from `~/.claude-pool/skills/` (user global).
+    Global,
+    /// Loaded from `.claude-pool/skills/` (project).
     Project,
     /// Added at runtime via `pool_skill_add`.
     Runtime,
@@ -27,6 +29,7 @@ impl std::fmt::Display for SkillSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Builtin => write!(f, "builtin"),
+            Self::Global => write!(f, "global"),
             Self::Project => write!(f, "project"),
             Self::Runtime => write!(f, "runtime"),
         }
@@ -106,6 +109,76 @@ pub struct SkillArgument {
 
     /// Whether this argument is required.
     pub required: bool,
+}
+
+/// YAML frontmatter from a SKILL.md file.
+///
+/// Follows the [Agent Skills standard](https://agentskills.io/specification):
+/// name, description, and pool-specific extensions under `metadata`.
+#[derive(Debug, Deserialize)]
+struct SkillFrontmatter {
+    name: String,
+    description: String,
+    #[serde(default)]
+    metadata: SkillMetadata,
+}
+
+/// Pool-specific metadata extensions in SKILL.md frontmatter.
+#[derive(Debug, Default, Deserialize)]
+struct SkillMetadata {
+    #[serde(default)]
+    scope: Option<SkillScope>,
+    #[serde(default)]
+    arguments: Vec<SkillArgument>,
+    #[serde(default)]
+    config: Option<SlotConfig>,
+}
+
+/// Parse a SKILL.md file into a [`Skill`].
+///
+/// The file format is YAML frontmatter between `---` delimiters, followed
+/// by a markdown body that becomes the prompt template.
+fn parse_skill_md(content: &str) -> crate::Result<Skill> {
+    let content = content.trim();
+    if !content.starts_with("---") {
+        return Err(crate::Error::Store(
+            "SKILL.md must start with YAML frontmatter (---)".into(),
+        ));
+    }
+
+    let after_first = &content[3..];
+    let end = after_first.find("---").ok_or_else(|| {
+        crate::Error::Store("SKILL.md missing closing frontmatter delimiter (---)".into())
+    })?;
+
+    let yaml = &after_first[..end];
+    let body = after_first[end + 3..].trim();
+
+    let fm: SkillFrontmatter = serde_yaml::from_str(yaml)
+        .map_err(|e| crate::Error::Store(format!("SKILL.md YAML parse error: {e}")))?;
+
+    // Infer scope from name prefix if not set explicitly.
+    let scope = fm.metadata.scope.unwrap_or_else(|| infer_scope(&fm.name));
+
+    Ok(Skill {
+        name: fm.name,
+        description: fm.description,
+        prompt: body.to_string(),
+        arguments: fm.metadata.arguments,
+        config: fm.metadata.config,
+        scope,
+    })
+}
+
+/// Infer skill scope from name prefix convention.
+fn infer_scope(name: &str) -> SkillScope {
+    if name.starts_with("cps-coordinator") {
+        SkillScope::Coordinator
+    } else if name.starts_with("cps-chain") {
+        SkillScope::Chain
+    } else {
+        SkillScope::Task
+    }
 }
 
 impl Skill {
@@ -200,32 +273,59 @@ impl SkillRegistry {
             .collect()
     }
 
-    /// Load skill definitions from JSON files in a directory.
+    /// Load skill definitions from a directory.
     ///
-    /// Each `.json` file in the directory is deserialized as a [`Skill`] and
-    /// registered with [`SkillSource::Project`]. Skills loaded this way
-    /// override any existing skill with the same name. Files are loaded in
-    /// sorted order for deterministic behavior.
+    /// Discovers skills in two formats, in sorted order:
+    /// - **SKILL.md folders**: `skill-name/SKILL.md` (Agent Skills standard)
+    /// - **JSON files**: `skill_name.json` (legacy, with deprecation warning)
     ///
-    /// Returns the number of skills loaded. If the directory does not exist,
-    /// returns `Ok(0)` without error.
+    /// Skills are registered with the given `source`. Skills loaded this way
+    /// override any existing skill with the same name. Returns the number of
+    /// skills loaded. If the directory does not exist, returns `Ok(0)`.
     pub fn load_from_dir(&mut self, dir: &Path) -> crate::Result<usize> {
+        self.load_from_dir_with_source(dir, SkillSource::Project)
+    }
+
+    /// Load skill definitions from a directory with the specified source.
+    pub fn load_from_dir_with_source(
+        &mut self,
+        dir: &Path,
+        source: SkillSource,
+    ) -> crate::Result<usize> {
         if !dir.is_dir() {
             return Ok(0);
         }
 
-        let mut entries: Vec<_> = std::fs::read_dir(dir)?
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
-            .collect();
+        let mut entries: Vec<_> = std::fs::read_dir(dir)?.filter_map(|e| e.ok()).collect();
         entries.sort_by_key(|e| e.file_name());
 
         let mut count = 0;
         for entry in entries {
-            let contents = std::fs::read_to_string(entry.path())?;
-            let skill: Skill = serde_json::from_str(&contents)?;
-            self.register(skill, SkillSource::Project);
-            count += 1;
+            let path = entry.path();
+
+            // SKILL.md folder format (preferred).
+            if path.is_dir() {
+                let skill_md = path.join("SKILL.md");
+                if skill_md.is_file() {
+                    let contents = std::fs::read_to_string(&skill_md)?;
+                    let skill = parse_skill_md(&contents)?;
+                    self.register(skill, source);
+                    count += 1;
+                }
+                continue;
+            }
+
+            // Legacy JSON format (deprecated).
+            if path.extension().is_some_and(|ext| ext == "json") {
+                tracing::warn!(
+                    path = %path.display(),
+                    "loading skill from JSON format (deprecated — migrate to SKILL.md folder)"
+                );
+                let contents = std::fs::read_to_string(&path)?;
+                let skill: Skill = serde_json::from_str(&contents)?;
+                self.register(skill, source);
+                count += 1;
+            }
         }
 
         Ok(count)
@@ -780,7 +880,234 @@ mod tests {
     #[test]
     fn source_display() {
         assert_eq!(SkillSource::Builtin.to_string(), "builtin");
+        assert_eq!(SkillSource::Global.to_string(), "global");
         assert_eq!(SkillSource::Project.to_string(), "project");
         assert_eq!(SkillSource::Runtime.to_string(), "runtime");
+    }
+
+    #[test]
+    fn source_global_serde_roundtrip() {
+        let json = serde_json::json!("global");
+        let source: SkillSource = serde_json::from_value(json).unwrap();
+        assert_eq!(source, SkillSource::Global);
+
+        let serialized = serde_json::to_value(source).unwrap();
+        assert_eq!(serialized, "global");
+    }
+
+    #[test]
+    fn parse_skill_md_basic() {
+        let content = "\
+---
+name: test-skill
+description: A test skill for parsing.
+metadata:
+  arguments:
+    - name: target
+      description: What to test
+      required: true
+---
+
+Run tests on {target}.
+
+Report results.
+";
+
+        let skill = parse_skill_md(content).unwrap();
+        assert_eq!(skill.name, "test-skill");
+        assert_eq!(skill.description, "A test skill for parsing.");
+        assert_eq!(skill.prompt, "Run tests on {target}.\n\nReport results.");
+        assert_eq!(skill.arguments.len(), 1);
+        assert_eq!(skill.arguments[0].name, "target");
+        assert!(skill.arguments[0].required);
+        assert_eq!(skill.scope, SkillScope::Task);
+    }
+
+    #[test]
+    fn parse_skill_md_with_scope() {
+        let content = "\
+---
+name: cps-coordinator-watcher
+description: Watches things.
+metadata:
+  scope: coordinator
+---
+
+Watch stuff.
+";
+        let skill = parse_skill_md(content).unwrap();
+        assert_eq!(skill.scope, SkillScope::Coordinator);
+    }
+
+    #[test]
+    fn parse_skill_md_infers_scope_from_prefix() {
+        let content = "\
+---
+name: cps-chain-deploy
+description: Deploy chain.
+---
+
+Deploy stuff.
+";
+        let skill = parse_skill_md(content).unwrap();
+        assert_eq!(skill.scope, SkillScope::Chain);
+    }
+
+    #[test]
+    fn parse_skill_md_no_metadata() {
+        let content = "\
+---
+name: simple
+description: Simple skill.
+---
+
+Just do it.
+";
+        let skill = parse_skill_md(content).unwrap();
+        assert_eq!(skill.name, "simple");
+        assert!(skill.arguments.is_empty());
+        assert_eq!(skill.scope, SkillScope::Task);
+    }
+
+    #[test]
+    fn parse_skill_md_missing_frontmatter() {
+        let result = parse_skill_md("no frontmatter here");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_skill_md_missing_closing_delimiter() {
+        let result = parse_skill_md("---\nname: broken\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_from_dir_with_skill_md_folders() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Create a SKILL.md folder.
+        let skill_dir = dir.path().join("my-skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "\
+---
+name: my-skill
+description: A folder-based skill.
+metadata:
+  arguments:
+    - name: input
+      description: The input
+      required: true
+---
+
+Process {input}.
+",
+        )
+        .unwrap();
+
+        let mut registry = SkillRegistry::new();
+        let count = registry.load_from_dir(dir.path()).unwrap();
+        assert_eq!(count, 1);
+
+        let skill = registry.get("my-skill").unwrap();
+        assert_eq!(skill.description, "A folder-based skill.");
+        assert_eq!(skill.prompt, "Process {input}.");
+        assert_eq!(skill.arguments.len(), 1);
+    }
+
+    #[test]
+    fn load_from_dir_mixed_formats() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // SKILL.md folder.
+        let skill_dir = dir.path().join("new-skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: new-skill\ndescription: New format.\n---\n\nNew prompt.\n",
+        )
+        .unwrap();
+
+        // Legacy JSON.
+        let skill_json = serde_json::json!({
+            "name": "old_skill",
+            "description": "Legacy format",
+            "prompt": "Old prompt",
+            "arguments": []
+        });
+        std::fs::write(
+            dir.path().join("old_skill.json"),
+            serde_json::to_string_pretty(&skill_json).unwrap(),
+        )
+        .unwrap();
+
+        let mut registry = SkillRegistry::new();
+        let count = registry.load_from_dir(dir.path()).unwrap();
+        assert_eq!(count, 2);
+        assert!(registry.get("new-skill").is_some());
+        assert!(registry.get("old_skill").is_some());
+    }
+
+    #[test]
+    fn load_from_dir_with_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("global-skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: global-skill\ndescription: Global.\n---\n\nDo global things.\n",
+        )
+        .unwrap();
+
+        let mut registry = SkillRegistry::new();
+        let count = registry
+            .load_from_dir_with_source(dir.path(), SkillSource::Global)
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let rs = registry.get_registered("global-skill").unwrap();
+        assert_eq!(rs.source, SkillSource::Global);
+    }
+
+    #[test]
+    fn skill_md_folder_overrides_builtin() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let skill_dir = dir.path().join("code_review");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "\
+---
+name: code_review
+description: Custom review via SKILL.md.
+metadata:
+  arguments:
+    - name: target
+      description: What to review
+      required: true
+---
+
+Custom review: {target}
+",
+        )
+        .unwrap();
+
+        let mut registry = SkillRegistry::with_builtins();
+        assert_eq!(
+            registry.get("code_review").unwrap().description,
+            "Review code for bugs, style issues, and improvements."
+        );
+
+        registry.load_from_dir(dir.path()).unwrap();
+        assert_eq!(
+            registry.get("code_review").unwrap().description,
+            "Custom review via SKILL.md."
+        );
+        assert_eq!(
+            registry.get_registered("code_review").unwrap().source,
+            SkillSource::Project
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Parse SKILL.md files (YAML frontmatter + markdown body) per the [Agent Skills standard](https://agentskills.io/specification)
- `load_from_dir` discovers both `*/SKILL.md` folders (preferred) and `*.json` files (legacy, with deprecation warning)
- Add `SkillSource::Global` and load from `~/.claude-pool/skills/` between builtins and project skills
- `pool_skill_save` now writes SKILL.md folders instead of JSON
- New `pool_skill_eject` tool to write builtins to disk for customization
- `pool_skill_get` includes `customized` field showing if a builtin has been overridden
- Scope inference from name prefix: `cps-chain-*` -> Chain, `cps-coordinator-*` -> Coordinator
- Priority order: builtins (lowest) -> global -> project (highest)

Closes #144

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (195 tests, 16 new)
- [x] `cargo test --test '*' --all-features` (integration tests pass)
- [x] `cargo test --doc --all-features` (35 doc tests pass)
- [ ] Manual: eject a builtin, modify SKILL.md, verify pool picks up changes
- [ ] Manual: create skill in `~/.claude-pool/skills/`, verify it loads as global source