### PR TITLE
feat: add pagination to REST task and chain list endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "claude-pool",
  "claude-wrapper",
  "dirs",
+ "http-body-util",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/claude-pool-server/src/rest/routes/chains.rs
+++ b/crates/claude-pool-server/src/rest/routes/chains.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use claude_pool::{ChainOptions, ChainStep, PoolStore, StepAction, TaskId};
 use serde::{Deserialize, Serialize};
 
@@ -68,7 +68,7 @@ pub struct ChainProgressResponse {
 }
 
 /// Summary entry for chain listing.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct ChainSummary {
     pub chain_id: String,
     pub status: String,
@@ -76,10 +76,39 @@ pub struct ChainSummary {
     pub completed_steps: usize,
 }
 
-/// `GET /v1/chains` — list all tracked chains.
+/// Pagination query parameters for `GET /v1/chains`.
+#[derive(Debug, Deserialize)]
+pub struct ListChainsQuery {
+    /// Maximum number of items per page (default: 50).
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    /// Offset for pagination (default: 0).
+    #[serde(default)]
+    pub offset: usize,
+}
+
+fn default_limit() -> usize {
+    50
+}
+
+/// Paginated response wrapper.
+#[derive(Debug, Serialize)]
+pub struct PaginatedResponse<T> {
+    /// Items in this page.
+    pub items: Vec<T>,
+    /// Total number of items available.
+    pub total: usize,
+    /// Items per page.
+    pub limit: usize,
+    /// Offset of this page.
+    pub offset: usize,
+}
+
+/// `GET /v1/chains` — list all tracked chains with pagination.
 pub async fn list_chains<S: PoolStore + 'static>(
     State(state): State<Arc<AppState<S>>>,
-) -> Json<Vec<ChainSummary>> {
+    Query(query): Query<ListChainsQuery>,
+) -> Json<PaginatedResponse<ChainSummary>> {
     let entries = state.state.pool.list_chain_progress();
     let summaries: Vec<ChainSummary> = entries
         .into_iter()
@@ -90,7 +119,18 @@ pub async fn list_chains<S: PoolStore + 'static>(
             completed_steps: progress.completed_steps.len(),
         })
         .collect();
-    Json(summaries)
+
+    let total = summaries.len();
+    let start = query.offset.min(total);
+    let end = (query.offset + query.limit).min(total);
+    let items = summaries[start..end].to_vec();
+
+    Json(PaginatedResponse {
+        items,
+        total,
+        limit: query.limit,
+        offset: query.offset,
+    })
 }
 
 /// `POST /v1/chains` — submit a chain for async execution.

--- a/crates/claude-pool-server/src/rest/routes/tasks.rs
+++ b/crates/claude-pool-server/src/rest/routes/tasks.rs
@@ -89,6 +89,34 @@ pub struct RejectRequest {
     pub feedback: String,
 }
 
+/// Pagination query parameters.
+#[derive(Debug, Deserialize)]
+pub struct PaginationQuery {
+    /// Maximum number of items per page (default: 50).
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    /// Offset for pagination (default: 0).
+    #[serde(default)]
+    pub offset: usize,
+}
+
+fn default_limit() -> usize {
+    50
+}
+
+/// Paginated response wrapper.
+#[derive(Debug, Serialize)]
+pub struct PaginatedResponse<T> {
+    /// Items in this page.
+    pub items: Vec<T>,
+    /// Total number of items available.
+    pub total: usize,
+    /// Items per page.
+    pub limit: usize,
+    /// Offset of this page.
+    pub offset: usize,
+}
+
 /// Query parameters for `GET /v1/tasks`.
 #[derive(Debug, Deserialize)]
 pub struct ListTasksQuery {
@@ -96,13 +124,19 @@ pub struct ListTasksQuery {
     pub state: Option<String>,
     /// Filter by tag (any match).
     pub tag: Option<String>,
+    /// Maximum number of items per page (default: 50).
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    /// Offset for pagination (default: 0).
+    #[serde(default)]
+    pub offset: usize,
 }
 
-/// `GET /v1/tasks` — list tasks with optional filtering.
+/// `GET /v1/tasks` — list tasks with optional filtering and pagination.
 pub async fn list_tasks<S: PoolStore + 'static>(
     State(state): State<Arc<AppState<S>>>,
     Query(query): Query<ListTasksQuery>,
-) -> Result<Json<Vec<TaskResponse>>, ProblemDetails> {
+) -> Result<Json<PaginatedResponse<TaskResponse>>, ProblemDetails> {
     let task_state = query.state.as_deref().and_then(parse_task_state);
     let tags = query.tag.map(|t| vec![t]);
 
@@ -120,7 +154,11 @@ pub async fn list_tasks<S: PoolStore + 'static>(
         .await
         .map_err(ProblemDetails::from)?;
 
-    let tasks: Vec<TaskResponse> = records
+    let total = records.len();
+    let start = query.offset.min(total);
+    let end = (query.offset + query.limit).min(total);
+
+    let tasks: Vec<TaskResponse> = records[start..end]
         .iter()
         .map(|record| {
             let state_str = format!("{:?}", record.state).to_lowercase();
@@ -144,7 +182,12 @@ pub async fn list_tasks<S: PoolStore + 'static>(
         })
         .collect();
 
-    Ok(Json(tasks))
+    Ok(Json(PaginatedResponse {
+        items: tasks,
+        total,
+        limit: query.limit,
+        offset: query.offset,
+    }))
 }
 
 fn parse_task_state(s: &str) -> Option<TaskState> {

--- a/crates/claude-pool-server/tests/rest_api_tests.rs
+++ b/crates/claude-pool-server/tests/rest_api_tests.rs
@@ -186,7 +186,10 @@ async fn list_tasks_empty() {
     let app = test_router(1).await;
     let (status, body) = send(app, get("/v1/tasks")).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body, json!([]));
+    assert_eq!(body["items"], json!([]));
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["limit"], 50);
+    assert_eq!(body["offset"], 0);
 }
 
 #[tokio::test]
@@ -240,6 +243,94 @@ async fn fan_out_empty_prompts_rejected() {
     assert!(body["type"].as_str().unwrap().contains("bad-request"));
 }
 
+#[tokio::test]
+async fn list_tasks_default_pagination() {
+    let app = test_router(1).await;
+
+    // Submit 3 tasks.
+    for i in 0..3 {
+        send(
+            app.clone(),
+            post_json("/v1/tasks", json!({"prompt": format!("task {i}")})),
+        )
+        .await;
+    }
+
+    // List with defaults: limit=50, offset=0.
+    let (status, body) = send(app, get("/v1/tasks")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 3);
+    assert_eq!(body["limit"], 50);
+    assert_eq!(body["offset"], 0);
+    assert_eq!(body["items"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn list_tasks_custom_limit() {
+    let app = test_router(1).await;
+
+    // Submit 10 tasks.
+    for i in 0..10 {
+        send(
+            app.clone(),
+            post_json("/v1/tasks", json!({"prompt": format!("task {i}")})),
+        )
+        .await;
+    }
+
+    // List with limit=3, offset=0.
+    let (status, body) = send(app, get("/v1/tasks?limit=3&offset=0")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 10);
+    assert_eq!(body["limit"], 3);
+    assert_eq!(body["offset"], 0);
+    assert_eq!(body["items"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn list_tasks_custom_offset() {
+    let app = test_router(1).await;
+
+    // Submit 5 tasks.
+    for i in 0..5 {
+        send(
+            app.clone(),
+            post_json("/v1/tasks", json!({"prompt": format!("task {i}")})),
+        )
+        .await;
+    }
+
+    // List with limit=2, offset=2.
+    let (status, body) = send(app, get("/v1/tasks?limit=2&offset=2")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 5);
+    assert_eq!(body["limit"], 2);
+    assert_eq!(body["offset"], 2);
+    assert_eq!(body["items"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn list_tasks_offset_beyond_results() {
+    let app = test_router(1).await;
+
+    // Submit 3 tasks.
+    for i in 0..3 {
+        send(
+            app.clone(),
+            post_json("/v1/tasks", json!({"prompt": format!("task {i}")})),
+        )
+        .await;
+    }
+
+    // List with offset=10 (beyond total).
+    let (status, body) = send(app, get("/v1/tasks?limit=10&offset=10")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 3);
+    assert_eq!(body["limit"], 10);
+    assert_eq!(body["offset"], 10);
+    assert_eq!(body["items"].as_array().unwrap().len(), 0);
+}
+
 // ── Chains ───────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -247,7 +338,10 @@ async fn list_chains_empty() {
     let app = test_router(1).await;
     let (status, body) = send(app, get("/v1/chains")).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body, json!([]));
+    assert_eq!(body["items"], json!([]));
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["limit"], 50);
+    assert_eq!(body["offset"], 0);
 }
 
 #[tokio::test]
@@ -283,6 +377,122 @@ async fn submit_and_get_chain() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["chain_id"], chain_id);
     assert_eq!(body["total_steps"], 2);
+}
+
+#[tokio::test]
+async fn list_chains_default_pagination() {
+    let app = test_router(1).await;
+
+    // Submit 3 chains.
+    for i in 0..3 {
+        send(
+            app.clone(),
+            post_json(
+                "/v1/chains",
+                json!({
+                    "steps": [
+                        {"name": format!("step_{i}_1"), "prompt": "do thing"},
+                    ]
+                }),
+            ),
+        )
+        .await;
+    }
+
+    // List with defaults: limit=50, offset=0.
+    let (status, body) = send(app, get("/v1/chains")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 3);
+    assert_eq!(body["limit"], 50);
+    assert_eq!(body["offset"], 0);
+    assert_eq!(body["items"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn list_chains_custom_limit() {
+    let app = test_router(1).await;
+
+    // Submit 5 chains.
+    for i in 0..5 {
+        send(
+            app.clone(),
+            post_json(
+                "/v1/chains",
+                json!({
+                    "steps": [
+                        {"name": format!("step_{i}_1"), "prompt": "do thing"},
+                    ]
+                }),
+            ),
+        )
+        .await;
+    }
+
+    // List with limit=2, offset=0.
+    let (status, body) = send(app, get("/v1/chains?limit=2&offset=0")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 5);
+    assert_eq!(body["limit"], 2);
+    assert_eq!(body["offset"], 0);
+    assert_eq!(body["items"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn list_chains_custom_offset() {
+    let app = test_router(1).await;
+
+    // Submit 5 chains.
+    for i in 0..5 {
+        send(
+            app.clone(),
+            post_json(
+                "/v1/chains",
+                json!({
+                    "steps": [
+                        {"name": format!("step_{i}_1"), "prompt": "do thing"},
+                    ]
+                }),
+            ),
+        )
+        .await;
+    }
+
+    // List with limit=2, offset=3.
+    let (status, body) = send(app, get("/v1/chains?limit=2&offset=3")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 5);
+    assert_eq!(body["limit"], 2);
+    assert_eq!(body["offset"], 3);
+    assert_eq!(body["items"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn list_chains_offset_beyond_results() {
+    let app = test_router(1).await;
+
+    // Submit 2 chains.
+    for i in 0..2 {
+        send(
+            app.clone(),
+            post_json(
+                "/v1/chains",
+                json!({
+                    "steps": [
+                        {"name": format!("step_{i}_1"), "prompt": "do thing"},
+                    ]
+                }),
+            ),
+        )
+        .await;
+    }
+
+    // List with offset=10 (beyond total).
+    let (status, body) = send(app, get("/v1/chains?limit=10&offset=10")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 2);
+    assert_eq!(body["limit"], 10);
+    assert_eq!(body["offset"], 10);
+    assert_eq!(body["items"].as_array().unwrap().len(), 0);
 }
 
 // ── Skills ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add ?limit=N&offset=M query params to GET /v1/tasks and GET /v1/chains
- Default: limit=50, offset=0
- Wrap responses in PaginatedResponse with total count
- Add integration tests for pagination

Closes #215