### PR TITLE
refactor: organize lib.rs re-exports with prelude module

### DIFF
--- a/crates/claude-pool/src/lib.rs
+++ b/crates/claude-pool/src/lib.rs
@@ -17,6 +17,17 @@
 //! ```
 //!
 //! One server. N slots. Nothing else.
+//!
+//! # Getting Started
+//!
+//! For most use cases, import the [`prelude`] module:
+//!
+//! ```rust,no_run
+//! use claude_pool::prelude::*;
+//! ```
+//!
+//! This brings in the most commonly needed types: [`Pool`], [`PoolBuilder`],
+//! [`TaskRecord`], [`TaskState`], [`ChainResult`], and related types.
 
 pub mod chain;
 pub(crate) mod cli_parsing;
@@ -25,6 +36,7 @@ pub mod error;
 pub(crate) mod executor;
 pub mod messaging;
 pub mod pool;
+pub mod prelude;
 pub mod skill;
 pub mod store;
 pub mod supervisor;
@@ -32,16 +44,35 @@ pub mod types;
 pub mod workflow;
 pub mod worktree;
 
+// Core pool types
+pub use pool::{DrainSummary, Pool, PoolBuilder, PoolStatus};
+
+// Error handling
+pub use error::{Error, Result};
+
+// All types (backwards compatibility)
+pub use types::*;
+
+// Chain execution
 pub use chain::{
     ChainIsolation, ChainOptions, ChainProgress, ChainResult, ChainStatus, ChainStep, StepAction,
     StepFailurePolicy, StepResult, execute_chain,
 };
-pub use error::{Error, Result};
-pub use messaging::{Message, MessageBus};
-pub use pool::{DrainSummary, Pool, PoolBuilder, PoolStatus};
+
+// Skill management
 pub use skill::{RegisteredSkill, Skill, SkillArgument, SkillRegistry, SkillScope, SkillSource};
+
+// Storage
 pub use store::{InMemoryStore, PoolStore};
+
+// Supervisor
 pub use supervisor::{SupervisorHandle, check_and_restart_slots};
-pub use types::*;
+
+// Messaging
+pub use messaging::{Message, MessageBus};
+
+// Workflow
 pub use workflow::{Workflow, WorkflowArgument, WorkflowRegistry};
+
+// Worktree management
 pub use worktree::WorktreeManager;

--- a/crates/claude-pool/src/prelude.rs
+++ b/crates/claude-pool/src/prelude.rs
@@ -1,0 +1,42 @@
+//! Commonly used types for working with `claude-pool` as a library.
+//!
+//! Import this module to bring the most frequently needed types into scope:
+//!
+//! ```rust,no_run
+//! use claude_pool::prelude::*;
+//! ```
+//!
+//! # What's Included
+//!
+//! **Pool management** — build and run the pool:
+//! - [`Pool`], [`PoolBuilder`], [`PoolStatus`], [`DrainSummary`]
+//!
+//! **Task tracking** — inspect work in flight:
+//! - [`TaskRecord`], [`TaskState`], [`TaskResult`], [`TaskFilter`], [`TaskId`]
+//!
+//! **Chain execution** — build multi-step pipelines:
+//! - [`execute_chain`], [`ChainStep`], [`ChainOptions`], [`ChainResult`], [`ChainStatus`]
+//!
+//! **Configuration** — tune pool and slot behavior:
+//! - [`PoolConfig`], [`SlotConfig`]
+//!
+//! **Errors** — handle failures:
+//! - [`Error`], [`Result`]
+
+// Pool management
+pub use crate::pool::{DrainSummary, Pool, PoolBuilder, PoolStatus};
+
+// Error handling
+pub use crate::error::{Error, Result};
+
+// Task types
+pub use crate::types::{
+    PoolConfig, ScalingConfig, SlotConfig, SlotId, SlotMode, SlotRecord, SlotState, TaskFilter,
+    TaskId, TaskRecord, TaskResult, TaskState,
+};
+
+// Chain execution
+pub use crate::chain::{ChainOptions, ChainResult, ChainStatus, ChainStep, execute_chain};
+
+// Skill management
+pub use crate::skill::{RegisteredSkill, Skill, SkillRegistry, SkillScope};


### PR DESCRIPTION
## Summary
- Add `prelude.rs` with curated type groups (pool management, tasks, chains, config, skills, errors)
- Organize existing root re-exports by logical category with comments
- Add crate-level doc example pointing to `use claude_pool::prelude::*`
- Backwards compatible — existing imports still work

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features`
- [x] `cargo doc --no-deps --all-features` (no warnings)

Closes #197