### PR TITLE
fix: suppress unexpected_cfgs warnings for rest feature

### DIFF
--- a/crates/claude-pool-server/Cargo.toml
+++ b/crates/claude-pool-server/Cargo.toml
@@ -53,3 +53,6 @@ tower-mcp = { workspace = true, features = ["testing"] }
 default = []
 http = ["tower-mcp/http", "dep:axum"]
 rest = ["dep:axum", "dep:tower-http"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("rest"))'] }


### PR DESCRIPTION
## Summary
- Add `[lints.rust]` check-cfg entry so `#[cfg(feature = "rest")]` doesn't produce warnings when building without the `rest` feature enabled

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings`