### PR TITLE
feat: add quality gate hooks for task lifecycle

### DIFF
--- a/crates/claude-pool-server/src/main.rs
+++ b/crates/claude-pool-server/src/main.rs
@@ -295,6 +295,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              \"claim\" = pool_claim (worker self-service: idle slot grabs next pending task), \
              \"cancel\" = pool_cancel / pool_cancel_chain, \
              \"check\" = pool_result / pool_chain_result, \
+             \"fire with review\" = pool_submit_with_review (async task requiring approval), \
+             \"approve\" = pool_approve_result (accept a pending-review result), \
+             \"reject\" = pool_reject_result (reject with feedback, re-queues), \
              \"inline\" = do the work yourself without the pool. \
              \
              When to use what: Default to inline when uncertain; user can say \"slotize it.\" \

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -235,6 +235,41 @@ pub struct ClaimInput {
     pub slot_id: String,
 }
 
+/// Input for submitting a task that requires review before completion.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SubmitWithReviewInput {
+    /// The prompt/task to execute.
+    pub prompt: String,
+    /// Model override for this task.
+    pub model: Option<String>,
+    /// Effort override for this task (min, low, medium, high, max).
+    pub effort: Option<String>,
+    /// Tags for grouping/filtering.
+    pub tags: Option<Vec<String>>,
+    /// Maximum number of rejections before failing (default: 3).
+    pub max_rejections: Option<u32>,
+    /// Additional MCP servers for this task (merged with global/slot servers).
+    /// Keys are server names, values are server config objects.
+    pub mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
+}
+
+/// Input for approving a task result.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ApproveResultInput {
+    /// The task ID to approve.
+    pub task_id: String,
+}
+
+/// Input for rejecting a task result with feedback.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RejectResultInput {
+    /// The task ID to reject.
+    pub task_id: String,
+    /// Feedback explaining why the result was rejected. This is appended to the
+    /// original prompt when the task is re-queued.
+    pub feedback: String,
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
@@ -365,15 +400,43 @@ pub fn pool_result_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
     ToolBuilder::new("pool_result")
         .title("Check on a Task")
         .description(
-            "Check on a fired task. Returns the result if complete, null if still running.",
+            "Check on a fired task. Returns the result if complete or pending_review, \
+             null if still running. Tasks with review_required=true will have \
+             state='pending_review' when done -- use pool_approve_result or \
+             pool_reject_result to finalize.",
         )
         .read_only()
         .handler(move |input: TaskIdInput| {
             let state = Arc::clone(&state);
             async move {
-                let task_id = claude_pool::TaskId(input.task_id);
+                let task_id = claude_pool::TaskId(input.task_id.clone());
+                // Fetch full task record for state info.
+                let task = state.pool.store().get_task(&task_id).await.ok().flatten();
+
                 match state.pool.result(&task_id).await {
-                    Ok(Some(r)) => Ok(CallToolResult::json(serde_json::to_value(&r).unwrap())),
+                    Ok(Some(r)) => {
+                        let mut val = serde_json::to_value(&r).unwrap();
+                        if let Some(ref t) = task
+                            && let Some(obj) = val.as_object_mut()
+                        {
+                            obj.insert("state".to_string(), serde_json::to_value(t.state).unwrap());
+                            if t.review_required {
+                                obj.insert(
+                                    "review_required".to_string(),
+                                    serde_json::Value::Bool(true),
+                                );
+                                obj.insert(
+                                    "rejection_count".to_string(),
+                                    serde_json::json!(t.rejection_count),
+                                );
+                                obj.insert(
+                                    "max_rejections".to_string(),
+                                    serde_json::json!(t.max_rejections),
+                                );
+                            }
+                        }
+                        Ok(CallToolResult::json(val))
+                    }
                     Ok(None) => Ok(CallToolResult::json(
                         serde_json::json!({ "status": "running" }),
                     )),
@@ -1423,6 +1486,75 @@ pub fn pool_claim_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
         .build()
 }
 
+pub fn pool_submit_with_review_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_submit_with_review")
+        .title("Fire a Task with Review Gate")
+        .description(
+            "Fire off a task that requires coordinator approval before completion. \
+             When the task finishes, it enters 'pending_review' state instead of 'completed'. \
+             Use pool_approve_result to accept or pool_reject_result to reject with feedback.",
+        )
+        .handler(move |input: SubmitWithReviewInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let config = task_config_from(input.model, input.effort, input.mcp_servers);
+                let tags = input.tags.unwrap_or_default();
+                match state
+                    .pool
+                    .submit_with_review(&input.prompt, config, tags, input.max_rejections)
+                    .await
+                {
+                    Ok(task_id) => Ok(CallToolResult::json(
+                        serde_json::json!({ "task_id": task_id.0, "review_required": true }),
+                    )),
+                    Err(e) => Ok(CallToolResult::error(e.to_string())),
+                }
+            }
+        })
+        .build()
+}
+
+pub fn pool_approve_result_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_approve_result")
+        .title("Approve Task Result")
+        .description(
+            "Approve a task that is pending review. Transitions the task from \
+             'pending_review' to 'completed'.",
+        )
+        .handler(move |input: ApproveResultInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let task_id = claude_pool::TaskId(input.task_id);
+                match state.pool.approve_result(&task_id).await {
+                    Ok(()) => Ok(CallToolResult::text("approved")),
+                    Err(e) => Ok(CallToolResult::error(e.to_string())),
+                }
+            }
+        })
+        .build()
+}
+
+pub fn pool_reject_result_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_reject_result")
+        .title("Reject Task Result")
+        .description(
+            "Reject a task that is pending review. The task is re-queued with the \
+             original prompt plus rejection feedback appended. If the task has been \
+             rejected max_rejections times, it is marked as failed.",
+        )
+        .handler(move |input: RejectResultInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let task_id = claude_pool::TaskId(input.task_id);
+                match state.pool.reject_result(&task_id, &input.feedback).await {
+                    Ok(()) => Ok(CallToolResult::text("rejected and re-queued")),
+                    Err(e) => Ok(CallToolResult::error(e.to_string())),
+                }
+            }
+        })
+        .build()
+}
+
 pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
     vec![
         pool_status_tool(Arc::clone(state)),
@@ -1459,5 +1591,8 @@ pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
         pool_skill_save_tool(Arc::clone(state)),
         pool_skill_eject_tool(Arc::clone(state)),
         pool_claim_tool(Arc::clone(state)),
+        pool_submit_with_review_tool(Arc::clone(state)),
+        pool_approve_result_tool(Arc::clone(state)),
+        pool_reject_result_tool(Arc::clone(state)),
     ]
 }

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -250,6 +250,10 @@ impl<S: PoolStore + 'static> Pool<S> {
             result: None,
             tags: vec![],
             config: task_config,
+            review_required: false,
+            max_rejections: 3,
+            rejection_count: 0,
+            original_prompt: None,
         };
         self.inner.store.put_task(record).await?;
 
@@ -307,6 +311,10 @@ impl<S: PoolStore + 'static> Pool<S> {
             result: None,
             tags: vec![],
             config: task_config,
+            review_required: false,
+            max_rejections: 3,
+            rejection_count: 0,
+            original_prompt: None,
         };
         self.inner.store.put_task(record).await?;
 
@@ -366,6 +374,10 @@ impl<S: PoolStore + 'static> Pool<S> {
             result: None,
             tags,
             config: task_config,
+            review_required: false,
+            max_rejections: 3,
+            rejection_count: 0,
+            original_prompt: None,
         };
         self.inner.store.put_task(record).await?;
 
@@ -430,6 +442,245 @@ impl<S: PoolStore + 'static> Pool<S> {
         Ok(task_id)
     }
 
+    /// Submit a task that requires coordinator review before completion.
+    ///
+    /// When the task finishes execution, it transitions to `PendingReview` instead
+    /// of `Completed`. Use [`Pool::approve_result`] to accept or [`Pool::reject_result`]
+    /// to reject with feedback and re-queue.
+    pub async fn submit_with_review(
+        &self,
+        prompt: &str,
+        task_config: Option<SlotConfig>,
+        tags: Vec<String>,
+        max_rejections: Option<u32>,
+    ) -> Result<TaskId> {
+        self.check_shutdown()?;
+        self.check_budget()?;
+
+        let task_id = TaskId(format!("task-{}", new_id()));
+        let prompt = prompt.to_string();
+        let max_rej = max_rejections.unwrap_or(3);
+
+        let record = TaskRecord {
+            id: task_id.clone(),
+            prompt: prompt.clone(),
+            state: TaskState::Pending,
+            slot_id: None,
+            result: None,
+            tags,
+            config: task_config,
+            review_required: true,
+            max_rejections: max_rej,
+            rejection_count: 0,
+            original_prompt: Some(prompt.clone()),
+        };
+        self.inner.store.put_task(record).await?;
+
+        // Spawn the task execution in the background.
+        let pool = self.clone();
+        let tid = task_id.clone();
+        tokio::spawn(async move {
+            let task = match pool.inner.store.get_task(&tid).await {
+                Ok(Some(t)) => t,
+                _ => return,
+            };
+
+            match pool.assign_slot(&tid).await {
+                Ok((slot_id, slot_config)) => {
+                    let result = pool
+                        .execute_task(&tid, &task.prompt, &slot_id, &slot_config, None)
+                        .await;
+
+                    let _ = pool.release_slot(&slot_id, &tid, &result).await;
+
+                    let mut updated = task;
+                    match result {
+                        Ok(task_result) => {
+                            // review_required: go to PendingReview instead of Completed
+                            if updated.review_required {
+                                updated.state = TaskState::PendingReview;
+                            } else {
+                                updated.state = TaskState::Completed;
+                            }
+                            updated.result = Some(task_result);
+                        }
+                        Err(e) => {
+                            let details = extract_failure_details(&e);
+                            updated.state = TaskState::Failed;
+                            updated.result = Some(TaskResult {
+                                output: e.to_string(),
+                                success: false,
+                                cost_microdollars: 0,
+                                turns_used: 0,
+                                session_id: None,
+                                failed_command: details.failed_command,
+                                exit_code: details.exit_code,
+                                stderr: details.stderr,
+                            });
+                        }
+                    }
+                    let _ = pool.inner.store.put_task(updated).await;
+                }
+                Err(e) => {
+                    let mut updated = task;
+                    updated.state = TaskState::Failed;
+                    updated.result = Some(TaskResult {
+                        output: e.to_string(),
+                        success: false,
+                        cost_microdollars: 0,
+                        turns_used: 0,
+                        session_id: None,
+                        failed_command: None,
+                        exit_code: None,
+                        stderr: None,
+                    });
+                    let _ = pool.inner.store.put_task(updated).await;
+                }
+            }
+        });
+
+        Ok(task_id)
+    }
+
+    /// Approve a task that is pending review, transitioning it to `Completed`.
+    pub async fn approve_result(&self, task_id: &TaskId) -> Result<()> {
+        let mut task = self
+            .inner
+            .store
+            .get_task(task_id)
+            .await?
+            .ok_or_else(|| Error::TaskNotFound(task_id.0.clone()))?;
+
+        if task.state != TaskState::PendingReview {
+            return Err(Error::Store(format!(
+                "task {} is not pending review (state: {:?})",
+                task_id.0, task.state
+            )));
+        }
+
+        task.state = TaskState::Completed;
+        self.inner.store.put_task(task).await
+    }
+
+    /// Reject a task that is pending review, re-queuing it with feedback appended.
+    ///
+    /// The original prompt is preserved and the feedback is appended. If the
+    /// rejection count reaches `max_rejections`, the task is marked as `Failed`.
+    pub async fn reject_result(&self, task_id: &TaskId, feedback: &str) -> Result<()> {
+        let mut task = self
+            .inner
+            .store
+            .get_task(task_id)
+            .await?
+            .ok_or_else(|| Error::TaskNotFound(task_id.0.clone()))?;
+
+        if task.state != TaskState::PendingReview {
+            return Err(Error::Store(format!(
+                "task {} is not pending review (state: {:?})",
+                task_id.0, task.state
+            )));
+        }
+
+        task.rejection_count += 1;
+
+        if task.rejection_count >= task.max_rejections {
+            task.state = TaskState::Failed;
+            task.result = Some(TaskResult {
+                output: format!(
+                    "task rejected {} times (max: {}). Last feedback: {}",
+                    task.rejection_count, task.max_rejections, feedback
+                ),
+                success: false,
+                cost_microdollars: 0,
+                turns_used: 0,
+                session_id: None,
+                failed_command: None,
+                exit_code: None,
+                stderr: None,
+            });
+            self.inner.store.put_task(task).await?;
+            return Ok(());
+        }
+
+        // Rebuild prompt: original + rejection feedback
+        let original = task
+            .original_prompt
+            .clone()
+            .unwrap_or_else(|| task.prompt.clone());
+        task.prompt = format!(
+            "{}\n\n--- Rejection feedback (attempt {}/{}) ---\n{}",
+            original, task.rejection_count, task.max_rejections, feedback
+        );
+        task.state = TaskState::Pending;
+        task.slot_id = None;
+        task.result = None;
+        self.inner.store.put_task(task.clone()).await?;
+
+        // Re-execute in background (same pattern as submit).
+        let pool = self.clone();
+        let tid = task_id.clone();
+        tokio::spawn(async move {
+            let task = match pool.inner.store.get_task(&tid).await {
+                Ok(Some(t)) => t,
+                _ => return,
+            };
+
+            match pool.assign_slot(&tid).await {
+                Ok((slot_id, slot_config)) => {
+                    let result = pool
+                        .execute_task(&tid, &task.prompt, &slot_id, &slot_config, None)
+                        .await;
+
+                    let _ = pool.release_slot(&slot_id, &tid, &result).await;
+
+                    let mut updated = task;
+                    match result {
+                        Ok(task_result) => {
+                            if updated.review_required {
+                                updated.state = TaskState::PendingReview;
+                            } else {
+                                updated.state = TaskState::Completed;
+                            }
+                            updated.result = Some(task_result);
+                        }
+                        Err(e) => {
+                            let details = extract_failure_details(&e);
+                            updated.state = TaskState::Failed;
+                            updated.result = Some(TaskResult {
+                                output: e.to_string(),
+                                success: false,
+                                cost_microdollars: 0,
+                                turns_used: 0,
+                                session_id: None,
+                                failed_command: details.failed_command,
+                                exit_code: details.exit_code,
+                                stderr: details.stderr,
+                            });
+                        }
+                    }
+                    let _ = pool.inner.store.put_task(updated).await;
+                }
+                Err(e) => {
+                    let mut updated = task;
+                    updated.state = TaskState::Failed;
+                    updated.result = Some(TaskResult {
+                        output: e.to_string(),
+                        success: false,
+                        cost_microdollars: 0,
+                        turns_used: 0,
+                        session_id: None,
+                        failed_command: None,
+                        exit_code: None,
+                        stderr: None,
+                    });
+                    let _ = pool.inner.store.put_task(updated).await;
+                }
+            }
+        });
+
+        Ok(())
+    }
+
     /// Get the result of a submitted task.
     ///
     /// Returns `None` if the task is still pending/running.
@@ -442,7 +693,7 @@ impl<S: PoolStore + 'static> Pool<S> {
             .ok_or_else(|| Error::TaskNotFound(task_id.0.clone()))?;
 
         match task.state {
-            TaskState::Completed | TaskState::Failed => Ok(task.result),
+            TaskState::Completed | TaskState::Failed | TaskState::PendingReview => Ok(task.result),
             _ => Ok(None),
         }
     }
@@ -457,7 +708,7 @@ impl<S: PoolStore + 'static> Pool<S> {
             .ok_or_else(|| Error::TaskNotFound(task_id.0.clone()))?;
 
         match task.state {
-            TaskState::Pending => {
+            TaskState::Pending | TaskState::PendingReview => {
                 task.state = TaskState::Cancelled;
                 self.inner.store.put_task(task).await?;
                 Ok(())
@@ -643,6 +894,10 @@ impl<S: PoolStore + 'static> Pool<S> {
             result: None,
             tags: options.tags,
             config: None,
+            review_required: false,
+            max_rejections: 3,
+            rejection_count: 0,
+            original_prompt: None,
         };
         self.inner.store.put_task(record).await?;
 
@@ -1096,12 +1351,23 @@ impl<S: PoolStore + 'static> Pool<S> {
             .await?
             .len();
 
+        let pending_review_tasks = self
+            .inner
+            .store
+            .list_tasks(&TaskFilter {
+                state: Some(TaskState::PendingReview),
+                ..Default::default()
+            })
+            .await?
+            .len();
+
         Ok(PoolStatus {
             total_slots: slots.len(),
             idle_slots: idle,
             busy_slots: busy,
             running_tasks,
             pending_tasks,
+            pending_review_tasks,
             total_spend_microdollars: self.inner.total_spend.load(Ordering::Relaxed),
             budget_microdollars: self.inner.config.budget_microdollars,
             shutdown: self.inner.shutdown.load(Ordering::Relaxed),
@@ -1799,6 +2065,8 @@ pub struct PoolStatus {
     pub running_tasks: usize,
     /// Number of pending (queued) tasks.
     pub pending_tasks: usize,
+    /// Number of tasks awaiting coordinator review.
+    pub pending_review_tasks: usize,
     /// Total spend in microdollars.
     pub total_spend_microdollars: u64,
     /// Budget cap in microdollars, if set.
@@ -2497,6 +2765,10 @@ mod tests {
             result: None,
             tags: vec![],
             config: None,
+            review_required: false,
+            max_rejections: 3,
+            rejection_count: 0,
+            original_prompt: None,
         };
         pool.store().put_task(record).await.unwrap();
 
@@ -2549,6 +2821,10 @@ mod tests {
             }),
             tags: vec![],
             config: None,
+            review_required: false,
+            max_rejections: 3,
+            rejection_count: 0,
+            original_prompt: None,
         };
         pool.store().put_task(record).await.unwrap();
 

--- a/crates/claude-pool/src/store.rs
+++ b/crates/claude-pool/src/store.rs
@@ -134,6 +134,10 @@ mod tests {
             result: None,
             tags: vec!["testing".into()],
             config: None,
+            review_required: false,
+            max_rejections: 3,
+            rejection_count: 0,
+            original_prompt: None,
         };
 
         store.put_task(record).await.unwrap();
@@ -200,6 +204,10 @@ mod tests {
                     result: None,
                     tags: vec![],
                     config: None,
+                    review_required: false,
+                    max_rejections: 3,
+                    rejection_count: 0,
+                    original_prompt: None,
                 })
                 .await
                 .unwrap();

--- a/crates/claude-pool/src/types.rs
+++ b/crates/claude-pool/src/types.rs
@@ -253,6 +253,8 @@ pub enum TaskState {
     Failed,
     /// Task was cancelled.
     Cancelled,
+    /// Task completed but awaits coordinator approval before being considered done.
+    PendingReview,
 }
 
 /// A task submitted to the pool.
@@ -278,6 +280,26 @@ pub struct TaskRecord {
 
     /// Per-task config overrides (takes precedence over slot and global config).
     pub config: Option<SlotConfig>,
+
+    /// When true, completed tasks transition to `PendingReview` instead of `Completed`.
+    #[serde(default)]
+    pub review_required: bool,
+
+    /// Maximum number of rejections before the task is marked as failed (default: 3).
+    #[serde(default = "default_max_rejections")]
+    pub max_rejections: u32,
+
+    /// Number of times this task has been rejected and re-queued.
+    #[serde(default)]
+    pub rejection_count: u32,
+
+    /// The original prompt before any rejection feedback was appended.
+    #[serde(default)]
+    pub original_prompt: Option<String>,
+}
+
+fn default_max_rejections() -> u32 {
+    3
 }
 
 /// The result of a completed task.


### PR DESCRIPTION
## Summary

- Add `PendingReview` task state and coordinator review workflow to claude-pool
- Tasks submitted via `pool_submit_with_review` transition to `PendingReview` on completion instead of `Completed`
- Coordinators use `pool_approve_result` to accept or `pool_reject_result` to reject with feedback and re-queue
- Rejection retry limit (`max_rejections`, default 3) prevents infinite reject loops
- `pool_result` response now includes task state and review metadata for review-gated tasks

## Test plan

- [ ] Verify `cargo test --lib --all-features` passes (81 tests)
- [ ] Verify `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [ ] Verify `cargo doc --no-deps --all-features` builds without warnings
- [ ] Integration test: submit with review, check result shows `pending_review` state
- [ ] Integration test: approve transitions to `completed`
- [ ] Integration test: reject re-queues with feedback appended, increments rejection_count
- [ ] Integration test: rejecting at max_rejections marks task as `failed`

Closes #168