### PR TITLE
feat: add broadcast messaging and slot discovery

### DIFF
--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -307,7 +307,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              Tools: pool_run (run), pool_submit/pool_result (fire/check), pool_fan_out (fan out), \
              pool_chain (chain), pool_submit_chain/pool_chain_result (fire a chain/check), \
              context_set/get/list (shared state), pool_configure_slot, pool_send_message/ \
-             pool_read_messages/pool_peek_messages (inter-slot messaging). \
+             pool_read_messages/pool_peek_messages/pool_broadcast (inter-slot messaging), \
+             pool_find_slots (discover slots by name/role/state). \
              Both effort and model can be overridden per-task and per-chain-step. \
              \
              Model guidance: default to the pool's configured model; override per-task/step with \

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -205,6 +205,29 @@ pub struct PeekMessagesInput {
     pub slot_id: String,
 }
 
+/// Input for broadcasting a message to all slots.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BroadcastInput {
+    /// Sender slot ID (e.g., "slot-0").
+    pub from: String,
+    /// Message content to broadcast.
+    pub content: String,
+}
+
+/// Input for finding slots by name, role, or state.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindSlotsInput {
+    /// Filter by slot name (exact match).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Filter by slot role (exact match).
+    #[serde(default)]
+    pub role: Option<String>,
+    /// Filter by slot state (idle, busy, stopped, errored).
+    #[serde(default)]
+    pub state: Option<String>,
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
@@ -1283,6 +1306,81 @@ pub fn pool_peek_messages_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> 
         .build()
 }
 
+pub fn pool_broadcast_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_broadcast")
+        .title("Broadcast Message to All Slots")
+        .description(
+            "Send a message from one slot to all other active slots. Returns the list of message IDs.",
+        )
+        .handler(move |input: BroadcastInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let from = claude_pool::types::SlotId(input.from);
+                match state.pool.broadcast_message(from, input.content).await {
+                    Ok(ids) => {
+                        let count = ids.len();
+                        Ok(CallToolResult::json(serde_json::json!({
+                            "message_ids": ids,
+                            "recipients": count,
+                        })))
+                    }
+                    Err(e) => Ok(CallToolResult::error(e.to_string())),
+                }
+            }
+        })
+        .build()
+}
+
+pub fn pool_find_slots_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_find_slots")
+        .title("Find Slots by Name, Role, or State")
+        .description(
+            "Query slots by name, role, and/or state. All filters are optional; omitted filters match everything.",
+        )
+        .read_only()
+        .handler(move |input: FindSlotsInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let slot_state = input.state.as_deref().and_then(|s| match s {
+                    "idle" => Some(claude_pool::types::SlotState::Idle),
+                    "busy" => Some(claude_pool::types::SlotState::Busy),
+                    "stopped" => Some(claude_pool::types::SlotState::Stopped),
+                    "errored" => Some(claude_pool::types::SlotState::Errored),
+                    _ => None,
+                });
+                match state
+                    .pool
+                    .find_slots(input.name.as_deref(), input.role.as_deref(), slot_state)
+                    .await
+                {
+                    Ok(slots) => {
+                        let results: Vec<_> = slots
+                            .iter()
+                            .map(|s| {
+                                serde_json::json!({
+                                    "id": s.id.0,
+                                    "state": s.state,
+                                    "name": s.config.name,
+                                    "role": s.config.role,
+                                    "description": s.config.description,
+                                    "current_task": s.current_task.as_ref().map(|t| &t.0),
+                                    "tasks_completed": s.tasks_completed,
+                                    "cost_microdollars": s.cost_microdollars,
+                                })
+                            })
+                            .collect();
+                        Ok(CallToolResult::json(serde_json::json!({
+                            "slots": results,
+                            "count": results.len(),
+                        })))
+                    }
+                    Err(e) => Ok(CallToolResult::error(e.to_string())),
+                }
+            }
+        })
+        .build()
+}
+
 pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
     vec![
         pool_status_tool(Arc::clone(state)),
@@ -1309,6 +1407,8 @@ pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
         pool_send_message_tool(Arc::clone(state)),
         pool_read_messages_tool(Arc::clone(state)),
         pool_peek_messages_tool(Arc::clone(state)),
+        pool_broadcast_tool(Arc::clone(state)),
+        pool_find_slots_tool(Arc::clone(state)),
         pool_configure_slot_tool(Arc::clone(state)),
         pool_skill_list_tool(Arc::clone(state)),
         pool_skill_get_tool(Arc::clone(state)),

--- a/crates/claude-pool/src/messaging.rs
+++ b/crates/claude-pool/src/messaging.rs
@@ -79,6 +79,22 @@ impl MessageBus {
             .unwrap_or_default()
     }
 
+    /// Broadcast a message from one slot to all other slots.
+    ///
+    /// Sends a copy of the message to every slot in `recipients` except the sender.
+    /// Returns the list of message IDs created.
+    pub fn broadcast(&self, from: SlotId, recipients: &[SlotId], content: String) -> Vec<String> {
+        let mut ids = Vec::new();
+        for to in recipients {
+            if *to == from {
+                continue;
+            }
+            let id = self.send(from.clone(), to.clone(), content.clone());
+            ids.push(id);
+        }
+        ids
+    }
+
     /// Get the count of messages in a slot's inbox.
     pub fn count(&self, slot_id: &SlotId) -> usize {
         self.inboxes
@@ -164,6 +180,31 @@ mod tests {
 
         let messages = bus.peek(&slot1);
         assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_broadcast() {
+        let bus = MessageBus::new();
+        let slot0 = SlotId("slot-0".to_string());
+        let slot1 = SlotId("slot-1".to_string());
+        let slot2 = SlotId("slot-2".to_string());
+        let slot3 = SlotId("slot-3".to_string());
+
+        let recipients = vec![slot0.clone(), slot1.clone(), slot2.clone(), slot3.clone()];
+        let ids = bus.broadcast(slot0.clone(), &recipients, "hello all".to_string());
+
+        // Should send to 3 recipients (not self)
+        assert_eq!(ids.len(), 3);
+
+        // Each recipient should have exactly one message
+        assert_eq!(bus.count(&slot1), 1);
+        assert_eq!(bus.count(&slot2), 1);
+        assert_eq!(bus.count(&slot3), 1);
+        assert_eq!(bus.count(&slot0), 0); // sender excluded
+
+        let msg = bus.read(&slot1);
+        assert_eq!(msg[0].content, "hello all");
+        assert_eq!(msg[0].from, slot0);
     }
 
     #[test]

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -832,6 +832,48 @@ impl<S: PoolStore + 'static> Pool<S> {
         self.inner.message_bus.send(from, to, content)
     }
 
+    /// Broadcast a message from one slot to all other active slots.
+    ///
+    /// Returns the list of message IDs created (one per recipient).
+    pub async fn broadcast_message(&self, from: SlotId, content: String) -> Result<Vec<String>> {
+        let slots = self.inner.store.list_slots().await?;
+        let recipients: Vec<SlotId> = slots.into_iter().map(|s| s.id).collect();
+        Ok(self.inner.message_bus.broadcast(from, &recipients, content))
+    }
+
+    /// Find slots matching optional name, role, and/or state filters.
+    ///
+    /// All filters are optional; omitted filters match everything.
+    pub async fn find_slots(
+        &self,
+        name: Option<&str>,
+        role: Option<&str>,
+        state: Option<SlotState>,
+    ) -> Result<Vec<SlotRecord>> {
+        let slots = self.inner.store.list_slots().await?;
+        Ok(slots
+            .into_iter()
+            .filter(|s| {
+                if let Some(n) = name
+                    && s.config.name.as_deref() != Some(n)
+                {
+                    return false;
+                }
+                if let Some(r) = role
+                    && s.config.role.as_deref() != Some(r)
+                {
+                    return false;
+                }
+                if let Some(st) = state
+                    && s.state != st
+                {
+                    return false;
+                }
+                true
+            })
+            .collect())
+    }
+
     /// Read and drain all messages for a slot.
     ///
     /// Returns messages in order, removing them from the inbox.
@@ -1935,6 +1977,78 @@ mod tests {
             slot.config.description.as_deref(),
             Some("Reviews PRs for correctness and style")
         );
+    }
+
+    #[tokio::test]
+    async fn find_slots_filters_by_name_role_state() {
+        let pool = Pool::builder(mock_claude())
+            .slots(1)
+            .slot_config(SlotConfig {
+                name: Some("reviewer".into()),
+                role: Some("code_review".into()),
+                ..Default::default()
+            })
+            .build()
+            .await
+            .unwrap();
+
+        // Scale up with a different config for the second slot.
+        pool.scale_up(1).await.unwrap();
+        let mut slots = pool.store().list_slots().await.unwrap();
+        if let Some(s) = slots.iter_mut().find(|s| s.id.0 == "slot-1") {
+            s.config.name = Some("writer".into());
+            s.config.role = Some("implementation".into());
+            pool.store().put_slot(s.clone()).await.unwrap();
+        }
+
+        // Find by name.
+        let found = pool.find_slots(Some("reviewer"), None, None).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id.0, "slot-0");
+
+        // Find by role.
+        let found = pool
+            .find_slots(None, Some("implementation"), None)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id.0, "slot-1");
+
+        // Find by state (all idle).
+        let found = pool
+            .find_slots(None, None, Some(SlotState::Idle))
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 2);
+
+        // Find with no filters (returns all).
+        let found = pool.find_slots(None, None, None).await.unwrap();
+        assert_eq!(found.len(), 2);
+
+        // Find with non-matching filter.
+        let found = pool
+            .find_slots(Some("nonexistent"), None, None)
+            .await
+            .unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[tokio::test]
+    async fn broadcast_sends_to_all_except_sender() {
+        let pool = Pool::builder(mock_claude()).slots(3).build().await.unwrap();
+
+        let from = SlotId("slot-0".into());
+        let ids = pool
+            .broadcast_message(from.clone(), "hello everyone".into())
+            .await
+            .unwrap();
+
+        assert_eq!(ids.len(), 2); // 3 slots minus sender
+
+        // Verify recipients got messages.
+        assert_eq!(pool.message_count(&SlotId("slot-1".into())), 1);
+        assert_eq!(pool.message_count(&SlotId("slot-2".into())), 1);
+        assert_eq!(pool.message_count(&from), 0); // sender excluded
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #165, closes #166

## Summary

- **Broadcast messaging** (`pool_broadcast`): Send a message from one slot to all other active slots. Skips the sender. Returns list of message IDs and recipient count.
- **Slot discovery** (`pool_find_slots`): Query slots by name, role, and/or state. All filters optional. Returns matching slots with metadata (id, state, name, role, description, current task, stats).

Both features close gaps identified in the Agent Teams competitive analysis (#163).

## Changes

- `messaging.rs`: Added `broadcast()` method to `MessageBus`
- `pool.rs`: Added `broadcast_message()` and `find_slots()` methods to `Pool`
- `tools.rs`: Added `pool_broadcast` and `pool_find_slots` MCP tools with input schemas
- `main.rs`: Updated server instructions to mention new tools
- 3 new unit tests (broadcast on bus, broadcast on pool, find_slots filtering)

## Test plan

- [x] `test_broadcast` — verifies broadcast sends to all except sender
- [x] `broadcast_sends_to_all_except_sender` — verifies pool-level broadcast
- [x] `find_slots_filters_by_name_role_state` — verifies name, role, state, all, and empty filters
- [x] Full test suite passes (81 lib + 34 doc)