### PR TITLE
feat: task execution metrics and session aggregation

### DIFF
--- a/crates/claude-pool-server/src/rest/mod.rs
+++ b/crates/claude-pool-server/src/rest/mod.rs
@@ -45,6 +45,7 @@
 //!
 //! ## Pool
 //! - `GET /v1/pool/status` — pool health
+//! - `GET /v1/pool/metrics` — aggregated session metrics
 //! - `GET /v1/pool/events` — SSE stream of pool events
 //! - `POST /v1/pool/drain` — graceful shutdown
 //! - `POST /v1/pool/scale` — scale slots
@@ -153,6 +154,7 @@ pub fn router<S: PoolStore + 'static>(state: Arc<State<S>>, config: RestConfig) 
 
     let pool = Router::new()
         .route("/status", get(routes::pool::get_status::<S>))
+        .route("/metrics", get(routes::pool::get_metrics::<S>))
         .route("/events", get(routes::pool::events::<S>))
         .route("/drain", post(routes::pool::drain::<S>))
         .route("/scale", post(routes::pool::scale::<S>));

--- a/crates/claude-pool-server/src/rest/routes/pool.rs
+++ b/crates/claude-pool-server/src/rest/routes/pool.rs
@@ -22,6 +22,9 @@ pub struct PoolStatusResponse {
     pub busy_slots: usize,
     pub pending_tasks: usize,
     pub running_tasks: usize,
+    pub completed_tasks: usize,
+    pub failed_tasks: usize,
+    pub cancelled_tasks: usize,
     pub total_spend_microdollars: u64,
     pub budget_microdollars: Option<u64>,
     pub shutdown: bool,
@@ -62,6 +65,9 @@ pub async fn get_status<S: PoolStore + 'static>(
         busy_slots: status.busy_slots,
         pending_tasks: status.pending_tasks,
         running_tasks: status.running_tasks,
+        completed_tasks: status.completed_tasks,
+        failed_tasks: status.failed_tasks,
+        cancelled_tasks: status.cancelled_tasks,
         total_spend_microdollars: status.total_spend_microdollars,
         budget_microdollars: status.budget_microdollars,
         shutdown: status.shutdown,
@@ -150,6 +156,44 @@ pub async fn scale<S: PoolStore + 'static>(
         previous_slots: previous,
         current_slots: new_status.total_slots,
     }))
+}
+
+/// Query parameters for `GET /v1/pool/metrics`.
+#[derive(Debug, Deserialize, Default)]
+pub struct MetricsQuery {
+    /// Only include tasks created after this time (millis since epoch).
+    pub since_ms: Option<u64>,
+    /// Only include tasks created before this time (millis since epoch).
+    pub until_ms: Option<u64>,
+    /// Only include tasks with this tag.
+    pub tag: Option<String>,
+    /// Only include tasks that ran on this model.
+    pub model: Option<String>,
+}
+
+/// `GET /v1/pool/metrics` — aggregated session metrics.
+///
+/// Returns cost, timing, and model breakdowns for the current session.
+/// Supports optional query filters: `?since_ms=&until_ms=&tag=&model=`.
+pub async fn get_metrics<S: PoolStore + 'static>(
+    State(state): State<Arc<AppState<S>>>,
+    axum::extract::Query(query): axum::extract::Query<MetricsQuery>,
+) -> Result<Json<claude_pool::types::SessionMetrics>, ProblemDetails> {
+    let filter = claude_pool::types::MetricsFilter {
+        since_ms: query.since_ms,
+        until_ms: query.until_ms,
+        tags: query.tag.map(|t| vec![t]),
+        model: query.model,
+    };
+
+    let metrics = state
+        .state
+        .pool
+        .session_metrics(&filter)
+        .await
+        .map_err(ProblemDetails::from)?;
+
+    Ok(Json(metrics))
 }
 
 /// `GET /v1/pool/events` — SSE stream of pool-wide events.

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -32,9 +32,10 @@
 //! - `pool_scale_up` — Add N new slots to the pool
 //! - `pool_scale_down` — Remove N slots from pool
 //!
-//! ### Pool Control (2 tools)
+//! ### Pool Control (3 tools)
 //! - `pool_drain` — Gracefully shut down pool, wait for in-flight tasks
 //! - `pool_set_target_slots` — Set pool to specific number of slots
+//! - `pool_session_metrics` — Get aggregated session metrics: spend, timing, model breakdown
 //!
 //! ### Skill Management (7 tools)
 //! - `pool_skill_run` — Run a registered skill by name with arguments (blocks)
@@ -2299,9 +2300,57 @@ pub fn pool_reject_result_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> 
         .build()
 }
 
+/// **pool_session_metrics** — Get aggregated session metrics: cost, timing, model breakdown
+///
+/// Returns developer-focused insights for the current pool session including
+/// spend tracking, task timing distributions, and per-model breakdowns.
+/// Useful for answering questions like "how much did I spend today?" and
+/// "how long are my tasks taking on average?".
+/// Input for `pool_session_metrics`.
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SessionMetricsInput {
+    /// Only include tasks created after this time (millis since epoch).
+    since_ms: Option<u64>,
+    /// Only include tasks created before this time (millis since epoch).
+    until_ms: Option<u64>,
+    /// Only include tasks that ran on this model.
+    model: Option<String>,
+    /// Only include tasks with this tag.
+    tag: Option<String>,
+}
+
+pub fn pool_session_metrics_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
+    ToolBuilder::new("pool_session_metrics")
+        .title("Session Metrics")
+        .description(
+            "Get aggregated session metrics: spend, timing, model breakdown, task counts. \
+             All parameters are optional filters.",
+        )
+        .read_only()
+        .handler(move |input: SessionMetricsInput| {
+            let state = Arc::clone(&state);
+            async move {
+                let filter = claude_pool::types::MetricsFilter {
+                    since_ms: input.since_ms,
+                    until_ms: input.until_ms,
+                    model: input.model,
+                    tags: input.tag.map(|t| vec![t]),
+                };
+                match state.pool.session_metrics(&filter).await {
+                    Ok(metrics) => Ok(CallToolResult::text(
+                        serde_json::to_string_pretty(&metrics).unwrap(),
+                    )),
+                    Err(e) => Ok(CallToolResult::error(e.to_string())),
+                }
+            }
+        })
+        .build()
+}
+
 pub fn all_tools<S: PoolStore + 'static>(state: &Arc<State<S>>) -> Vec<Tool> {
     vec![
         pool_status_tool(Arc::clone(state)),
+        pool_session_metrics_tool(Arc::clone(state)),
         pool_run_tool(Arc::clone(state)),
         pool_submit_tool(Arc::clone(state)),
         pool_result_tool(Arc::clone(state)),

--- a/crates/claude-pool-server/tests/rest_api_tests.rs
+++ b/crates/claude-pool-server/tests/rest_api_tests.rs
@@ -166,6 +166,19 @@ async fn pool_status_returns_slot_info() {
     assert!(body["server_version"].is_string());
 }
 
+#[tokio::test]
+async fn pool_metrics_returns_session_data() {
+    let app = test_router(2).await;
+    let (status, body) = send(app, get("/v1/pool/metrics")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total_tasks"], 0);
+    assert_eq!(body["completed_tasks"], 0);
+    assert_eq!(body["total_spend_microdollars"], 0);
+    assert!(body["session_start_ms"].is_number());
+    assert!(body["session_duration_ms"].is_number());
+    assert!(body["tasks_by_model"].is_object());
+}
+
 // ── Tasks ────────────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/claude-pool/src/executor.rs
+++ b/crates/claude-pool/src/executor.rs
@@ -248,6 +248,8 @@ pub(crate) async fn execute_task<S: PoolStore + 'static>(
         "executing task"
     );
 
+    let start = std::time::Instant::now();
+
     let query_result = match cmd.execute_json(&claude_instance).await {
         Ok(r) => r,
         Err(e) if inner.config.detect_permission_prompts => {
@@ -259,21 +261,30 @@ pub(crate) async fn execute_task<S: PoolStore + 'static>(
         Err(e) => return Err(e.into()),
     };
 
+    let elapsed_ms = start.elapsed().as_millis() as u64;
+
     let cost_microdollars = query_result
         .cost_usd
         .map(|c| (c * 1_000_000.0) as u64)
         .unwrap_or(0);
 
-    Ok(TaskResult {
-        output: query_result.result,
-        success: !query_result.is_error,
+    let mut result = TaskResult::success(
+        query_result.result,
         cost_microdollars,
-        turns_used: query_result.num_turns.unwrap_or(0),
-        session_id: Some(query_result.session_id),
-        failed_command: None,
-        exit_code: None,
-        stderr: None,
-    })
+        query_result.num_turns.unwrap_or(0),
+    )
+    .with_elapsed_ms(elapsed_ms)
+    .with_session_id(query_result.session_id);
+
+    if query_result.is_error {
+        result.success = false;
+    }
+
+    if let Some(ref model) = resolved.model {
+        result = result.with_model(model);
+    }
+
+    Ok(result)
 }
 
 /// Execute a task with optional streaming output.
@@ -375,6 +386,8 @@ pub(crate) async fn execute_task_streaming<S: PoolStore + 'static>(
         "executing task (streaming)"
     );
 
+    let start = std::time::Instant::now();
+
     // Collect the final result from stream events.
     let mut result_text = String::new();
     let mut session_id = String::new();
@@ -443,16 +456,25 @@ pub(crate) async fn execute_task_streaming<S: PoolStore + 'static>(
         Err(e) => return Err(e.into()),
     }
 
+    let elapsed_ms = start.elapsed().as_millis() as u64;
     let cost_microdollars = cost_usd.map(|c| (c * 1_000_000.0) as u64).unwrap_or(0);
 
-    Ok(TaskResult {
-        output: result_text,
-        success: !is_error,
-        cost_microdollars,
-        turns_used: 0,
-        session_id: Some(session_id),
-        failed_command: None,
-        exit_code: None,
-        stderr: None,
-    })
+    let mut result = if is_error {
+        TaskResult::failure(&result_text)
+    } else {
+        TaskResult::success(result_text, cost_microdollars, 0)
+    }
+    .with_elapsed_ms(elapsed_ms)
+    .with_session_id(session_id);
+
+    if is_error {
+        // failure() sets cost to 0; preserve the actual cost if known.
+        result.cost_microdollars = cost_microdollars;
+    }
+
+    if let Some(ref model) = resolved.model {
+        result = result.with_model(model);
+    }
+
+    Ok(result)
 }

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -23,6 +23,7 @@
 //! # }
 //! ```
 
+use std::collections::HashMap;
 use std::future::IntoFuture;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -57,6 +58,8 @@ pub(crate) struct PoolInner<S: PoolStore> {
     pub(crate) chain_progress: dashmap::DashMap<String, crate::chain::ChainProgress>,
     /// Message bus for inter-slot communication.
     pub(crate) message_bus: MessageBus,
+    /// When this pool was created (millis since epoch).
+    pub(crate) created_at_ms: u64,
 }
 
 /// A pool of Claude CLI slots.
@@ -150,6 +153,7 @@ impl<S: PoolStore + 'static> PoolBuilder<S> {
             worktree_manager,
             chain_progress: dashmap::DashMap::new(),
             message_bus: MessageBus::default(),
+            created_at_ms: now_ms(),
         });
 
         // Register slots in the store.
@@ -383,19 +387,7 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         let task_id = TaskId(format!("task-{}", new_id()));
 
-        let record = TaskRecord {
-            id: task_id.clone(),
-            prompt: prompt.to_string(),
-            state: TaskState::Pending,
-            slot_id: None,
-            result: None,
-            tags: vec![],
-            config: task_config,
-            review_required: false,
-            max_rejections: 3,
-            rejection_count: 0,
-            original_prompt: None,
-        };
+        let record = TaskRecord::new_pending(task_id.clone(), prompt).with_config(task_config);
         self.inner.store.put_task(record).await?;
 
         let (slot_id, slot_config) = self.assign_slot(&task_id).await?;
@@ -419,7 +411,7 @@ impl<S: PoolStore + 'static> Pool<S> {
             .get_task(&task_id)
             .await?
             .ok_or_else(|| Error::TaskNotFound(task_id.0.clone()))?;
-        task.state = TaskState::Completed;
+        task.transition_to(TaskState::Completed);
         task.result = Some(task_result.clone());
         self.inner.store.put_task(task).await?;
 
@@ -446,19 +438,9 @@ impl<S: PoolStore + 'static> Pool<S> {
         let task_id = TaskId(format!("task-{}", new_id()));
         let prompt = prompt.to_string();
 
-        let record = TaskRecord {
-            id: task_id.clone(),
-            prompt: prompt.clone(),
-            state: TaskState::Pending,
-            slot_id: None,
-            result: None,
-            tags,
-            config: task_config,
-            review_required: false,
-            max_rejections: 3,
-            rejection_count: 0,
-            original_prompt: None,
-        };
+        let record = TaskRecord::new_pending(task_id.clone(), prompt.clone())
+            .with_tags(tags)
+            .with_config(task_config);
         self.inner.store.put_task(record).await?;
 
         // Spawn the task execution in the background.
@@ -487,39 +469,26 @@ impl<S: PoolStore + 'static> Pool<S> {
                     let mut updated = task;
                     match result {
                         Ok(task_result) => {
-                            updated.state = TaskState::Completed;
+                            updated.transition_to(TaskState::Completed);
                             updated.result = Some(task_result);
                         }
                         Err(e) => {
                             let details = extract_failure_details(&e);
-                            updated.state = TaskState::Failed;
-                            updated.result = Some(TaskResult {
-                                output: e.to_string(),
-                                success: false,
-                                cost_microdollars: 0,
-                                turns_used: 0,
-                                session_id: None,
-                                failed_command: details.failed_command,
-                                exit_code: details.exit_code,
-                                stderr: details.stderr,
-                            });
+                            updated.transition_to(TaskState::Failed);
+                            updated.result =
+                                Some(TaskResult::failure(e.to_string()).with_failure_details(
+                                    details.failed_command,
+                                    details.exit_code,
+                                    details.stderr,
+                                ));
                         }
                     }
                     let _ = pool.inner.store.put_task(updated).await;
                 }
                 Err(e) => {
                     let mut updated = task;
-                    updated.state = TaskState::Failed;
-                    updated.result = Some(TaskResult {
-                        output: e.to_string(),
-                        success: false,
-                        cost_microdollars: 0,
-                        turns_used: 0,
-                        session_id: None,
-                        failed_command: None,
-                        exit_code: None,
-                        stderr: None,
-                    });
+                    updated.transition_to(TaskState::Failed);
+                    updated.result = Some(TaskResult::failure(e.to_string()));
                     let _ = pool.inner.store.put_task(updated).await;
                 }
             }
@@ -547,19 +516,10 @@ impl<S: PoolStore + 'static> Pool<S> {
         let prompt = prompt.to_string();
         let max_rej = max_rejections.unwrap_or(3);
 
-        let record = TaskRecord {
-            id: task_id.clone(),
-            prompt: prompt.clone(),
-            state: TaskState::Pending,
-            slot_id: None,
-            result: None,
-            tags,
-            config: task_config,
-            review_required: true,
-            max_rejections: max_rej,
-            rejection_count: 0,
-            original_prompt: Some(prompt.clone()),
-        };
+        let record = TaskRecord::new_pending(task_id.clone(), prompt.clone())
+            .with_tags(tags)
+            .with_config(task_config)
+            .with_review(max_rej);
         self.inner.store.put_task(record).await?;
 
         // Spawn the task execution in the background.
@@ -590,42 +550,29 @@ impl<S: PoolStore + 'static> Pool<S> {
                         Ok(task_result) => {
                             // review_required: go to PendingReview instead of Completed
                             if updated.review_required {
-                                updated.state = TaskState::PendingReview;
+                                updated.transition_to(TaskState::PendingReview);
                             } else {
-                                updated.state = TaskState::Completed;
+                                updated.transition_to(TaskState::Completed);
                             }
                             updated.result = Some(task_result);
                         }
                         Err(e) => {
                             let details = extract_failure_details(&e);
-                            updated.state = TaskState::Failed;
-                            updated.result = Some(TaskResult {
-                                output: e.to_string(),
-                                success: false,
-                                cost_microdollars: 0,
-                                turns_used: 0,
-                                session_id: None,
-                                failed_command: details.failed_command,
-                                exit_code: details.exit_code,
-                                stderr: details.stderr,
-                            });
+                            updated.transition_to(TaskState::Failed);
+                            updated.result =
+                                Some(TaskResult::failure(e.to_string()).with_failure_details(
+                                    details.failed_command,
+                                    details.exit_code,
+                                    details.stderr,
+                                ));
                         }
                     }
                     let _ = pool.inner.store.put_task(updated).await;
                 }
                 Err(e) => {
                     let mut updated = task;
-                    updated.state = TaskState::Failed;
-                    updated.result = Some(TaskResult {
-                        output: e.to_string(),
-                        success: false,
-                        cost_microdollars: 0,
-                        turns_used: 0,
-                        session_id: None,
-                        failed_command: None,
-                        exit_code: None,
-                        stderr: None,
-                    });
+                    updated.transition_to(TaskState::Failed);
+                    updated.result = Some(TaskResult::failure(e.to_string()));
                     let _ = pool.inner.store.put_task(updated).await;
                 }
             }
@@ -650,7 +597,7 @@ impl<S: PoolStore + 'static> Pool<S> {
             )));
         }
 
-        task.state = TaskState::Completed;
+        task.transition_to(TaskState::Completed);
         self.inner.store.put_task(task).await
     }
 
@@ -676,20 +623,11 @@ impl<S: PoolStore + 'static> Pool<S> {
         task.rejection_count += 1;
 
         if task.rejection_count >= task.max_rejections {
-            task.state = TaskState::Failed;
-            task.result = Some(TaskResult {
-                output: format!(
-                    "task rejected {} times (max: {}). Last feedback: {}",
-                    task.rejection_count, task.max_rejections, feedback
-                ),
-                success: false,
-                cost_microdollars: 0,
-                turns_used: 0,
-                session_id: None,
-                failed_command: None,
-                exit_code: None,
-                stderr: None,
-            });
+            task.transition_to(TaskState::Failed);
+            task.result = Some(TaskResult::failure(format!(
+                "task rejected {} times (max: {}). Last feedback: {}",
+                task.rejection_count, task.max_rejections, feedback
+            )));
             self.inner.store.put_task(task).await?;
             return Ok(());
         }
@@ -703,7 +641,7 @@ impl<S: PoolStore + 'static> Pool<S> {
             "{}\n\n--- Rejection feedback (attempt {}/{}) ---\n{}",
             original, task.rejection_count, task.max_rejections, feedback
         );
-        task.state = TaskState::Pending;
+        task.transition_to(TaskState::Pending);
         task.slot_id = None;
         task.result = None;
         self.inner.store.put_task(task.clone()).await?;
@@ -735,42 +673,29 @@ impl<S: PoolStore + 'static> Pool<S> {
                     match result {
                         Ok(task_result) => {
                             if updated.review_required {
-                                updated.state = TaskState::PendingReview;
+                                updated.transition_to(TaskState::PendingReview);
                             } else {
-                                updated.state = TaskState::Completed;
+                                updated.transition_to(TaskState::Completed);
                             }
                             updated.result = Some(task_result);
                         }
                         Err(e) => {
                             let details = extract_failure_details(&e);
-                            updated.state = TaskState::Failed;
-                            updated.result = Some(TaskResult {
-                                output: e.to_string(),
-                                success: false,
-                                cost_microdollars: 0,
-                                turns_used: 0,
-                                session_id: None,
-                                failed_command: details.failed_command,
-                                exit_code: details.exit_code,
-                                stderr: details.stderr,
-                            });
+                            updated.transition_to(TaskState::Failed);
+                            updated.result =
+                                Some(TaskResult::failure(e.to_string()).with_failure_details(
+                                    details.failed_command,
+                                    details.exit_code,
+                                    details.stderr,
+                                ));
                         }
                     }
                     let _ = pool.inner.store.put_task(updated).await;
                 }
                 Err(e) => {
                     let mut updated = task;
-                    updated.state = TaskState::Failed;
-                    updated.result = Some(TaskResult {
-                        output: e.to_string(),
-                        success: false,
-                        cost_microdollars: 0,
-                        turns_used: 0,
-                        session_id: None,
-                        failed_command: None,
-                        exit_code: None,
-                        stderr: None,
-                    });
+                    updated.transition_to(TaskState::Failed);
+                    updated.result = Some(TaskResult::failure(e.to_string()));
                     let _ = pool.inner.store.put_task(updated).await;
                 }
             }
@@ -807,13 +732,13 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         match task.state {
             TaskState::Pending | TaskState::PendingReview => {
-                task.state = TaskState::Cancelled;
+                task.transition_to(TaskState::Cancelled);
                 self.inner.store.put_task(task).await?;
                 Ok(())
             }
             TaskState::Running => {
                 // Mark as cancelled; the executing task will check on completion.
-                task.state = TaskState::Cancelled;
+                task.transition_to(TaskState::Cancelled);
                 self.inner.store.put_task(task).await?;
                 Ok(())
             }
@@ -862,7 +787,7 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         // Mark task as running and assign to slot.
         let mut updated_task = task;
-        updated_task.state = TaskState::Running;
+        updated_task.transition_to(TaskState::Running);
         updated_task.slot_id = Some(slot_id.clone());
         self.inner.store.put_task(updated_task.clone()).await?;
 
@@ -886,22 +811,18 @@ impl<S: PoolStore + 'static> Pool<S> {
             if let Ok(Some(mut task)) = pool.inner.store.get_task(&tid).await {
                 match result {
                     Ok(task_result) => {
-                        task.state = TaskState::Completed;
+                        task.transition_to(TaskState::Completed);
                         task.result = Some(task_result);
                     }
                     Err(e) => {
                         let details = extract_failure_details(&e);
-                        task.state = TaskState::Failed;
-                        task.result = Some(TaskResult {
-                            output: e.to_string(),
-                            success: false,
-                            cost_microdollars: 0,
-                            turns_used: 0,
-                            session_id: None,
-                            failed_command: details.failed_command,
-                            exit_code: details.exit_code,
-                            stderr: details.stderr,
-                        });
+                        task.transition_to(TaskState::Failed);
+                        task.result =
+                            Some(TaskResult::failure(e.to_string()).with_failure_details(
+                                details.failed_command,
+                                details.exit_code,
+                                details.stderr,
+                            ));
                     }
                 }
                 let _ = pool.inner.store.put_task(task).await;
@@ -926,7 +847,7 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         match task.state {
             TaskState::Running | TaskState::Pending => {
-                task.state = TaskState::Cancelled;
+                task.transition_to(TaskState::Cancelled);
                 self.inner.store.put_task(task).await?;
                 // Optimistically update in-flight progress status.
                 if let Some(mut progress) = self.inner.chain_progress.get_mut(&task_id.0) {
@@ -984,19 +905,9 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         let isolation = options.isolation;
 
-        let record = TaskRecord {
-            id: task_id.clone(),
-            prompt: format!("chain: {} steps", steps.len()),
-            state: TaskState::Pending,
-            slot_id: None,
-            result: None,
-            tags: options.tags,
-            config: None,
-            review_required: false,
-            max_rejections: 3,
-            rejection_count: 0,
-            original_prompt: None,
-        };
+        let record =
+            TaskRecord::new_pending(task_id.clone(), format!("chain: {} steps", steps.len()))
+                .with_tags(options.tags);
         self.inner.store.put_task(record).await?;
 
         // Initialize progress.
@@ -1015,7 +926,7 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         // Mark as running.
         if let Some(mut task) = self.inner.store.get_task(&task_id).await? {
-            task.state = TaskState::Running;
+            task.transition_to(TaskState::Running);
             self.inner.store.put_task(task).await?;
         }
 
@@ -1103,35 +1014,29 @@ impl<S: PoolStore + 'static> Pool<S> {
                 match result {
                     Ok(chain_result) => {
                         let success = chain_result.success;
-                        task.state = if success {
-                            TaskState::Completed
+                        if success {
+                            task.transition_to(TaskState::Completed);
                         } else {
-                            TaskState::Failed
-                        };
-                        task.result = Some(TaskResult {
-                            output: serde_json::to_string(&chain_result).unwrap_or_default(),
-                            success,
-                            cost_microdollars: chain_result.total_cost_microdollars,
-                            turns_used: 0,
-                            session_id: None,
-                            failed_command: None,
-                            exit_code: None,
-                            stderr: None,
+                            task.transition_to(TaskState::Failed);
+                        }
+                        let output = serde_json::to_string(&chain_result).unwrap_or_default();
+                        task.result = Some(if success {
+                            TaskResult::success(output, chain_result.total_cost_microdollars, 0)
+                        } else {
+                            let mut r = TaskResult::failure(output);
+                            r.cost_microdollars = chain_result.total_cost_microdollars;
+                            r
                         });
                     }
                     Err(e) => {
                         let details = extract_failure_details(&e);
-                        task.state = TaskState::Failed;
-                        task.result = Some(TaskResult {
-                            output: e.to_string(),
-                            success: false,
-                            cost_microdollars: 0,
-                            turns_used: 0,
-                            session_id: None,
-                            failed_command: details.failed_command,
-                            exit_code: details.exit_code,
-                            stderr: details.stderr,
-                        });
+                        task.transition_to(TaskState::Failed);
+                        task.result =
+                            Some(TaskResult::failure(e.to_string()).with_failure_details(
+                                details.failed_command,
+                                details.exit_code,
+                                details.stderr,
+                            ));
                     }
                 }
                 let _ = pool.inner.store.put_task(task).await;
@@ -1416,35 +1321,32 @@ impl<S: PoolStore + 'static> Pool<S> {
         let idle = slots.iter().filter(|w| w.state == SlotState::Idle).count();
         let busy = slots.iter().filter(|w| w.state == SlotState::Busy).count();
 
-        let running_tasks = self
-            .inner
-            .store
-            .list_tasks(&TaskFilter {
-                state: Some(TaskState::Running),
-                ..Default::default()
-            })
-            .await?
-            .len();
+        let all_tasks = self.inner.store.list_tasks(&TaskFilter::default()).await?;
 
-        let pending_tasks = self
-            .inner
-            .store
-            .list_tasks(&TaskFilter {
-                state: Some(TaskState::Pending),
-                ..Default::default()
-            })
-            .await?
-            .len();
-
-        let pending_review_tasks = self
-            .inner
-            .store
-            .list_tasks(&TaskFilter {
-                state: Some(TaskState::PendingReview),
-                ..Default::default()
-            })
-            .await?
-            .len();
+        let running_tasks = all_tasks
+            .iter()
+            .filter(|t| t.state == TaskState::Running)
+            .count();
+        let pending_tasks = all_tasks
+            .iter()
+            .filter(|t| t.state == TaskState::Pending)
+            .count();
+        let pending_review_tasks = all_tasks
+            .iter()
+            .filter(|t| t.state == TaskState::PendingReview)
+            .count();
+        let completed_tasks = all_tasks
+            .iter()
+            .filter(|t| t.state == TaskState::Completed)
+            .count();
+        let failed_tasks = all_tasks
+            .iter()
+            .filter(|t| t.state == TaskState::Failed)
+            .count();
+        let cancelled_tasks = all_tasks
+            .iter()
+            .filter(|t| t.state == TaskState::Cancelled)
+            .count();
 
         Ok(PoolStatus {
             total_slots: slots.len(),
@@ -1453,6 +1355,9 @@ impl<S: PoolStore + 'static> Pool<S> {
             running_tasks,
             pending_tasks,
             pending_review_tasks,
+            completed_tasks,
+            failed_tasks,
+            cancelled_tasks,
             total_spend_microdollars: self.inner.total_spend.load(Ordering::Relaxed),
             budget_microdollars: self.inner.config.budget_microdollars,
             shutdown: self.inner.shutdown.load(Ordering::Relaxed),
@@ -1467,6 +1372,136 @@ impl<S: PoolStore + 'static> Pool<S> {
     /// Get a reference to the pool configuration.
     pub fn config(&self) -> &PoolConfig {
         &self.inner.config
+    }
+
+    /// Compute aggregated session metrics from all tasks.
+    ///
+    /// Scans all tasks in the store and computes cost, timing, and model
+    /// breakdowns useful for developer insights. Accepts an optional filter
+    /// to narrow results by time window, tags, or model.
+    pub async fn session_metrics(&self, filter: &MetricsFilter) -> Result<SessionMetrics> {
+        let all_tasks = self.inner.store.list_tasks(&TaskFilter::default()).await?;
+
+        // Apply time/tag/model filters.
+        let filtered: Vec<&TaskRecord> = all_tasks
+            .iter()
+            .filter(|t| {
+                if let Some(since) = filter.since_ms
+                    && t.created_at_ms.unwrap_or(0) < since
+                {
+                    return false;
+                }
+                if let Some(until) = filter.until_ms
+                    && t.created_at_ms.unwrap_or(0) > until
+                {
+                    return false;
+                }
+                if let Some(ref tags) = filter.tags
+                    && !tags.iter().any(|tag| t.tags.contains(tag))
+                {
+                    return false;
+                }
+                if let Some(ref model) = filter.model {
+                    match t.result {
+                        Some(ref result) if result.model.as_deref() == Some(model) => {}
+                        _ => return false,
+                    }
+                }
+                true
+            })
+            .collect();
+
+        let mut metrics = SessionMetrics {
+            session_start_ms: self.inner.created_at_ms,
+            session_duration_ms: now_ms().saturating_sub(self.inner.created_at_ms),
+            total_tasks: filtered.len() as u64,
+            ..Default::default()
+        };
+
+        let mut elapsed_values: Vec<u64> = Vec::new();
+        let mut total_turns: u64 = 0;
+        let mut completed_count: u64 = 0;
+
+        // Per-model accumulators: (count, total_cost, total_elapsed, total_turns)
+        let mut model_accum: HashMap<String, (u64, u64, u64, u64)> = HashMap::new();
+
+        for task in &filtered {
+            match task.state {
+                TaskState::Pending => metrics.pending_tasks += 1,
+                TaskState::Running => metrics.running_tasks += 1,
+                TaskState::Completed | TaskState::PendingReview => metrics.completed_tasks += 1,
+                TaskState::Failed => metrics.failed_tasks += 1,
+                TaskState::Cancelled => metrics.cancelled_tasks += 1,
+            }
+
+            if let Some(ref result) = task.result {
+                metrics.total_spend_microdollars += result.cost_microdollars;
+
+                if result.cost_microdollars > metrics.max_cost_microdollars {
+                    metrics.max_cost_microdollars = result.cost_microdollars;
+                }
+
+                if task.state == TaskState::Completed || task.state == TaskState::PendingReview {
+                    completed_count += 1;
+                    total_turns += result.turns_used as u64;
+
+                    if result.elapsed_ms > 0 {
+                        elapsed_values.push(result.elapsed_ms);
+                    }
+                    if result.elapsed_ms > metrics.max_elapsed_ms {
+                        metrics.max_elapsed_ms = result.elapsed_ms;
+                    }
+                }
+
+                if let Some(ref model) = result.model {
+                    *metrics.tasks_by_model.entry(model.clone()).or_insert(0) += 1;
+                    let acc = model_accum.entry(model.clone()).or_default();
+                    acc.0 += 1;
+                    acc.1 += result.cost_microdollars;
+                    acc.2 += result.elapsed_ms;
+                    acc.3 += result.turns_used as u64;
+                }
+            }
+        }
+
+        if completed_count > 0 {
+            metrics.avg_cost_microdollars = metrics.total_spend_microdollars / completed_count;
+            metrics.avg_turns = total_turns as f64 / completed_count as f64;
+        }
+
+        if !elapsed_values.is_empty() {
+            let sum: u64 = elapsed_values.iter().sum();
+            metrics.avg_elapsed_ms = sum / elapsed_values.len() as u64;
+            metrics.min_elapsed_ms = elapsed_values.iter().copied().min().unwrap_or(0);
+
+            elapsed_values.sort_unstable();
+            let mid = elapsed_values.len() / 2;
+            metrics.median_elapsed_ms = if elapsed_values.len().is_multiple_of(2) && mid > 0 {
+                (elapsed_values[mid - 1] + elapsed_values[mid]) / 2
+            } else {
+                elapsed_values[mid]
+            };
+        }
+
+        // Build per-model breakdown.
+        metrics.model_breakdown = model_accum
+            .into_iter()
+            .map(|(model, (count, cost, elapsed, turns))| ModelMetrics {
+                model,
+                task_count: count,
+                total_cost_microdollars: cost,
+                avg_cost_microdollars: if count > 0 { cost / count } else { 0 },
+                avg_elapsed_ms: if count > 0 { elapsed / count } else { 0 },
+                total_turns: turns,
+            })
+            .collect();
+
+        // Sort breakdown by cost descending for easy reading.
+        metrics
+            .model_breakdown
+            .sort_by(|a, b| b.total_cost_microdollars.cmp(&a.total_cost_microdollars));
+
+        Ok(metrics)
     }
 
     /// Start the background supervisor loop.
@@ -1686,7 +1721,7 @@ impl<S: PoolStore + 'static> Pool<S> {
 
         // Update task with assigned slot.
         if let Some(mut task) = self.inner.store.get_task(task_id).await? {
-            task.state = TaskState::Running;
+            task.transition_to(TaskState::Running);
             task.slot_id = Some(slot.id.clone());
             self.inner.store.put_task(task).await?;
         }
@@ -1746,6 +1781,12 @@ pub struct PoolStatus {
     pub pending_tasks: usize,
     /// Number of tasks awaiting coordinator review.
     pub pending_review_tasks: usize,
+    /// Number of completed tasks.
+    pub completed_tasks: usize,
+    /// Number of failed tasks.
+    pub failed_tasks: usize,
+    /// Number of cancelled tasks.
+    pub cancelled_tasks: usize,
     /// Total spend in microdollars.
     pub total_spend_microdollars: u64,
     /// Budget cap in microdollars, if set.
@@ -2337,6 +2378,9 @@ mod tests {
             max_rejections: 3,
             rejection_count: 0,
             original_prompt: None,
+            created_at_ms: None,
+            started_at_ms: None,
+            completed_at_ms: None,
         };
         pool.store().put_task(record).await.unwrap();
 
@@ -2382,6 +2426,8 @@ mod tests {
                 success: true,
                 cost_microdollars: 100,
                 turns_used: 0,
+                elapsed_ms: 0,
+                model: None,
                 session_id: None,
                 failed_command: None,
                 exit_code: None,
@@ -2393,6 +2439,9 @@ mod tests {
             max_rejections: 3,
             rejection_count: 0,
             original_prompt: None,
+            created_at_ms: None,
+            started_at_ms: None,
+            completed_at_ms: None,
         };
         pool.store().put_task(record).await.unwrap();
 

--- a/crates/claude-pool/src/store.rs
+++ b/crates/claude-pool/src/store.rs
@@ -138,6 +138,9 @@ mod tests {
             max_rejections: 3,
             rejection_count: 0,
             original_prompt: None,
+            created_at_ms: None,
+            started_at_ms: None,
+            completed_at_ms: None,
         };
 
         store.put_task(record).await.unwrap();
@@ -208,6 +211,9 @@ mod tests {
                     max_rejections: 3,
                     rejection_count: 0,
                     original_prompt: None,
+                    created_at_ms: None,
+                    started_at_ms: None,
+                    completed_at_ms: None,
                 })
                 .await
                 .unwrap();

--- a/crates/claude-pool/src/types.rs
+++ b/crates/claude-pool/src/types.rs
@@ -2,6 +2,15 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Current time in milliseconds since epoch.
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
 
 // Re-export shared types from claude-wrapper so consumers don't need
 // to depend on both crates for basic config.
@@ -325,6 +334,18 @@ pub struct TaskRecord {
     /// The original prompt before any rejection feedback was appended.
     #[serde(default)]
     pub original_prompt: Option<String>,
+
+    /// When this task was submitted (millis since epoch).
+    #[serde(default)]
+    pub created_at_ms: Option<u64>,
+
+    /// When this task started executing (millis since epoch).
+    #[serde(default)]
+    pub started_at_ms: Option<u64>,
+
+    /// When this task completed/failed/was cancelled (millis since epoch).
+    #[serde(default)]
+    pub completed_at_ms: Option<u64>,
 }
 
 fn default_max_rejections() -> u32 {
@@ -346,6 +367,14 @@ pub struct TaskResult {
     /// Number of turns used.
     pub turns_used: u32,
 
+    /// Wall-clock execution time in milliseconds.
+    #[serde(default)]
+    pub elapsed_ms: u64,
+
+    /// Model that executed this task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
     /// Session ID from the execution.
     pub session_id: Option<String>,
 
@@ -362,6 +391,134 @@ pub struct TaskResult {
     pub stderr: Option<String>,
 }
 
+impl TaskResult {
+    /// Create a successful task result.
+    pub fn success(output: impl Into<String>, cost_microdollars: u64, turns_used: u32) -> Self {
+        Self {
+            output: output.into(),
+            success: true,
+            cost_microdollars,
+            turns_used,
+            elapsed_ms: 0,
+            model: None,
+            session_id: None,
+            failed_command: None,
+            exit_code: None,
+            stderr: None,
+        }
+    }
+
+    /// Create a failed task result.
+    pub fn failure(output: impl Into<String>) -> Self {
+        Self {
+            output: output.into(),
+            success: false,
+            cost_microdollars: 0,
+            turns_used: 0,
+            elapsed_ms: 0,
+            model: None,
+            session_id: None,
+            failed_command: None,
+            exit_code: None,
+            stderr: None,
+        }
+    }
+
+    /// Set the model that executed this task.
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the elapsed execution time in milliseconds.
+    pub fn with_elapsed_ms(mut self, elapsed_ms: u64) -> Self {
+        self.elapsed_ms = elapsed_ms;
+        self
+    }
+
+    /// Set the session ID.
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    /// Set failure details (command, exit code, stderr).
+    pub fn with_failure_details(
+        mut self,
+        command: Option<String>,
+        exit_code: Option<i32>,
+        stderr: Option<String>,
+    ) -> Self {
+        self.failed_command = command;
+        self.exit_code = exit_code;
+        self.stderr = stderr;
+        self
+    }
+}
+
+impl TaskRecord {
+    /// Create a new pending task record with timestamps.
+    pub fn new_pending(id: TaskId, prompt: impl Into<String>) -> Self {
+        Self {
+            id,
+            prompt: prompt.into(),
+            state: TaskState::Pending,
+            slot_id: None,
+            result: None,
+            tags: vec![],
+            config: None,
+            review_required: false,
+            max_rejections: 3,
+            rejection_count: 0,
+            original_prompt: None,
+            created_at_ms: Some(now_ms()),
+            started_at_ms: None,
+            completed_at_ms: None,
+        }
+    }
+
+    /// Set tags.
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags = tags;
+        self
+    }
+
+    /// Set per-task config overrides.
+    pub fn with_config(mut self, config: Option<TaskOverrides>) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Enable review-required mode.
+    pub fn with_review(mut self, max_rejections: u32) -> Self {
+        self.review_required = true;
+        self.max_rejections = max_rejections;
+        self.original_prompt = Some(self.prompt.clone());
+        self
+    }
+
+    /// Transition the task to a new state, setting timestamps automatically.
+    ///
+    /// - `Running`: sets `started_at_ms`
+    /// - `Completed`, `Failed`, `Cancelled`, `PendingReview`: sets `completed_at_ms`
+    pub fn transition_to(&mut self, state: TaskState) {
+        self.state = state;
+        let now = now_ms();
+        match state {
+            TaskState::Running => {
+                self.started_at_ms = Some(now);
+            }
+            TaskState::Completed
+            | TaskState::Failed
+            | TaskState::Cancelled
+            | TaskState::PendingReview => {
+                self.completed_at_ms = Some(now);
+            }
+            TaskState::Pending => {}
+        }
+    }
+}
+
 /// Filter criteria for listing tasks.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TaskFilter {
@@ -373,4 +530,84 @@ pub struct TaskFilter {
 
     /// Filter by tags (any match).
     pub tags: Option<Vec<String>>,
+}
+
+/// Aggregated metrics for the current pool session.
+///
+/// Provides developer-focused insights: spend tracking, task timing,
+/// and sizing data useful for optimizing pool usage patterns.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionMetrics {
+    /// Total number of tasks submitted this session.
+    pub total_tasks: u64,
+    /// Number of completed tasks.
+    pub completed_tasks: u64,
+    /// Number of failed tasks.
+    pub failed_tasks: u64,
+    /// Number of cancelled tasks.
+    pub cancelled_tasks: u64,
+    /// Number of currently running tasks.
+    pub running_tasks: u64,
+    /// Number of pending tasks.
+    pub pending_tasks: u64,
+
+    /// Total spend across all tasks in microdollars.
+    pub total_spend_microdollars: u64,
+    /// Average cost per completed task in microdollars.
+    pub avg_cost_microdollars: u64,
+    /// Highest single-task cost in microdollars.
+    pub max_cost_microdollars: u64,
+
+    /// Average execution time for completed tasks in milliseconds.
+    pub avg_elapsed_ms: u64,
+    /// Median execution time for completed tasks in milliseconds.
+    pub median_elapsed_ms: u64,
+    /// Maximum execution time for completed tasks in milliseconds.
+    pub max_elapsed_ms: u64,
+    /// Minimum execution time for completed tasks in milliseconds.
+    pub min_elapsed_ms: u64,
+
+    /// Average number of turns per completed task.
+    pub avg_turns: f64,
+
+    /// Breakdown of tasks by model (count only).
+    pub tasks_by_model: HashMap<String, u64>,
+
+    /// Detailed per-model metrics.
+    pub model_breakdown: Vec<ModelMetrics>,
+
+    /// Session start time (millis since epoch).
+    pub session_start_ms: u64,
+    /// Session duration so far in milliseconds.
+    pub session_duration_ms: u64,
+}
+
+/// Per-model aggregated metrics.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ModelMetrics {
+    /// Model identifier.
+    pub model: String,
+    /// Number of tasks run on this model.
+    pub task_count: u64,
+    /// Total spend for this model in microdollars.
+    pub total_cost_microdollars: u64,
+    /// Average cost per task in microdollars.
+    pub avg_cost_microdollars: u64,
+    /// Average execution time in milliseconds.
+    pub avg_elapsed_ms: u64,
+    /// Total turns used by this model.
+    pub total_turns: u64,
+}
+
+/// Filter criteria for session metrics queries.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MetricsFilter {
+    /// Only include tasks created after this time (millis since epoch).
+    pub since_ms: Option<u64>,
+    /// Only include tasks created before this time (millis since epoch).
+    pub until_ms: Option<u64>,
+    /// Only include tasks with these tags (any match).
+    pub tags: Option<Vec<String>>,
+    /// Only include tasks that ran on this model.
+    pub model: Option<String>,
 }


### PR DESCRIPTION
## Summary
- Add timestamps (`created_at_ms`, `started_at_ms`, `completed_at_ms`) to `TaskRecord` and execution metrics (`elapsed_ms`, `model`) to `TaskResult`
- Introduce `TaskRecord::transition_to()` method that centralizes state transitions and sets timestamps automatically across ~25 call sites
- Add `SessionMetrics` aggregation with per-model cost/timing breakdowns, median/avg/min/max elapsed times, and `MetricsFilter` for time-window/tag/model filtering
- Expose metrics via `Pool::session_metrics()`, REST endpoint `GET /v1/pool/metrics`, and MCP tool `pool_session_metrics`
- Builder pattern for `TaskResult` and `TaskRecord` reduces construction boilerplate
- Add completed/failed/cancelled task counts to `PoolStatus`
- Update CLAUDE.md with pool usage guidelines (prefer pool over Agent(), model selection guidance)

## Test plan
- [x] All 81 lib tests pass
- [x] All 32 REST API tests pass (including new metrics endpoint test)
- [x] All 34 doc tests pass
- [x] clippy clean, fmt clean
- [ ] Manual verification with live pool session

Closes #210