### PR TITLE
refactor: centralize ID generation

### DIFF
--- a/crates/claude-pool/src/cli_parsing.rs
+++ b/crates/claude-pool/src/cli_parsing.rs
@@ -6,16 +6,6 @@
 
 use crate::error::Error;
 
-/// Generate a short unique ID based on the current timestamp.
-pub(crate) fn new_id() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    format!("{nanos:x}")
-}
-
 // ── Permission prompt detection ─────────────────────────────────────
 
 /// Patterns in stderr that indicate the CLI is waiting for permission/tool approval.

--- a/crates/claude-pool/src/lib.rs
+++ b/crates/claude-pool/src/lib.rs
@@ -29,6 +29,7 @@ pub mod skill;
 pub mod store;
 pub mod supervisor;
 pub mod types;
+pub(crate) mod utils;
 pub mod workflow;
 pub mod worktree;
 

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -30,12 +30,13 @@ use tokio::sync::Mutex;
 
 use claude_wrapper::Claude;
 
-use crate::cli_parsing::{extract_failure_details, new_id};
+use crate::cli_parsing::extract_failure_details;
 use crate::error::{Error, Result};
 use crate::messaging::MessageBus;
 use crate::skill::SkillRegistry;
 use crate::store::PoolStore;
 use crate::types::*;
+use crate::utils::new_id;
 
 /// Shared pool state behind an `Arc`.
 pub(crate) struct PoolInner<S: PoolStore> {

--- a/crates/claude-pool/src/utils.rs
+++ b/crates/claude-pool/src/utils.rs
@@ -1,0 +1,14 @@
+//! Shared utilities used across the claude-pool crate.
+
+/// Generate a short unique ID based on the current timestamp in nanoseconds.
+///
+/// Returns a hex-encoded string derived from the number of nanoseconds elapsed
+/// since the Unix epoch. Suitable for generating task, chain, and message IDs.
+pub(crate) fn new_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{nanos:x}")
+}


### PR DESCRIPTION
## Summary
- Create `utils.rs` as canonical home for `new_id()`
- Remove `new_id()` from `cli_parsing.rs` (wrong home — that module is for CLI output parsing)
- Update all import sites in pool.rs

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features`

Closes #195