### PR TITLE
feat: add disallowed_tools and tools to TaskOverrides

### DIFF
--- a/crates/claude-pool-server/src/rest/routes/tasks.rs
+++ b/crates/claude-pool-server/src/rest/routes/tasks.rs
@@ -30,6 +30,10 @@ pub struct SubmitTaskRequest {
     /// Tags for grouping/filtering.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Tools to explicitly disallow for this task.
+    pub disallowed_tools: Option<Vec<String>>,
+    /// Built-in tool selection for this task (e.g. "Bash", "Edit", "Read").
+    pub tools: Option<Vec<String>>,
     /// Whether this task requires coordinator approval before completion.
     #[serde(default)]
     pub review_required: bool,
@@ -71,6 +75,10 @@ pub struct FanOutRequest {
     pub model: Option<String>,
     /// Optional effort override for all tasks.
     pub effort: Option<String>,
+    /// Tools to explicitly disallow for all tasks.
+    pub disallowed_tools: Option<Vec<String>>,
+    /// Built-in tool selection for all tasks (e.g. "Bash", "Edit", "Read").
+    pub tools: Option<Vec<String>>,
 }
 
 /// Response body for fan-out.
@@ -107,16 +115,6 @@ pub struct PaginationQuery {
 
 fn default_limit() -> usize {
     50
-}
-
-fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
-    match s {
-        "low" => Some(claude_pool::Effort::Low),
-        "medium" => Some(claude_pool::Effort::Medium),
-        "high" => Some(claude_pool::Effort::High),
-        "max" => Some(claude_pool::Effort::Max),
-        _ => None,
-    }
 }
 
 /// Paginated response wrapper.
@@ -222,22 +220,14 @@ pub async fn submit_task<S: PoolStore + 'static>(
     State(state): State<Arc<AppState<S>>>,
     Json(req): Json<SubmitTaskRequest>,
 ) -> Result<(axum::http::StatusCode, Json<SubmitTaskResponse>), ProblemDetails> {
-    // Build task config if any overrides are provided.
-    let config = if req.model.is_some()
-        || req.effort.is_some()
-        || req.mcp_servers.is_some()
-        || req.json_schema.is_some()
-    {
-        Some(claude_pool::TaskOverrides {
-            model: req.model,
-            effort: req.effort.and_then(|e| parse_effort(&e)),
-            mcp_servers: req.mcp_servers,
-            json_schema: req.json_schema,
-            ..Default::default()
-        })
-    } else {
-        None
-    };
+    let config = build_task_config(
+        req.model,
+        req.effort,
+        req.mcp_servers,
+        req.json_schema,
+        req.disallowed_tools,
+        req.tools,
+    );
 
     let task_id = if req.review_required {
         state
@@ -405,4 +395,44 @@ pub async fn stream_task<S: PoolStore + 'static>(
 
     let stream = crate::rest::sse::task_stream(state.state.clone(), id);
     Ok(axum::response::sse::Sse::new(stream).keep_alive(crate::rest::sse::keep_alive()))
+}
+
+// ── Helper functions ────────────────────────────────────────────────────
+
+fn parse_effort(s: &str) -> Option<claude_pool::Effort> {
+    match s.to_lowercase().as_str() {
+        "min" | "low" => Some(claude_pool::Effort::Low),
+        "medium" => Some(claude_pool::Effort::Medium),
+        "high" => Some(claude_pool::Effort::High),
+        "max" => Some(claude_pool::Effort::Max),
+        _ => None,
+    }
+}
+
+fn build_task_config(
+    model: Option<String>,
+    effort: Option<String>,
+    mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
+    json_schema: Option<serde_json::Value>,
+    disallowed_tools: Option<Vec<String>>,
+    tools: Option<Vec<String>>,
+) -> Option<claude_pool::types::TaskOverrides> {
+    if model.is_none()
+        && effort.is_none()
+        && mcp_servers.is_none()
+        && json_schema.is_none()
+        && disallowed_tools.is_none()
+        && tools.is_none()
+    {
+        return None;
+    }
+    Some(claude_pool::types::TaskOverrides {
+        model,
+        effort: effort.and_then(|e| parse_effort(&e)),
+        mcp_servers,
+        json_schema,
+        disallowed_tools,
+        tools,
+        ..Default::default()
+    })
 }

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -101,6 +101,10 @@ pub struct RunInput {
     pub model: Option<String>,
     /// Effort override for this task (min, low, medium, high, max).
     pub effort: Option<String>,
+    /// Tools to explicitly disallow for this task.
+    pub disallowed_tools: Option<Vec<String>>,
+    /// Built-in tool selection for this task (e.g. "Bash", "Edit", "Read").
+    pub tools: Option<Vec<String>>,
     /// Additional MCP servers for this task (merged with global/slot servers).
     /// Keys are server names, values are server config objects.
     pub mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
@@ -118,6 +122,10 @@ pub struct SubmitInput {
     pub effort: Option<String>,
     /// Tags for grouping/filtering.
     pub tags: Option<Vec<String>>,
+    /// Tools to explicitly disallow for this task.
+    pub disallowed_tools: Option<Vec<String>>,
+    /// Built-in tool selection for this task (e.g. "Bash", "Edit", "Read").
+    pub tools: Option<Vec<String>>,
     /// Additional MCP servers for this task (merged with global/slot servers).
     /// Keys are server names, values are server config objects.
     pub mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
@@ -334,6 +342,10 @@ pub struct SubmitWithReviewInput {
     pub mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
     /// JSON schema for structured output validation.
     pub json_schema: Option<serde_json::Value>,
+    /// Tools to explicitly deny for this task.
+    pub disallowed_tools: Option<Vec<String>>,
+    /// Built-in tool selection for this task (Bash, Edit, Read, etc.).
+    pub tools: Option<Vec<String>>,
 }
 
 /// Input for approving a task result.
@@ -370,8 +382,16 @@ fn task_config_from(
     effort: Option<String>,
     mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
     json_schema: Option<serde_json::Value>,
+    disallowed_tools: Option<Vec<String>>,
+    tools: Option<Vec<String>>,
 ) -> Option<TaskOverrides> {
-    if model.is_none() && effort.is_none() && mcp_servers.is_none() && json_schema.is_none() {
+    if model.is_none()
+        && effort.is_none()
+        && mcp_servers.is_none()
+        && json_schema.is_none()
+        && disallowed_tools.is_none()
+        && tools.is_none()
+    {
         return None;
     }
     Some(TaskOverrides {
@@ -379,6 +399,8 @@ fn task_config_from(
         effort: effort.and_then(|e| parse_effort(&e)),
         mcp_servers,
         json_schema,
+        disallowed_tools,
+        tools,
         ..Default::default()
     })
 }
@@ -520,6 +542,8 @@ pub fn pool_run_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
                     input.effort,
                     input.mcp_servers,
                     input.json_schema,
+                    input.disallowed_tools,
+                    input.tools,
                 );
                 let mut builder = state.pool.run(&input.prompt);
                 if let Some(cfg) = config {
@@ -574,7 +598,14 @@ pub fn pool_submit_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
         .handler(move |input: SubmitInput| {
             let state = Arc::clone(&state);
             async move {
-                let config = task_config_from(input.model, input.effort, input.mcp_servers, input.json_schema);
+                let config = task_config_from(
+                    input.model,
+                    input.effort,
+                    input.mcp_servers,
+                    input.json_schema,
+                    input.disallowed_tools,
+                    input.tools,
+                );
                 let tags = input.tags.unwrap_or_default();
                 match state
                     .pool
@@ -1157,7 +1188,7 @@ fn convert_chain_steps(steps: Vec<ChainStepInput>) -> Vec<claude_pool::ChainStep
                 },
                 _ => claude_pool::StepAction::Prompt { prompt: s.value },
             };
-            let config = task_config_from(s.model, s.effort, None, None);
+            let config = task_config_from(s.model, s.effort, None, None, None, None);
             let failure_policy = claude_pool::StepFailurePolicy {
                 retries: s.retries.unwrap_or(0),
                 recovery_prompt: s.recovery_prompt,
@@ -2208,6 +2239,8 @@ pub fn pool_submit_with_review_tool<S: PoolStore + 'static>(state: Arc<State<S>>
                     input.effort,
                     input.mcp_servers,
                     input.json_schema,
+                    input.disallowed_tools,
+                    input.tools,
                 );
                 let tags = input.tags.unwrap_or_default();
                 match state

--- a/crates/claude-pool/src/config.rs
+++ b/crates/claude-pool/src/config.rs
@@ -21,6 +21,8 @@ pub struct ResolvedConfig {
     pub max_turns: Option<u32>,
     pub system_prompt: Option<String>,
     pub allowed_tools: Vec<String>,
+    pub disallowed_tools: Vec<String>,
+    pub tools: Vec<String>,
     pub effort: Option<Effort>,
     /// Merged MCP servers from global + slot + task layers.
     /// Later layers override earlier layers by server name.
@@ -75,6 +77,18 @@ impl ResolvedConfig {
             allowed_tools.extend(tt.iter().cloned());
         }
 
+        // Task-level disallowed tools
+        let disallowed_tools = task
+            .and_then(|t| t.disallowed_tools.as_ref())
+            .cloned()
+            .unwrap_or_default();
+
+        // Task-level tools selection
+        let tools = task
+            .and_then(|t| t.tools.as_ref())
+            .cloned()
+            .unwrap_or_default();
+
         // Merge MCP servers: global base, slot overrides/adds, task overrides/adds.
         // Same-named servers in later layers replace earlier ones.
         let mut mcp_servers = global.mcp_servers.clone();
@@ -97,6 +111,8 @@ impl ResolvedConfig {
             max_turns,
             system_prompt,
             allowed_tools,
+            disallowed_tools,
+            tools,
             effort,
             mcp_servers,
             strict_mcp_config,

--- a/crates/claude-pool/src/executor.rs
+++ b/crates/claude-pool/src/executor.rs
@@ -209,6 +209,12 @@ pub(crate) async fn execute_task<S: PoolStore + 'static>(
     if !resolved.allowed_tools.is_empty() {
         cmd = cmd.allowed_tools(&resolved.allowed_tools);
     }
+    if !resolved.disallowed_tools.is_empty() {
+        cmd = cmd.disallowed_tools(&resolved.disallowed_tools);
+    }
+    if !resolved.tools.is_empty() {
+        cmd = cmd.tools(&resolved.tools);
+    }
 
     // Write per-slot MCP config if servers are configured.
     // Reuses an existing temp file if the slot already has one; otherwise
@@ -351,6 +357,12 @@ pub(crate) async fn execute_task_streaming<S: PoolStore + 'static>(
     }
     if !resolved.allowed_tools.is_empty() {
         cmd = cmd.allowed_tools(&resolved.allowed_tools);
+    }
+    if !resolved.disallowed_tools.is_empty() {
+        cmd = cmd.disallowed_tools(&resolved.disallowed_tools);
+    }
+    if !resolved.tools.is_empty() {
+        cmd = cmd.tools(&resolved.tools);
     }
 
     if !resolved.mcp_servers.is_empty() {

--- a/crates/claude-pool/src/types.rs
+++ b/crates/claude-pool/src/types.rs
@@ -216,6 +216,12 @@ pub struct TaskOverrides {
     /// Additional allowed tools for this task (merged with global and slot).
     pub allowed_tools: Option<Vec<String>>,
 
+    /// Tools to explicitly disallow for this task.
+    pub disallowed_tools: Option<Vec<String>>,
+
+    /// Built-in tool selection for this task (e.g. "Bash", "Edit", "Read").
+    pub tools: Option<Vec<String>>,
+
     /// Additional MCP servers for this task (merged with global and slot).
     pub mcp_servers: Option<HashMap<String, serde_json::Value>>,
 


### PR DESCRIPTION
## Summary
- Add disallowed_tools and tools fields to TaskOverrides
- Wire through config merge (task overrides slot overrides pool)
- Pass as --disallowed-tools and --tools CLI flags in executor
- Exposed in MCP submit/run tools and REST POST /v1/tasks
- Enables per-task tool scoping: read-only workers, no-Bash workers, etc.

Closes #225