### PR TITLE
fix: rewrite coordinator skill prompts for haiku compatibility

### DIFF
--- a/crates/claude-pool/skills/chain_watcher/SKILL.md
+++ b/crates/claude-pool/skills/chain_watcher/SKILL.md
@@ -12,33 +12,37 @@ metadata:
       required: false
 ---
 
-Monitor active chains and report progress changes.
+Execute the following monitoring steps and report the results. Do NOT create files, scripts, or skills. Do NOT modify any code. Only query data and report.
 
-## Step 1: Gather State
+## Immediate Action: Gather Current State
 
-1. Get previous state: `context_get` key: `chain_watcher_state`
-2. Get the list of chain task IDs to watch from the previous state, or from the arguments if this is the first run.
-3. For each chain ID, call `pool_chain_result` to get current progress.
+Start by getting the previous state: call `context_get` key: `chain_watcher_state`.
+
+Use the list of chain task IDs from the previous state, or from the arguments if this is the first run. For each chain ID, call `pool_chain_result` to get current progress.
+
+## Step 1: Retrieve and Prepare Chain Data
+
+Load the chain IDs to watch (from context state on repeat runs, or from arguments on the first run). Query each chain's current progress.
 
 ## Step 2: Detect Changes
 
-For each chain, compare current vs previous:
+For each chain, compare current vs previous state:
 - **Step transitions**: step N completed, step N+1 started
 - **Completions**: chain finished (success or failure)
 - **Cost accumulation**: new spend since last check
 - **Retries**: if a step used retries, note it
 - **Failures**: step failed, chain stopped
 
-## Step 3: Format Output
+## Step 3: Format and Report Output
 
-Compact per-chain status line:
+Generate a compact per-chain status line for each:
 ```
 chain-abc: [3/5] running "test" ($0.08)
 chain-def: [5/5] completed ($0.15)
 chain-ghi: [2/4] FAILED at "build" ($0.04)
 ```
 
-If changes since last check, add details:
+If changes since last check, add a details section:
 ```
 Changes:
 - chain-abc: step "lint" completed (0 retries), started "test"
@@ -47,9 +51,9 @@ Changes:
 
 If no changes: show status lines with "(no changes)".
 
-## Step 4: Store State
+## Step 4: Store Updated State
 
-Call `context_set` key: `chain_watcher_state` with JSON:
+Call `context_set` key: `chain_watcher_state` with this JSON structure:
 ```json
 {
   "chain_ids": ["chain-abc", "chain-def"],
@@ -60,8 +64,10 @@ Call `context_set` key: `chain_watcher_state` with JSON:
 }
 ```
 
-## Usage
+Completed/failed chains are kept in the report until removed.
+
+## Usage Examples
 
 `/loop 1m pool_skill_run skill: "chain_watcher" arguments: { "chain_ids": "chain-abc,chain-def" }`
 
-On subsequent iterations, chain IDs are loaded from context state. Completed/failed chains are kept in the report until removed.
+On subsequent iterations, chain IDs are loaded from context state automatically.

--- a/crates/claude-pool/skills/loop_monitor/SKILL.md
+++ b/crates/claude-pool/skills/loop_monitor/SKILL.md
@@ -16,25 +16,28 @@ metadata:
       required: false
 ---
 
-Monitor GitHub PRs in {repo}{filters_note} and report only changes.
+Execute the following monitoring steps and report the results. Do NOT create files, scripts, or skills. Do NOT modify any code. Only query data and report.
 
-## Workflow
+## Immediate Action: Fetch Current PR State
 
-### 1. Fetch Current State
+Start by running this command:
 ```bash
 gh pr list -R {repo} {filters} --json number,title,state,statusCheckRollup,reviewDecision,labels,updatedAt --limit 100
 ```
 
-Parse as JSON array of PRs. Each PR needs: number, title, state (OPEN/DRAFT/MERGED/CLOSED), statusCheckRollup (PENDING/FAILURE/SUCCESS/NEUTRAL), reviewDecision (APPROVE/REQUEST_CHANGES/REVIEW_REQUIRED/COMMENTED), labels (array), updatedAt (timestamp).
+Parse as JSON array. Each PR needs: number, title, state (OPEN/DRAFT/MERGED/CLOSED), statusCheckRollup (PENDING/FAILURE/SUCCESS/NEUTRAL), reviewDecision (APPROVE/REQUEST_CHANGES/REVIEW_REQUIRED/COMMENTED), labels (array), updatedAt (timestamp).
 
-### 2. Retrieve Previous State
+## Step 1: Retrieve Previous State
+
 Use mcp context_get key: "loop_monitor_state_{repo_slug}".
 
-If nothing found, store current state and report:
+If nothing found, store the current state and report:
 "Initial snapshot of {repo}. {count} PRs. Monitoring now."
 Then exit.
 
-### 3. Diff: Identify Only Meaningful Changes
+## Step 2: Diff and Identify Only Meaningful Changes
+
+Compare current state vs previous:
 
 **New PRs** (in current, not in previous):
 - Report: "NEW #{number}: {title} ({state})"
@@ -59,7 +62,7 @@ Then exit.
 
 Skip cosmetic changes (comment count, updatedAt alone).
 
-### 4. Format Output
+## Step 3: Format and Report Output
 
 If changes found:
 ```
@@ -76,7 +79,8 @@ If no changes:
 No changes to {repo}.
 ```
 
-### 5. Store New State
+## Step 4: Store New State
+
 Use mcp context_set key: "loop_monitor_state_{repo_slug}" with compact JSON:
 ```json
 {
@@ -93,6 +97,6 @@ If `gh pr list` fails:
 - Report: "Failed to fetch PRs: {error}"
 - Don't update context
 
-## Usage
+## Usage Examples
 
 `/loop 5m pool_skill_run skill: "loop_monitor" arguments: { "repo": "owner/repo", "filters": "is:draft" }`

--- a/crates/claude-pool/skills/pool_dashboard/SKILL.md
+++ b/crates/claude-pool/skills/pool_dashboard/SKILL.md
@@ -8,7 +8,9 @@ metadata:
   scope: coordinator
 ---
 
-Generate a pool health dashboard. Compare against previous state and report changes.
+Execute the following monitoring steps and report the results.
+
+**GUARDRAIL: Do NOT create files, scripts, or skills. Do NOT modify any code. Only query status and report.**
 
 ## Step 1: Gather Current State
 


### PR DESCRIPTION
## Summary

- Rewrite `pool_dashboard`, `loop_monitor`, and `chain_watcher` skill prompts to be imperative
- Haiku was interpreting "Generate a dashboard" as "create dashboard code" instead of executing monitoring steps
- Add guardrails: "Do NOT create files, scripts, or skills. Do NOT modify any code."
- Front-load first concrete action in each skill

Closes #184.

## Test plan

- [x] `builtins_load` test passes (all SKILL.md files parse correctly)
- [x] fmt, clippy, all 81 lib tests pass
- [ ] Manual: run `pool_skill_run skill: "pool_dashboard"` on haiku and verify it queries status instead of creating files