### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.3.2](https://github.com/joshrotenberg/claude-wrapper/compare/v0.3.1...v0.3.2) - 2026-03-12
+
+### Fixed
+
+- streaming timeout + gitignore .claude-pool ([#202](https://github.com/joshrotenberg/claude-wrapper/pull/202))
+
 ## [0.3.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.3.0...v0.3.1) - 2026-03-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-pool"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "claude-pool-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -306,6 +306,7 @@ dependencies = [
  "claude-pool",
  "claude-wrapper",
  "dirs",
+ "http-body-util",
  "schemars",
  "serde",
  "serde_json",
@@ -321,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "claude-wrapper"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/joshrotenberg/claude-wrapper"
 
 [workspace.dependencies]
 claude-wrapper = { path = "crates/claude-wrapper", version = "0.3" }
-claude-pool = { path = "crates/claude-pool", version = "0.3" }
+claude-pool = { path = "crates/claude-pool", version = "0.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/claude-pool-server/CHANGELOG.md
+++ b/crates/claude-pool-server/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-server-v0.3.0...claude-pool-server-v0.3.1) - 2026-03-12
+
+### Added
+
+- task execution metrics, session aggregation, and REST/MCP endpoints ([#216](https://github.com/joshrotenberg/claude-wrapper/pull/216))
+- REST API Phase 4 — auth, concurrency limiting, webhooks, tests ([#214](https://github.com/joshrotenberg/claude-wrapper/pull/214))
+- SSE streaming endpoints for REST API (Phase 2) ([#213](https://github.com/joshrotenberg/claude-wrapper/pull/213))
+- REST API scaffold (Phase 1) ([#211](https://github.com/joshrotenberg/claude-wrapper/pull/211))
+
+### Fixed
+
+- suppress unexpected_cfgs warnings for rest feature ([#212](https://github.com/joshrotenberg/claude-wrapper/pull/212))
+
+### Other
+
+- TaskOverrides + RunOptions builder ([#209](https://github.com/joshrotenberg/claude-wrapper/pull/209))
+- add comprehensive rustdoc to pool server tools ([#205](https://github.com/joshrotenberg/claude-wrapper/pull/205))
+
 ## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-server-v0.2.0...claude-pool-server-v0.3.0) - 2026-03-11
 
 ### Added

--- a/crates/claude-pool-server/Cargo.toml
+++ b/crates/claude-pool-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-pool-server"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/claude-pool/CHANGELOG.md
+++ b/crates/claude-pool/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.3.0...claude-pool-v0.4.0) - 2026-03-12
+
+### Added
+
+- task execution metrics, session aggregation, and REST/MCP endpoints ([#216](https://github.com/joshrotenberg/claude-wrapper/pull/216))
+- SSE streaming endpoints for REST API (Phase 2) ([#213](https://github.com/joshrotenberg/claude-wrapper/pull/213))
+
+### Other
+
+- TaskOverrides + RunOptions builder ([#209](https://github.com/joshrotenberg/claude-wrapper/pull/209))
+- organize lib.rs re-exports with prelude module ([#208](https://github.com/joshrotenberg/claude-wrapper/pull/208))
+- centralize ID generation ([#207](https://github.com/joshrotenberg/claude-wrapper/pull/207))
+- add comprehensive rustdoc to pool server tools ([#205](https://github.com/joshrotenberg/claude-wrapper/pull/205))
+
 ## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.2.0...claude-pool-v0.3.0) - 2026-03-11
 
 ### Added

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-pool"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `claude-pool`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `claude-pool-server`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

### ⚠ `claude-pool` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TaskResult.elapsed_ms in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:372
  field TaskResult.model in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:376
  field TaskResult.elapsed_ms in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:372
  field TaskResult.model in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:376
  field TaskRecord.created_at_ms in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:340
  field TaskRecord.started_at_ms in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:344
  field TaskRecord.completed_at_ms in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:348
  field TaskRecord.created_at_ms in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:340
  field TaskRecord.started_at_ms in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:344
  field TaskRecord.completed_at_ms in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/types.rs:348
  field PoolStatus.completed_tasks in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/pool.rs:1785
  field PoolStatus.failed_tasks in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/pool.rs:1787
  field PoolStatus.cancelled_tasks in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/pool.rs:1789
  field PoolStatus.completed_tasks in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/pool.rs:1785
  field PoolStatus.failed_tasks in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/pool.rs:1787
  field PoolStatus.cancelled_tasks in /tmp/.tmp0XPiQJ/claude-wrapper/crates/claude-pool/src/pool.rs:1789
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-wrapper`

<blockquote>

## [0.3.2](https://github.com/joshrotenberg/claude-wrapper/compare/v0.3.1...v0.3.2) - 2026-03-12

### Fixed

- streaming timeout + gitignore .claude-pool ([#202](https://github.com/joshrotenberg/claude-wrapper/pull/202))
</blockquote>

## `claude-pool`

<blockquote>

## [0.4.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.3.0...claude-pool-v0.4.0) - 2026-03-12

### Added

- task execution metrics, session aggregation, and REST/MCP endpoints ([#216](https://github.com/joshrotenberg/claude-wrapper/pull/216))
- SSE streaming endpoints for REST API (Phase 2) ([#213](https://github.com/joshrotenberg/claude-wrapper/pull/213))

### Other

- TaskOverrides + RunOptions builder ([#209](https://github.com/joshrotenberg/claude-wrapper/pull/209))
- organize lib.rs re-exports with prelude module ([#208](https://github.com/joshrotenberg/claude-wrapper/pull/208))
- centralize ID generation ([#207](https://github.com/joshrotenberg/claude-wrapper/pull/207))
- add comprehensive rustdoc to pool server tools ([#205](https://github.com/joshrotenberg/claude-wrapper/pull/205))
</blockquote>

## `claude-pool-server`

<blockquote>

## [0.3.1](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-server-v0.3.0...claude-pool-server-v0.3.1) - 2026-03-12

### Added

- task execution metrics, session aggregation, and REST/MCP endpoints ([#216](https://github.com/joshrotenberg/claude-wrapper/pull/216))
- REST API Phase 4 — auth, concurrency limiting, webhooks, tests ([#214](https://github.com/joshrotenberg/claude-wrapper/pull/214))
- SSE streaming endpoints for REST API (Phase 2) ([#213](https://github.com/joshrotenberg/claude-wrapper/pull/213))
- REST API scaffold (Phase 1) ([#211](https://github.com/joshrotenberg/claude-wrapper/pull/211))

### Fixed

- suppress unexpected_cfgs warnings for rest feature ([#212](https://github.com/joshrotenberg/claude-wrapper/pull/212))

### Other

- TaskOverrides + RunOptions builder ([#209](https://github.com/joshrotenberg/claude-wrapper/pull/209))
- add comprehensive rustdoc to pool server tools ([#205](https://github.com/joshrotenberg/claude-wrapper/pull/205))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).