### PR TITLE
feat: auto-delivery messaging and self-claiming task queue

### DIFF
--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -292,6 +292,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              \"fire a chain\" = pool_submit_chain (async pipeline, check with pool_chain_result), \
              \"fan out\" = pool_fan_out (parallel independent tasks), \
              \"run skill\" = pool_skill_run (execute a registered skill), \
+             \"claim\" = pool_claim (worker self-service: idle slot grabs next pending task), \
              \"cancel\" = pool_cancel / pool_cancel_chain, \
              \"check\" = pool_result / pool_chain_result, \
              \"inline\" = do the work yourself without the pool. \

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -228,6 +228,13 @@ pub struct FindSlotsInput {
     pub state: Option<String>,
 }
 
+/// Input for claiming the next pending task.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ClaimInput {
+    /// Slot ID that wants to claim a task (e.g., "slot-0").
+    pub slot_id: String,
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
@@ -1381,6 +1388,35 @@ pub fn pool_find_slots_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Too
         .build()
 }
 
+pub fn pool_claim_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_claim")
+        .title("Claim Next Pending Task")
+        .description(
+            "Self-service task claiming: an idle slot grabs the next pending task from the queue. \
+             Returns the claimed task ID, or null if no tasks are waiting. The task executes \
+             in the background on the claiming slot.",
+        )
+        .handler(move |input: ClaimInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let slot_id = claude_pool::types::SlotId(input.slot_id);
+                match state.pool.claim(&slot_id).await {
+                    Ok(Some(task_id)) => Ok(CallToolResult::json(serde_json::json!({
+                        "claimed": true,
+                        "task_id": task_id.0,
+                    }))),
+                    Ok(None) => Ok(CallToolResult::json(serde_json::json!({
+                        "claimed": false,
+                        "task_id": null,
+                        "reason": "no pending tasks or slot not idle",
+                    }))),
+                    Err(e) => Ok(CallToolResult::error(e.to_string())),
+                }
+            }
+        })
+        .build()
+}
+
 pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
     vec![
         pool_status_tool(Arc::clone(state)),
@@ -1416,5 +1452,6 @@ pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
         pool_skill_remove_tool(Arc::clone(state)),
         pool_skill_save_tool(Arc::clone(state)),
         pool_skill_eject_tool(Arc::clone(state)),
+        pool_claim_tool(Arc::clone(state)),
     ]
 }

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -472,6 +472,96 @@ impl<S: PoolStore + 'static> Pool<S> {
         }
     }
 
+    /// Claim the next pending task for a specific slot.
+    ///
+    /// Atomically finds the oldest pending task (with no slot assigned),
+    /// assigns it to the given slot, and executes it in the background.
+    /// Returns the claimed task ID, or `None` if no pending tasks are available.
+    pub async fn claim(&self, slot_id: &SlotId) -> Result<Option<TaskId>> {
+        self.check_shutdown()?;
+
+        // Verify the slot exists and is idle.
+        let slot = self
+            .inner
+            .store
+            .get_slot(slot_id)
+            .await?
+            .ok_or_else(|| Error::SlotNotFound(slot_id.0.clone()))?;
+
+        if slot.state != SlotState::Idle {
+            return Ok(None);
+        }
+
+        // Find the oldest pending task with no slot assigned.
+        let pending = self
+            .inner
+            .store
+            .list_tasks(&TaskFilter {
+                state: Some(TaskState::Pending),
+                ..Default::default()
+            })
+            .await?;
+
+        let task = match pending.into_iter().find(|t| t.slot_id.is_none()) {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+
+        let task_id = task.id.clone();
+        let prompt = task.prompt.clone();
+        let slot_config = slot.config.clone();
+
+        // Mark task as running and assign to slot.
+        let mut updated_task = task;
+        updated_task.state = TaskState::Running;
+        updated_task.slot_id = Some(slot_id.clone());
+        self.inner.store.put_task(updated_task.clone()).await?;
+
+        // Mark slot as busy.
+        let mut updated_slot = slot;
+        updated_slot.state = SlotState::Busy;
+        updated_slot.current_task = Some(task_id.clone());
+        self.inner.store.put_slot(updated_slot).await?;
+
+        // Execute in background.
+        let pool = self.clone();
+        let tid = task_id.clone();
+        let sid = slot_id.clone();
+        tokio::spawn(async move {
+            let result = pool
+                .execute_task(&tid, &prompt, &sid, &slot_config, None)
+                .await;
+
+            let _ = pool.release_slot(&sid, &tid, &result).await;
+
+            if let Ok(Some(mut task)) = pool.inner.store.get_task(&tid).await {
+                match result {
+                    Ok(task_result) => {
+                        task.state = TaskState::Completed;
+                        task.result = Some(task_result);
+                    }
+                    Err(e) => {
+                        let details = extract_failure_details(&e);
+                        task.state = TaskState::Failed;
+                        task.result = Some(TaskResult {
+                            output: e.to_string(),
+                            success: false,
+                            cost_microdollars: 0,
+                            turns_used: 0,
+                            session_id: None,
+                            failed_command: details.failed_command,
+                            exit_code: details.exit_code,
+                            stderr: details.stderr,
+                        });
+                    }
+                }
+                let _ = pool.inner.store.put_task(task).await;
+            }
+        });
+
+        Ok(Some(task_id))
+    }
+
     /// Cancel a running chain, skipping remaining steps.
     ///
     /// Sets the chain's task state to `Cancelled`. The currently-executing step
@@ -891,6 +981,31 @@ impl<S: PoolStore + 'static> Pool<S> {
     /// Get the count of messages in a slot's inbox.
     pub fn message_count(&self, slot_id: &SlotId) -> usize {
         self.inner.message_bus.count(slot_id)
+    }
+
+    /// Drain pending messages for a slot and prepend them to a prompt.
+    ///
+    /// If the slot has pending messages, they are consumed (removed from inbox)
+    /// and formatted as a preamble before the actual task prompt. This provides
+    /// automatic message delivery at task boundaries without requiring polling.
+    fn prepend_messages(&self, slot_id: &SlotId, prompt: &str) -> String {
+        let messages = self.inner.message_bus.read(slot_id);
+        if messages.is_empty() {
+            return prompt.to_string();
+        }
+
+        let mut preamble = String::from("## Messages received while idle\n\n");
+        for msg in &messages {
+            preamble.push_str(&format!(
+                "**From {}** ({}): {}\n\n",
+                msg.from.0,
+                msg.timestamp.format("%H:%M:%S"),
+                msg.content
+            ));
+        }
+        preamble.push_str("---\n\n");
+        preamble.push_str(prompt);
+        preamble
     }
 
     /// Gracefully shut down the pool.
@@ -1326,8 +1441,11 @@ impl<S: PoolStore + 'static> Pool<S> {
         // Build the system prompt with identity and context injection.
         let system_prompt = self.build_system_prompt(&resolved, slot_config);
 
+        // Auto-deliver pending messages by prepending them to the prompt.
+        let effective_prompt = self.prepend_messages(slot_id, prompt);
+
         // Build and execute the query.
-        let mut cmd = claude_wrapper::QueryCommand::new(prompt)
+        let mut cmd = claude_wrapper::QueryCommand::new(&effective_prompt)
             .output_format(OutputFormat::Json)
             .permission_mode(resolved.permission_mode);
 
@@ -1452,8 +1570,11 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         let system_prompt = self.build_system_prompt(&resolved, slot_config);
 
+        // Auto-deliver pending messages by prepending them to the prompt.
+        let effective_prompt = self.prepend_messages(slot_id, prompt);
+
         // Build the query with StreamJson format for streaming.
-        let mut cmd = claude_wrapper::QueryCommand::new(prompt)
+        let mut cmd = claude_wrapper::QueryCommand::new(&effective_prompt)
             .output_format(OutputFormat::StreamJson)
             .permission_mode(resolved.permission_mode);
 


### PR DESCRIPTION
## Summary

- **Auto-delivery (#169):** Pending inbox messages are drained and prepended to task prompts when a slot begins execution, so slots receive inter-slot messages without polling.
- **Self-claim (#170):** `pool_claim` lets an idle slot atomically grab the next unassigned pending task and begin executing it, enabling a pull-based work distribution model.

## Changes

- `pool.rs`: Added `prepend_messages()` helper called in both `execute_task` and `execute_task_streaming`; added `claim()` method for atomic task claiming
- `tools.rs`: Added `pool_claim` tool with `ClaimInput` schema, registered in `all_tools`
- `main.rs`: Updated server instructions vocabulary to include `claim`

Closes #169, closes #170