### PR TITLE
refactor: extract executor.rs and cli_parsing.rs from pool.rs

### DIFF
--- a/crates/claude-pool/src/cli_parsing.rs
+++ b/crates/claude-pool/src/cli_parsing.rs
@@ -1,0 +1,124 @@
+//! CLI output parsing helpers — pure functions, no pool state.
+//!
+//! These helpers parse CLI output, detect permission prompts, and extract
+//! structured failure information from errors. All functions are stateless
+//! and depend only on their arguments.
+
+use crate::error::Error;
+
+/// Generate a short unique ID based on the current timestamp.
+pub(crate) fn new_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{nanos:x}")
+}
+
+// ── Permission prompt detection ─────────────────────────────────────
+
+/// Patterns in stderr that indicate the CLI is waiting for permission/tool approval.
+pub(crate) const PERMISSION_PATTERNS: &[&str] = &[
+    "Allow",
+    "allow this action",
+    "approve",
+    "permission",
+    "Do you want to",
+    "tool requires approval",
+    "wants to use",
+    "Press Enter",
+    "y/n",
+    "Y/n",
+    "(yes/no)",
+];
+
+/// Structured failure details extracted from an error.
+pub(crate) struct FailureDetails {
+    pub(crate) failed_command: Option<String>,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) stderr: Option<String>,
+}
+
+/// Extract structured failure details from a pool error.
+///
+/// When the error wraps a `CommandFailed`, we capture the command, exit code,
+/// and stderr so callers get actionable diagnostics.
+pub(crate) fn extract_failure_details(err: &Error) -> FailureDetails {
+    match err {
+        Error::Wrapper(claude_wrapper::Error::CommandFailed {
+            command,
+            exit_code,
+            stderr,
+            ..
+        }) => FailureDetails {
+            failed_command: Some(command.clone()),
+            exit_code: Some(*exit_code),
+            stderr: if stderr.is_empty() {
+                None
+            } else {
+                Some(stderr.clone())
+            },
+        },
+        _ => FailureDetails {
+            failed_command: None,
+            exit_code: None,
+            stderr: None,
+        },
+    }
+}
+
+/// Inspect a claude-wrapper error for signs of a permission prompt.
+///
+/// Returns `Some(Error::PermissionPromptDetected)` if the stderr in a
+/// `CommandFailed` error contains permission prompt patterns.
+pub(crate) fn detect_permission_prompt(
+    err: &claude_wrapper::Error,
+    slot_id: &str,
+) -> Option<Error> {
+    let stderr = match err {
+        claude_wrapper::Error::CommandFailed { stderr, .. } => stderr,
+        _ => return None,
+    };
+
+    if stderr.is_empty() {
+        return None;
+    }
+
+    for pattern in PERMISSION_PATTERNS {
+        if stderr.contains(pattern) {
+            let tool_name = extract_tool_name(stderr);
+            tracing::warn!(
+                slot_id,
+                tool = %tool_name,
+                "permission prompt detected in slot stderr"
+            );
+            return Some(Error::PermissionPromptDetected {
+                tool_name,
+                stderr: stderr.clone(),
+                slot_id: slot_id.to_string(),
+            });
+        }
+    }
+
+    None
+}
+
+/// Best-effort extraction of the tool name from stderr text.
+pub(crate) fn extract_tool_name(stderr: &str) -> String {
+    for line in stderr.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("Allow ")
+            && let Some(tool) = rest.split_whitespace().next()
+        {
+            return tool.trim_end_matches('?').to_string();
+        }
+        if let Some(idx) = trimmed.find("wants to use ") {
+            let after = &trimmed[idx + "wants to use ".len()..];
+            if let Some(tool) = after.split_whitespace().next() {
+                return tool.trim_end_matches(['.', '?', ',']).to_string();
+            }
+        }
+    }
+    "unknown".to_string()
+}

--- a/crates/claude-pool/src/executor.rs
+++ b/crates/claude-pool/src/executor.rs
@@ -1,0 +1,458 @@
+//! Task execution helpers — core Claude CLI invocation logic.
+//!
+//! These functions handle the low-level work of building commands, managing
+//! per-slot MCP config files, and invoking the Claude CLI. They operate on
+//! `&PoolInner<S>` directly so they can be called from pool.rs without going
+//! through the public `Pool<S>` API.
+
+use std::path::Path;
+
+use claude_wrapper::types::OutputFormat;
+
+use crate::cli_parsing::detect_permission_prompt;
+use crate::config::ResolvedConfig;
+use crate::error::Result;
+use crate::pool::PoolInner;
+use crate::store::PoolStore;
+use crate::types::*;
+
+/// Drain pending messages for a slot and prepend them to a prompt.
+///
+/// If the slot has pending messages, they are consumed (removed from inbox)
+/// and formatted as a preamble before the actual task prompt. This provides
+/// automatic message delivery at task boundaries without requiring polling.
+pub(crate) fn prepend_messages<S: PoolStore>(
+    inner: &PoolInner<S>,
+    slot_id: &SlotId,
+    prompt: &str,
+) -> String {
+    let messages = inner.message_bus.read(slot_id);
+    if messages.is_empty() {
+        return prompt.to_string();
+    }
+
+    let mut preamble = String::from("## Messages received while idle\n\n");
+    for msg in &messages {
+        preamble.push_str(&format!(
+            "**From {}** ({}): {}\n\n",
+            msg.from.0,
+            msg.timestamp.format("%H:%M:%S"),
+            msg.content
+        ));
+    }
+    preamble.push_str("---\n\n");
+    preamble.push_str(prompt);
+    preamble
+}
+
+/// Build the system prompt by combining slot identity, resolved config and context.
+pub(crate) fn build_system_prompt<S: PoolStore>(
+    inner: &PoolInner<S>,
+    resolved: &ResolvedConfig,
+    slot_config: &SlotConfig,
+) -> Option<String> {
+    let context_entries: Vec<_> = inner
+        .context
+        .iter()
+        .map(|r| (r.key().clone(), r.value().clone()))
+        .collect();
+
+    // Check if there's any content to include
+    let has_identity = slot_config.name.is_some()
+        || slot_config.role.is_some()
+        || slot_config.description.is_some();
+
+    if resolved.system_prompt.is_none() && context_entries.is_empty() && !has_identity {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+
+    // Inject slot identity
+    if has_identity {
+        let mut identity = String::new();
+        identity.push_str("You are ");
+
+        if let Some(ref name) = slot_config.name {
+            identity.push_str(name);
+        } else {
+            identity.push_str("a slot");
+        }
+
+        if let Some(ref role) = slot_config.role {
+            identity.push_str(", a ");
+            identity.push_str(role);
+        }
+
+        if let Some(ref description) = slot_config.description {
+            identity.push_str(". ");
+            identity.push_str(description);
+        } else if slot_config.role.is_some() {
+            identity.push('.');
+        }
+
+        parts.push(identity);
+    }
+
+    if let Some(ref sp) = resolved.system_prompt {
+        parts.push(sp.clone());
+    }
+
+    if !context_entries.is_empty() {
+        parts.push("\n\n## Shared Context\n".to_string());
+        for (key, value) in &context_entries {
+            parts.push(format!("- **{key}**: {value}"));
+        }
+    }
+
+    Some(parts.join("\n"))
+}
+
+/// Ensure a per-slot MCP config temp file exists. Writes a new one on first
+/// call for a given slot, then reuses the stored path on subsequent calls.
+///
+/// Returns the path to the temp file.
+pub(crate) async fn ensure_slot_mcp_config<S: PoolStore>(
+    inner: &PoolInner<S>,
+    slot_id: &SlotId,
+    servers: &std::collections::HashMap<String, serde_json::Value>,
+) -> Result<std::path::PathBuf> {
+    // Check if this slot already has a temp file.
+    if let Some(slot) = inner.store.get_slot(slot_id).await?
+        && let Some(ref path) = slot.mcp_config_path
+    {
+        // Re-write the file in case servers changed (task-level overrides).
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "mcpServers": servers
+        }))?;
+        std::fs::write(path, json)?;
+        return Ok(path.clone());
+    }
+
+    // First call for this slot — create a new temp file.
+    use std::io::Write as _;
+    let json = serde_json::to_string_pretty(&serde_json::json!({
+        "mcpServers": servers
+    }))?;
+    let mut file = tempfile::Builder::new()
+        .prefix(&format!("claude-pool-{}-", slot_id.0))
+        .suffix(".mcp.json")
+        .tempfile()?;
+    file.write_all(json.as_bytes())?;
+
+    // Persist the temp file (prevents deletion on drop) and store the path.
+    let path = file
+        .into_temp_path()
+        .keep()
+        .map_err(std::io::Error::other)?
+        .to_path_buf();
+
+    if let Some(mut slot) = inner.store.get_slot(slot_id).await? {
+        slot.mcp_config_path = Some(path.clone());
+        inner.store.put_slot(slot).await?;
+    }
+
+    tracing::debug!(
+        slot_id = %slot_id.0,
+        path = %path.display(),
+        servers = servers.len(),
+        "created slot MCP config"
+    );
+
+    Ok(path)
+}
+
+/// Execute a task on a specific slot by invoking the Claude CLI.
+pub(crate) async fn execute_task<S: PoolStore + 'static>(
+    inner: &PoolInner<S>,
+    task_id: &TaskId,
+    prompt: &str,
+    slot_id: &SlotId,
+    slot_config: &SlotConfig,
+    override_working_dir: Option<&Path>,
+) -> Result<TaskResult> {
+    let task_record = inner.store.get_task(task_id).await?;
+    let task_cfg = task_record.as_ref().and_then(|t| t.config.as_ref());
+
+    let resolved = ResolvedConfig::resolve(&inner.config, slot_config, task_cfg);
+
+    // Build the system prompt with identity and context injection.
+    let system_prompt = build_system_prompt(inner, &resolved, slot_config);
+
+    // Auto-deliver pending messages by prepending them to the prompt.
+    let effective_prompt = prepend_messages(inner, slot_id, prompt);
+
+    // Build and execute the query.
+    let mut cmd = claude_wrapper::QueryCommand::new(&effective_prompt)
+        .output_format(OutputFormat::Json)
+        .permission_mode(resolved.permission_mode);
+
+    if resolved.permission_mode == PermissionMode::BypassPermissions {
+        cmd = cmd.dangerously_skip_permissions();
+    }
+
+    if let Some(ref model) = resolved.model {
+        cmd = cmd.model(model);
+    }
+    if let Some(max_turns) = resolved.max_turns {
+        cmd = cmd.max_turns(max_turns);
+    }
+    if let Some(ref sp) = system_prompt {
+        cmd = cmd.system_prompt(sp);
+    }
+    if let Some(effort) = resolved.effort {
+        cmd = cmd.effort(effort);
+    }
+    if !resolved.allowed_tools.is_empty() {
+        cmd = cmd.allowed_tools(&resolved.allowed_tools);
+    }
+
+    // Write per-slot MCP config if servers are configured.
+    // Reuses an existing temp file if the slot already has one; otherwise
+    // writes a new one and stores the path on the slot record.
+    if !resolved.mcp_servers.is_empty() {
+        let mcp_path = ensure_slot_mcp_config(inner, slot_id, &resolved.mcp_servers).await?;
+        cmd = cmd.mcp_config(mcp_path.to_string_lossy());
+        if resolved.strict_mcp_config {
+            cmd = cmd.strict_mcp_config();
+        }
+    }
+
+    // Use override working dir, slot worktree, or default.
+    let claude_instance = if let Some(slot) = inner.store.get_slot(slot_id).await? {
+        // Resume session if the slot has one, but NOT when using an
+        // override working dir (clone isolation) — the session belongs
+        // to the original working directory and won't exist in the clone.
+        if override_working_dir.is_none()
+            && let Some(ref session_id) = slot.session_id
+        {
+            cmd = cmd.resume(session_id);
+        }
+
+        if let Some(dir) = override_working_dir {
+            inner.claude.with_working_dir(dir)
+        } else if let Some(ref wt_path) = slot.worktree_path {
+            inner.claude.with_working_dir(wt_path)
+        } else {
+            inner.claude.clone()
+        }
+    } else {
+        inner.claude.clone()
+    };
+
+    tracing::debug!(
+        slot_id = %slot_id.0,
+        model = ?resolved.model,
+        effort = ?resolved.effort,
+        mcp_servers = resolved.mcp_servers.len(),
+        "executing task"
+    );
+
+    let query_result = match cmd.execute_json(&claude_instance).await {
+        Ok(r) => r,
+        Err(e) if inner.config.detect_permission_prompts => {
+            if let Some(detected) = detect_permission_prompt(&e, &slot_id.0) {
+                return Err(detected);
+            }
+            return Err(e.into());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let cost_microdollars = query_result
+        .cost_usd
+        .map(|c| (c * 1_000_000.0) as u64)
+        .unwrap_or(0);
+
+    Ok(TaskResult {
+        output: query_result.result,
+        success: !query_result.is_error,
+        cost_microdollars,
+        turns_used: query_result.num_turns.unwrap_or(0),
+        session_id: Some(query_result.session_id),
+        failed_command: None,
+        exit_code: None,
+        stderr: None,
+    })
+}
+
+/// Execute a task with optional streaming output.
+///
+/// When `on_output` is `Some`, uses streaming execution (`stream-json` format)
+/// and calls the callback with each text chunk as it arrives. When `None`,
+/// falls back to the standard `execute_task` path.
+pub(crate) async fn execute_task_streaming<S: PoolStore + 'static>(
+    inner: &PoolInner<S>,
+    task_id: &TaskId,
+    prompt: &str,
+    slot_id: &SlotId,
+    slot_config: &SlotConfig,
+    on_output: Option<crate::chain::OnOutputChunk>,
+    override_working_dir: Option<&Path>,
+) -> Result<TaskResult> {
+    // If no streaming callback, use the standard non-streaming path.
+    let on_output = match on_output {
+        Some(cb) => cb,
+        None => {
+            return execute_task(
+                inner,
+                task_id,
+                prompt,
+                slot_id,
+                slot_config,
+                override_working_dir,
+            )
+            .await;
+        }
+    };
+
+    let task_record = inner.store.get_task(task_id).await?;
+    let task_cfg = task_record.as_ref().and_then(|t| t.config.as_ref());
+    let resolved = ResolvedConfig::resolve(&inner.config, slot_config, task_cfg);
+
+    let system_prompt = build_system_prompt(inner, &resolved, slot_config);
+
+    // Auto-deliver pending messages by prepending them to the prompt.
+    let effective_prompt = prepend_messages(inner, slot_id, prompt);
+
+    // Build the query with StreamJson format for streaming.
+    let mut cmd = claude_wrapper::QueryCommand::new(&effective_prompt)
+        .output_format(OutputFormat::StreamJson)
+        .permission_mode(resolved.permission_mode);
+
+    if resolved.permission_mode == PermissionMode::BypassPermissions {
+        cmd = cmd.dangerously_skip_permissions();
+    }
+    if let Some(ref model) = resolved.model {
+        cmd = cmd.model(model);
+    }
+    if let Some(max_turns) = resolved.max_turns {
+        cmd = cmd.max_turns(max_turns);
+    }
+    if let Some(ref sp) = system_prompt {
+        cmd = cmd.system_prompt(sp);
+    }
+    if let Some(effort) = resolved.effort {
+        cmd = cmd.effort(effort);
+    }
+    if !resolved.allowed_tools.is_empty() {
+        cmd = cmd.allowed_tools(&resolved.allowed_tools);
+    }
+
+    if !resolved.mcp_servers.is_empty() {
+        let mcp_path = ensure_slot_mcp_config(inner, slot_id, &resolved.mcp_servers).await?;
+        cmd = cmd.mcp_config(mcp_path.to_string_lossy());
+        if resolved.strict_mcp_config {
+            cmd = cmd.strict_mcp_config();
+        }
+    }
+
+    // Use override working dir (chain worktree) > slot worktree > default.
+    let claude_instance = if let Some(slot) = inner.store.get_slot(slot_id).await? {
+        // Skip session resumption in clone isolation — the session
+        // belongs to the original directory and won't exist in the clone.
+        if override_working_dir.is_none()
+            && let Some(ref session_id) = slot.session_id
+        {
+            cmd = cmd.resume(session_id);
+        }
+        if let Some(dir) = override_working_dir {
+            inner.claude.with_working_dir(dir)
+        } else if let Some(ref wt_path) = slot.worktree_path {
+            inner.claude.with_working_dir(wt_path)
+        } else {
+            inner.claude.clone()
+        }
+    } else {
+        inner.claude.clone()
+    };
+
+    tracing::debug!(
+        slot_id = %slot_id.0,
+        model = ?resolved.model,
+        effort = ?resolved.effort,
+        mcp_servers = resolved.mcp_servers.len(),
+        "executing task (streaming)"
+    );
+
+    // Collect the final result from stream events.
+    let mut result_text = String::new();
+    let mut session_id = String::new();
+    let mut cost_usd: Option<f64> = None;
+    let mut is_error = false;
+
+    let stream_result = claude_wrapper::streaming::stream_query(
+        &claude_instance,
+        &cmd,
+        |event: claude_wrapper::streaming::StreamEvent| {
+            match event.event_type() {
+                Some("result") => {
+                    if let Some(text) = event.result_text() {
+                        result_text = text.to_string();
+                    }
+                    if let Some(sid) = event.session_id() {
+                        session_id = sid.to_string();
+                    }
+                    cost_usd = event.cost_usd();
+                    is_error = event
+                        .data
+                        .get("is_error")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                }
+                Some("assistant") => {
+                    // Extract text from content blocks in assistant messages.
+                    // Content may be at top level or nested under message.
+                    let content_sources = [
+                        event.data.get("content"),
+                        event.data.get("message").and_then(|m| m.get("content")),
+                    ];
+                    for content in content_sources.into_iter().flatten() {
+                        for block in content.as_array().into_iter().flatten() {
+                            if block.get("type").and_then(|t| t.as_str()) == Some("text")
+                                && let Some(text) = block.get("text").and_then(|t| t.as_str())
+                            {
+                                on_output(text);
+                            }
+                        }
+                    }
+                }
+                Some("content_block_delta") => {
+                    // Handle incremental text deltas.
+                    if let Some(delta) = event.data.get("delta")
+                        && delta.get("type").and_then(|t| t.as_str()) == Some("text_delta")
+                        && let Some(text) = delta.get("text").and_then(|t| t.as_str())
+                    {
+                        on_output(text);
+                    }
+                }
+                _ => {}
+            }
+        },
+    )
+    .await;
+
+    match stream_result {
+        Ok(_) => {}
+        Err(e) if inner.config.detect_permission_prompts => {
+            if let Some(detected) = detect_permission_prompt(&e, &slot_id.0) {
+                return Err(detected);
+            }
+            return Err(e.into());
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    let cost_microdollars = cost_usd.map(|c| (c * 1_000_000.0) as u64).unwrap_or(0);
+
+    Ok(TaskResult {
+        output: result_text,
+        success: !is_error,
+        cost_microdollars,
+        turns_used: 0,
+        session_id: Some(session_id),
+        failed_command: None,
+        exit_code: None,
+        stderr: None,
+    })
+}

--- a/crates/claude-pool/src/lib.rs
+++ b/crates/claude-pool/src/lib.rs
@@ -19,8 +19,10 @@
 //! One server. N slots. Nothing else.
 
 pub mod chain;
+pub(crate) mod cli_parsing;
 pub mod config;
 pub mod error;
+pub(crate) mod executor;
 pub mod messaging;
 pub mod pool;
 pub mod skill;

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -29,9 +29,8 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::Mutex;
 
 use claude_wrapper::Claude;
-use claude_wrapper::types::OutputFormat;
 
-use crate::config::ResolvedConfig;
+use crate::cli_parsing::{extract_failure_details, new_id};
 use crate::error::{Error, Result};
 use crate::messaging::MessageBus;
 use crate::skill::SkillRegistry;
@@ -39,22 +38,22 @@ use crate::store::PoolStore;
 use crate::types::*;
 
 /// Shared pool state behind an `Arc`.
-struct PoolInner<S: PoolStore> {
-    claude: Claude,
-    config: PoolConfig,
-    store: S,
-    total_spend: AtomicU64,
-    shutdown: AtomicBool,
+pub(crate) struct PoolInner<S: PoolStore> {
+    pub(crate) claude: Claude,
+    pub(crate) config: PoolConfig,
+    pub(crate) store: S,
+    pub(crate) total_spend: AtomicU64,
+    pub(crate) shutdown: AtomicBool,
     /// Context key-value pairs injected into slot system prompts.
-    context: dashmap::DashMap<String, String>,
+    pub(crate) context: dashmap::DashMap<String, String>,
     /// Mutex for slot assignment to avoid races.
-    assignment_lock: Mutex<()>,
+    pub(crate) assignment_lock: Mutex<()>,
     /// Worktree manager, if worktree isolation is enabled.
-    worktree_manager: Option<crate::worktree::WorktreeManager>,
+    pub(crate) worktree_manager: Option<crate::worktree::WorktreeManager>,
     /// In-flight chain progress, keyed by task ID.
-    chain_progress: dashmap::DashMap<String, crate::chain::ChainProgress>,
+    pub(crate) chain_progress: dashmap::DashMap<String, crate::chain::ChainProgress>,
     /// Message bus for inter-slot communication.
-    message_bus: MessageBus,
+    pub(crate) message_bus: MessageBus,
 }
 
 /// A pool of Claude CLI slots.
@@ -258,15 +257,15 @@ impl<S: PoolStore + 'static> Pool<S> {
         self.inner.store.put_task(record).await?;
 
         let (slot_id, slot_config) = self.assign_slot(&task_id).await?;
-        let result = self
-            .execute_task(
-                &task_id,
-                prompt,
-                &slot_id,
-                &slot_config,
-                working_dir.as_deref(),
-            )
-            .await;
+        let result = crate::executor::execute_task(
+            &self.inner,
+            &task_id,
+            prompt,
+            &slot_id,
+            &slot_config,
+            working_dir.as_deref(),
+        )
+        .await;
 
         self.release_slot(&slot_id, &task_id, &result).await?;
 
@@ -319,16 +318,16 @@ impl<S: PoolStore + 'static> Pool<S> {
         self.inner.store.put_task(record).await?;
 
         let (slot_id, slot_config) = self.assign_slot(&task_id).await?;
-        let result = self
-            .execute_task_streaming(
-                &task_id,
-                prompt,
-                &slot_id,
-                &slot_config,
-                on_output,
-                working_dir.as_deref(),
-            )
-            .await;
+        let result = crate::executor::execute_task_streaming(
+            &self.inner,
+            &task_id,
+            prompt,
+            &slot_id,
+            &slot_config,
+            on_output,
+            working_dir.as_deref(),
+        )
+        .await;
 
         self.release_slot(&slot_id, &task_id, &result).await?;
 
@@ -392,9 +391,15 @@ impl<S: PoolStore + 'static> Pool<S> {
 
             match pool.assign_slot(&tid).await {
                 Ok((slot_id, slot_config)) => {
-                    let result = pool
-                        .execute_task(&tid, &prompt, &slot_id, &slot_config, None)
-                        .await;
+                    let result = crate::executor::execute_task(
+                        &pool.inner,
+                        &tid,
+                        &prompt,
+                        &slot_id,
+                        &slot_config,
+                        None,
+                    )
+                    .await;
 
                     let _ = pool.release_slot(&slot_id, &tid, &result).await;
 
@@ -487,9 +492,15 @@ impl<S: PoolStore + 'static> Pool<S> {
 
             match pool.assign_slot(&tid).await {
                 Ok((slot_id, slot_config)) => {
-                    let result = pool
-                        .execute_task(&tid, &task.prompt, &slot_id, &slot_config, None)
-                        .await;
+                    let result = crate::executor::execute_task(
+                        &pool.inner,
+                        &tid,
+                        &task.prompt,
+                        &slot_id,
+                        &slot_config,
+                        None,
+                    )
+                    .await;
 
                     let _ = pool.release_slot(&slot_id, &tid, &result).await;
 
@@ -627,9 +638,15 @@ impl<S: PoolStore + 'static> Pool<S> {
 
             match pool.assign_slot(&tid).await {
                 Ok((slot_id, slot_config)) => {
-                    let result = pool
-                        .execute_task(&tid, &task.prompt, &slot_id, &slot_config, None)
-                        .await;
+                    let result = crate::executor::execute_task(
+                        &pool.inner,
+                        &tid,
+                        &task.prompt,
+                        &slot_id,
+                        &slot_config,
+                        None,
+                    )
+                    .await;
 
                     let _ = pool.release_slot(&slot_id, &tid, &result).await;
 
@@ -779,9 +796,9 @@ impl<S: PoolStore + 'static> Pool<S> {
         let tid = task_id.clone();
         let sid = slot_id.clone();
         tokio::spawn(async move {
-            let result = pool
-                .execute_task(&tid, &prompt, &sid, &slot_config, None)
-                .await;
+            let result =
+                crate::executor::execute_task(&pool.inner, &tid, &prompt, &sid, &slot_config, None)
+                    .await;
 
             let _ = pool.release_slot(&sid, &tid, &result).await;
 
@@ -1238,31 +1255,6 @@ impl<S: PoolStore + 'static> Pool<S> {
         self.inner.message_bus.count(slot_id)
     }
 
-    /// Drain pending messages for a slot and prepend them to a prompt.
-    ///
-    /// If the slot has pending messages, they are consumed (removed from inbox)
-    /// and formatted as a preamble before the actual task prompt. This provides
-    /// automatic message delivery at task boundaries without requiring polling.
-    fn prepend_messages(&self, slot_id: &SlotId, prompt: &str) -> String {
-        let messages = self.inner.message_bus.read(slot_id);
-        if messages.is_empty() {
-            return prompt.to_string();
-        }
-
-        let mut preamble = String::from("## Messages received while idle\n\n");
-        for msg in &messages {
-            preamble.push_str(&format!(
-                "**From {}** ({}): {}\n\n",
-                msg.from.0,
-                msg.timestamp.format("%H:%M:%S"),
-                msg.content
-            ));
-        }
-        preamble.push_str("---\n\n");
-        preamble.push_str(prompt);
-        preamble
-    }
-
     /// Gracefully shut down the pool.
     ///
     /// Marks the pool as shut down so no new tasks are accepted,
@@ -1635,412 +1627,6 @@ impl<S: PoolStore + 'static> Pool<S> {
         }
         Ok(())
     }
-
-    /// Ensure a per-slot MCP config temp file exists. Writes a new one on first
-    /// call for a given slot, then reuses the stored path on subsequent calls.
-    ///
-    /// Returns the path to the temp file.
-    async fn ensure_slot_mcp_config(
-        &self,
-        slot_id: &SlotId,
-        servers: &std::collections::HashMap<String, serde_json::Value>,
-    ) -> Result<std::path::PathBuf> {
-        // Check if this slot already has a temp file.
-        if let Some(slot) = self.inner.store.get_slot(slot_id).await?
-            && let Some(ref path) = slot.mcp_config_path
-        {
-            // Re-write the file in case servers changed (task-level overrides).
-            let json = serde_json::to_string_pretty(&serde_json::json!({
-                "mcpServers": servers
-            }))?;
-            std::fs::write(path, json)?;
-            return Ok(path.clone());
-        }
-
-        // First call for this slot — create a new temp file.
-        use std::io::Write as _;
-        let json = serde_json::to_string_pretty(&serde_json::json!({
-            "mcpServers": servers
-        }))?;
-        let mut file = tempfile::Builder::new()
-            .prefix(&format!("claude-pool-{}-", slot_id.0))
-            .suffix(".mcp.json")
-            .tempfile()?;
-        file.write_all(json.as_bytes())?;
-
-        // Persist the temp file (prevents deletion on drop) and store the path.
-        let path = file
-            .into_temp_path()
-            .keep()
-            .map_err(std::io::Error::other)?
-            .to_path_buf();
-
-        if let Some(mut slot) = self.inner.store.get_slot(slot_id).await? {
-            slot.mcp_config_path = Some(path.clone());
-            self.inner.store.put_slot(slot).await?;
-        }
-
-        tracing::debug!(
-            slot_id = %slot_id.0,
-            path = %path.display(),
-            servers = servers.len(),
-            "created slot MCP config"
-        );
-
-        Ok(path)
-    }
-
-    /// Execute a task on a specific slot by invoking the Claude CLI.
-    async fn execute_task(
-        &self,
-        _task_id: &TaskId,
-        prompt: &str,
-        slot_id: &SlotId,
-        slot_config: &SlotConfig,
-        override_working_dir: Option<&std::path::Path>,
-    ) -> Result<TaskResult> {
-        let task_record = self.inner.store.get_task(_task_id).await?;
-        let task_cfg = task_record.as_ref().and_then(|t| t.config.as_ref());
-
-        let resolved = ResolvedConfig::resolve(&self.inner.config, slot_config, task_cfg);
-
-        // Build the system prompt with identity and context injection.
-        let system_prompt = self.build_system_prompt(&resolved, slot_config);
-
-        // Auto-deliver pending messages by prepending them to the prompt.
-        let effective_prompt = self.prepend_messages(slot_id, prompt);
-
-        // Build and execute the query.
-        let mut cmd = claude_wrapper::QueryCommand::new(&effective_prompt)
-            .output_format(OutputFormat::Json)
-            .permission_mode(resolved.permission_mode);
-
-        if resolved.permission_mode == PermissionMode::BypassPermissions {
-            cmd = cmd.dangerously_skip_permissions();
-        }
-
-        if let Some(ref model) = resolved.model {
-            cmd = cmd.model(model);
-        }
-        if let Some(max_turns) = resolved.max_turns {
-            cmd = cmd.max_turns(max_turns);
-        }
-        if let Some(ref sp) = system_prompt {
-            cmd = cmd.system_prompt(sp);
-        }
-        if let Some(effort) = resolved.effort {
-            cmd = cmd.effort(effort);
-        }
-        if !resolved.allowed_tools.is_empty() {
-            cmd = cmd.allowed_tools(&resolved.allowed_tools);
-        }
-
-        // Write per-slot MCP config if servers are configured.
-        // Reuses an existing temp file if the slot already has one; otherwise
-        // writes a new one and stores the path on the slot record.
-        if !resolved.mcp_servers.is_empty() {
-            let mcp_path = self
-                .ensure_slot_mcp_config(slot_id, &resolved.mcp_servers)
-                .await?;
-            cmd = cmd.mcp_config(mcp_path.to_string_lossy());
-            if resolved.strict_mcp_config {
-                cmd = cmd.strict_mcp_config();
-            }
-        }
-
-        // Use override working dir, slot worktree, or default.
-        let claude_instance = if let Some(slot) = self.inner.store.get_slot(slot_id).await? {
-            // Resume session if the slot has one, but NOT when using an
-            // override working dir (clone isolation) — the session belongs
-            // to the original working directory and won't exist in the clone.
-            if override_working_dir.is_none()
-                && let Some(ref session_id) = slot.session_id
-            {
-                cmd = cmd.resume(session_id);
-            }
-
-            if let Some(dir) = override_working_dir {
-                self.inner.claude.with_working_dir(dir)
-            } else if let Some(ref wt_path) = slot.worktree_path {
-                self.inner.claude.with_working_dir(wt_path)
-            } else {
-                self.inner.claude.clone()
-            }
-        } else {
-            self.inner.claude.clone()
-        };
-
-        tracing::debug!(
-            slot_id = %slot_id.0,
-            model = ?resolved.model,
-            effort = ?resolved.effort,
-            mcp_servers = resolved.mcp_servers.len(),
-            "executing task"
-        );
-
-        let query_result = match cmd.execute_json(&claude_instance).await {
-            Ok(r) => r,
-            Err(e) if self.inner.config.detect_permission_prompts => {
-                if let Some(detected) = detect_permission_prompt(&e, &slot_id.0) {
-                    return Err(detected);
-                }
-                return Err(e.into());
-            }
-            Err(e) => return Err(e.into()),
-        };
-
-        let cost_microdollars = query_result
-            .cost_usd
-            .map(|c| (c * 1_000_000.0) as u64)
-            .unwrap_or(0);
-
-        Ok(TaskResult {
-            output: query_result.result,
-            success: !query_result.is_error,
-            cost_microdollars,
-            turns_used: query_result.num_turns.unwrap_or(0),
-            session_id: Some(query_result.session_id),
-            failed_command: None,
-            exit_code: None,
-            stderr: None,
-        })
-    }
-
-    /// Execute a task with optional streaming output.
-    ///
-    /// When `on_output` is `Some`, uses streaming execution (`stream-json` format)
-    /// and calls the callback with each text chunk as it arrives. When `None`,
-    /// falls back to the standard `execute_task` path.
-    async fn execute_task_streaming(
-        &self,
-        task_id: &TaskId,
-        prompt: &str,
-        slot_id: &SlotId,
-        slot_config: &SlotConfig,
-        on_output: Option<crate::chain::OnOutputChunk>,
-        override_working_dir: Option<&std::path::Path>,
-    ) -> Result<TaskResult> {
-        // If no streaming callback, use the standard non-streaming path.
-        let on_output = match on_output {
-            Some(cb) => cb,
-            None => {
-                return self
-                    .execute_task(task_id, prompt, slot_id, slot_config, override_working_dir)
-                    .await;
-            }
-        };
-
-        let task_record = self.inner.store.get_task(task_id).await?;
-        let task_cfg = task_record.as_ref().and_then(|t| t.config.as_ref());
-        let resolved = ResolvedConfig::resolve(&self.inner.config, slot_config, task_cfg);
-
-        let system_prompt = self.build_system_prompt(&resolved, slot_config);
-
-        // Auto-deliver pending messages by prepending them to the prompt.
-        let effective_prompt = self.prepend_messages(slot_id, prompt);
-
-        // Build the query with StreamJson format for streaming.
-        let mut cmd = claude_wrapper::QueryCommand::new(&effective_prompt)
-            .output_format(OutputFormat::StreamJson)
-            .permission_mode(resolved.permission_mode);
-
-        if resolved.permission_mode == PermissionMode::BypassPermissions {
-            cmd = cmd.dangerously_skip_permissions();
-        }
-        if let Some(ref model) = resolved.model {
-            cmd = cmd.model(model);
-        }
-        if let Some(max_turns) = resolved.max_turns {
-            cmd = cmd.max_turns(max_turns);
-        }
-        if let Some(ref sp) = system_prompt {
-            cmd = cmd.system_prompt(sp);
-        }
-        if let Some(effort) = resolved.effort {
-            cmd = cmd.effort(effort);
-        }
-        if !resolved.allowed_tools.is_empty() {
-            cmd = cmd.allowed_tools(&resolved.allowed_tools);
-        }
-
-        if !resolved.mcp_servers.is_empty() {
-            let mcp_path = self
-                .ensure_slot_mcp_config(slot_id, &resolved.mcp_servers)
-                .await?;
-            cmd = cmd.mcp_config(mcp_path.to_string_lossy());
-            if resolved.strict_mcp_config {
-                cmd = cmd.strict_mcp_config();
-            }
-        }
-
-        // Use override working dir (chain worktree) > slot worktree > default.
-        let claude_instance = if let Some(slot) = self.inner.store.get_slot(slot_id).await? {
-            // Skip session resumption in clone isolation — the session
-            // belongs to the original directory and won't exist in the clone.
-            if override_working_dir.is_none()
-                && let Some(ref session_id) = slot.session_id
-            {
-                cmd = cmd.resume(session_id);
-            }
-            if let Some(dir) = override_working_dir {
-                self.inner.claude.with_working_dir(dir)
-            } else if let Some(ref wt_path) = slot.worktree_path {
-                self.inner.claude.with_working_dir(wt_path)
-            } else {
-                self.inner.claude.clone()
-            }
-        } else {
-            self.inner.claude.clone()
-        };
-
-        tracing::debug!(
-            slot_id = %slot_id.0,
-            model = ?resolved.model,
-            effort = ?resolved.effort,
-            mcp_servers = resolved.mcp_servers.len(),
-            "executing task (streaming)"
-        );
-
-        // Collect the final result from stream events.
-        let mut result_text = String::new();
-        let mut session_id = String::new();
-        let mut cost_usd: Option<f64> = None;
-        let mut is_error = false;
-
-        let stream_result = claude_wrapper::streaming::stream_query(
-            &claude_instance,
-            &cmd,
-            |event: claude_wrapper::streaming::StreamEvent| {
-                match event.event_type() {
-                    Some("result") => {
-                        if let Some(text) = event.result_text() {
-                            result_text = text.to_string();
-                        }
-                        if let Some(sid) = event.session_id() {
-                            session_id = sid.to_string();
-                        }
-                        cost_usd = event.cost_usd();
-                        is_error = event
-                            .data
-                            .get("is_error")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                    }
-                    Some("assistant") => {
-                        // Extract text from content blocks in assistant messages.
-                        // Content may be at top level or nested under message.
-                        let content_sources = [
-                            event.data.get("content"),
-                            event.data.get("message").and_then(|m| m.get("content")),
-                        ];
-                        for content in content_sources.into_iter().flatten() {
-                            for block in content.as_array().into_iter().flatten() {
-                                if block.get("type").and_then(|t| t.as_str()) == Some("text")
-                                    && let Some(text) = block.get("text").and_then(|t| t.as_str())
-                                {
-                                    on_output(text);
-                                }
-                            }
-                        }
-                    }
-                    Some("content_block_delta") => {
-                        // Handle incremental text deltas.
-                        if let Some(delta) = event.data.get("delta")
-                            && delta.get("type").and_then(|t| t.as_str()) == Some("text_delta")
-                            && let Some(text) = delta.get("text").and_then(|t| t.as_str())
-                        {
-                            on_output(text);
-                        }
-                    }
-                    _ => {}
-                }
-            },
-        )
-        .await;
-
-        match stream_result {
-            Ok(_) => {}
-            Err(e) if self.inner.config.detect_permission_prompts => {
-                if let Some(detected) = detect_permission_prompt(&e, &slot_id.0) {
-                    return Err(detected);
-                }
-                return Err(e.into());
-            }
-            Err(e) => return Err(e.into()),
-        }
-
-        let cost_microdollars = cost_usd.map(|c| (c * 1_000_000.0) as u64).unwrap_or(0);
-
-        Ok(TaskResult {
-            output: result_text,
-            success: !is_error,
-            cost_microdollars,
-            turns_used: 0,
-            session_id: Some(session_id),
-            failed_command: None,
-            exit_code: None,
-            stderr: None,
-        })
-    }
-
-    /// Build the system prompt by combining slot identity, resolved config and context.
-    fn build_system_prompt(
-        &self,
-        resolved: &ResolvedConfig,
-        slot_config: &SlotConfig,
-    ) -> Option<String> {
-        let context_entries: Vec<_> = self.list_context();
-
-        // Check if there's any content to include
-        let has_identity = slot_config.name.is_some()
-            || slot_config.role.is_some()
-            || slot_config.description.is_some();
-
-        if resolved.system_prompt.is_none() && context_entries.is_empty() && !has_identity {
-            return None;
-        }
-
-        let mut parts = Vec::new();
-
-        // Inject slot identity
-        if has_identity {
-            let mut identity = String::new();
-            identity.push_str("You are ");
-
-            if let Some(ref name) = slot_config.name {
-                identity.push_str(name);
-            } else {
-                identity.push_str("a slot");
-            }
-
-            if let Some(ref role) = slot_config.role {
-                identity.push_str(", a ");
-                identity.push_str(role);
-            }
-
-            if let Some(ref description) = slot_config.description {
-                identity.push_str(". ");
-                identity.push_str(description);
-            } else if slot_config.role.is_some() {
-                identity.push('.');
-            }
-
-            parts.push(identity);
-        }
-
-        if let Some(ref sp) = resolved.system_prompt {
-            parts.push(sp.clone());
-        }
-
-        if !context_entries.is_empty() {
-            parts.push("\n\n## Shared Context\n".to_string());
-            for (key, value) in &context_entries {
-                parts.push(format!("- **{key}**: {value}"));
-            }
-        }
-
-        Some(parts.join("\n"))
-    }
 }
 
 /// Summary returned by [`Pool::drain`].
@@ -2077,123 +1663,12 @@ pub struct PoolStatus {
 
 use serde::{Deserialize, Serialize};
 
-/// Generate a short unique ID.
-fn new_id() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    format!("{nanos:x}")
-}
-
-// ── Permission prompt detection ─────────────────────────────────────
-
-/// Patterns in stderr that indicate the CLI is waiting for permission/tool approval.
-const PERMISSION_PATTERNS: &[&str] = &[
-    "Allow",
-    "allow this action",
-    "approve",
-    "permission",
-    "Do you want to",
-    "tool requires approval",
-    "wants to use",
-    "Press Enter",
-    "y/n",
-    "Y/n",
-    "(yes/no)",
-];
-
-/// Structured failure details extracted from an error.
-struct FailureDetails {
-    failed_command: Option<String>,
-    exit_code: Option<i32>,
-    stderr: Option<String>,
-}
-
-/// Extract structured failure details from a pool error.
-///
-/// When the error wraps a `CommandFailed`, we capture the command, exit code,
-/// and stderr so callers get actionable diagnostics.
-fn extract_failure_details(err: &Error) -> FailureDetails {
-    match err {
-        Error::Wrapper(claude_wrapper::Error::CommandFailed {
-            command,
-            exit_code,
-            stderr,
-            ..
-        }) => FailureDetails {
-            failed_command: Some(command.clone()),
-            exit_code: Some(*exit_code),
-            stderr: if stderr.is_empty() {
-                None
-            } else {
-                Some(stderr.clone())
-            },
-        },
-        _ => FailureDetails {
-            failed_command: None,
-            exit_code: None,
-            stderr: None,
-        },
-    }
-}
-
-/// Inspect a claude-wrapper error for signs of a permission prompt.
-///
-/// Returns `Some(Error::PermissionPromptDetected)` if the stderr in a
-/// `CommandFailed` error contains permission prompt patterns.
-fn detect_permission_prompt(err: &claude_wrapper::Error, slot_id: &str) -> Option<Error> {
-    let stderr = match err {
-        claude_wrapper::Error::CommandFailed { stderr, .. } => stderr,
-        _ => return None,
-    };
-
-    if stderr.is_empty() {
-        return None;
-    }
-
-    for pattern in PERMISSION_PATTERNS {
-        if stderr.contains(pattern) {
-            let tool_name = extract_tool_name(stderr);
-            tracing::warn!(
-                slot_id,
-                tool = %tool_name,
-                "permission prompt detected in slot stderr"
-            );
-            return Some(Error::PermissionPromptDetected {
-                tool_name,
-                stderr: stderr.clone(),
-                slot_id: slot_id.to_string(),
-            });
-        }
-    }
-
-    None
-}
-
-/// Best-effort extraction of the tool name from stderr text.
-fn extract_tool_name(stderr: &str) -> String {
-    for line in stderr.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("Allow ")
-            && let Some(tool) = rest.split_whitespace().next()
-        {
-            return tool.trim_end_matches('?').to_string();
-        }
-        if let Some(idx) = trimmed.find("wants to use ") {
-            let after = &trimmed[idx + "wants to use ".len()..];
-            if let Some(tool) = after.split_whitespace().next() {
-                return tool.trim_end_matches(['.', '?', ',']).to_string();
-            }
-        }
-    }
-    "unknown".to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli_parsing::{
+        detect_permission_prompt, extract_failure_details, extract_tool_name,
+    };
 
     fn mock_claude() -> Claude {
         // Build a Claude instance pointing at a non-existent binary.


### PR DESCRIPTION
## Summary
- Extract `executor.rs` (458 lines) from pool.rs: task execution, streaming, system prompt building
- Extract `cli_parsing.rs` (124 lines) from pool.rs: ID generation, permission detection, failure extraction
- Reduces pool.rs from 2,904 to 2,379 lines (-525)
- All public Pool API methods remain in pool.rs; internal fields made `pub(crate)`

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib --all-features` — 81 tests pass
- [x] `cargo doc --no-deps --all-features` builds without warnings

Closes #192