### PR TITLE
feat: add max_budget_usd to TaskOverrides for per-task budget caps

### DIFF
--- a/crates/claude-pool-server/src/rest/routes/tasks.rs
+++ b/crates/claude-pool-server/src/rest/routes/tasks.rs
@@ -44,6 +44,8 @@ pub struct SubmitTaskRequest {
     /// Additional MCP servers for this task (merged with global/slot servers).
     /// Keys are server names, values are server config objects.
     pub mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
+    /// Maximum budget cap for this task in USD.
+    pub max_budget_usd: Option<f64>,
 }
 
 /// Response body for task submission.
@@ -227,6 +229,7 @@ pub async fn submit_task<S: PoolStore + 'static>(
         req.json_schema,
         req.disallowed_tools,
         req.tools,
+        req.max_budget_usd,
     );
 
     let task_id = if req.review_required {
@@ -416,6 +419,7 @@ fn build_task_config(
     json_schema: Option<serde_json::Value>,
     disallowed_tools: Option<Vec<String>>,
     tools: Option<Vec<String>>,
+    max_budget_usd: Option<f64>,
 ) -> Option<claude_pool::types::TaskOverrides> {
     if model.is_none()
         && effort.is_none()
@@ -423,6 +427,7 @@ fn build_task_config(
         && json_schema.is_none()
         && disallowed_tools.is_none()
         && tools.is_none()
+        && max_budget_usd.is_none()
     {
         return None;
     }
@@ -433,6 +438,7 @@ fn build_task_config(
         json_schema,
         disallowed_tools,
         tools,
+        max_budget_usd,
         ..Default::default()
     })
 }

--- a/crates/claude-pool-server/src/tools.rs
+++ b/crates/claude-pool-server/src/tools.rs
@@ -110,6 +110,8 @@ pub struct RunInput {
     pub mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
     /// JSON schema for structured output validation.
     pub json_schema: Option<serde_json::Value>,
+    /// Maximum budget cap for this task in USD.
+    pub max_budget_usd: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -131,6 +133,8 @@ pub struct SubmitInput {
     pub mcp_servers: Option<std::collections::HashMap<String, serde_json::Value>>,
     /// JSON schema for structured output validation.
     pub json_schema: Option<serde_json::Value>,
+    /// Maximum budget cap for this task in USD.
+    pub max_budget_usd: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -346,6 +350,8 @@ pub struct SubmitWithReviewInput {
     pub disallowed_tools: Option<Vec<String>>,
     /// Built-in tool selection for this task (Bash, Edit, Read, etc.).
     pub tools: Option<Vec<String>>,
+    /// Maximum budget cap for this task in USD.
+    pub max_budget_usd: Option<f64>,
 }
 
 /// Input for approving a task result.
@@ -384,6 +390,7 @@ fn task_config_from(
     json_schema: Option<serde_json::Value>,
     disallowed_tools: Option<Vec<String>>,
     tools: Option<Vec<String>>,
+    max_budget_usd: Option<f64>,
 ) -> Option<TaskOverrides> {
     if model.is_none()
         && effort.is_none()
@@ -391,6 +398,7 @@ fn task_config_from(
         && json_schema.is_none()
         && disallowed_tools.is_none()
         && tools.is_none()
+        && max_budget_usd.is_none()
     {
         return None;
     }
@@ -401,6 +409,7 @@ fn task_config_from(
         json_schema,
         disallowed_tools,
         tools,
+        max_budget_usd,
         ..Default::default()
     })
 }
@@ -544,6 +553,7 @@ pub fn pool_run_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
                     input.json_schema,
                     input.disallowed_tools,
                     input.tools,
+                    input.max_budget_usd,
                 );
                 let mut builder = state.pool.run(&input.prompt);
                 if let Some(cfg) = config {
@@ -605,6 +615,7 @@ pub fn pool_submit_tool<S: PoolStore + 'static>(state: Arc<State<S>>) -> Tool {
                     input.json_schema,
                     input.disallowed_tools,
                     input.tools,
+                    input.max_budget_usd,
                 );
                 let tags = input.tags.unwrap_or_default();
                 match state
@@ -1188,7 +1199,7 @@ fn convert_chain_steps(steps: Vec<ChainStepInput>) -> Vec<claude_pool::ChainStep
                 },
                 _ => claude_pool::StepAction::Prompt { prompt: s.value },
             };
-            let config = task_config_from(s.model, s.effort, None, None, None, None);
+            let config = task_config_from(s.model, s.effort, None, None, None, None, None);
             let failure_policy = claude_pool::StepFailurePolicy {
                 retries: s.retries.unwrap_or(0),
                 recovery_prompt: s.recovery_prompt,
@@ -2241,6 +2252,7 @@ pub fn pool_submit_with_review_tool<S: PoolStore + 'static>(state: Arc<State<S>>
                     input.json_schema,
                     input.disallowed_tools,
                     input.tools,
+                    input.max_budget_usd,
                 );
                 let tags = input.tags.unwrap_or_default();
                 match state

--- a/crates/claude-pool/src/config.rs
+++ b/crates/claude-pool/src/config.rs
@@ -31,6 +31,8 @@ pub struct ResolvedConfig {
     pub strict_mcp_config: bool,
     /// JSON schema for structured output validation (task overrides).
     pub json_schema: Option<serde_json::Value>,
+    /// Maximum budget cap for the task in USD.
+    pub max_budget_usd: Option<f64>,
 }
 
 impl ResolvedConfig {
@@ -104,6 +106,9 @@ impl ResolvedConfig {
         let strict_mcp_config = global.strict_mcp_config;
 
         let json_schema = task.and_then(|t| t.json_schema.clone());
+        let max_budget_usd = task
+            .and_then(|t| t.max_budget_usd)
+            .or_else(|| global.budget_microdollars.map(|m| m as f64 / 1_000_000.0));
 
         Self {
             model,
@@ -117,6 +122,7 @@ impl ResolvedConfig {
             mcp_servers,
             strict_mcp_config,
             json_schema,
+            max_budget_usd,
         }
     }
 }

--- a/crates/claude-pool/src/executor.rs
+++ b/crates/claude-pool/src/executor.rs
@@ -206,6 +206,9 @@ pub(crate) async fn execute_task<S: PoolStore + 'static>(
     if let Some(ref schema) = resolved.json_schema {
         cmd = cmd.json_schema(schema.to_string());
     }
+    if let Some(max_budget) = resolved.max_budget_usd {
+        cmd = cmd.max_budget_usd(max_budget);
+    }
     if !resolved.allowed_tools.is_empty() {
         cmd = cmd.allowed_tools(&resolved.allowed_tools);
     }
@@ -354,6 +357,9 @@ pub(crate) async fn execute_task_streaming<S: PoolStore + 'static>(
     }
     if let Some(effort) = resolved.effort {
         cmd = cmd.effort(effort);
+    }
+    if let Some(max_budget) = resolved.max_budget_usd {
+        cmd = cmd.max_budget_usd(max_budget);
     }
     if !resolved.allowed_tools.is_empty() {
         cmd = cmd.allowed_tools(&resolved.allowed_tools);

--- a/crates/claude-pool/src/types.rs
+++ b/crates/claude-pool/src/types.rs
@@ -230,6 +230,9 @@ pub struct TaskOverrides {
 
     /// JSON schema for structured output validation.
     pub json_schema: Option<serde_json::Value>,
+
+    /// Maximum budget cap for this task in USD.
+    pub max_budget_usd: Option<f64>,
 }
 
 /// Current state of a slot.


### PR DESCRIPTION
## Summary
- Add max_budget_usd field to TaskOverrides
- Wire through config merge and executor as --max-budget-usd CLI flag
- Exposed in MCP submit/run tools and REST POST /v1/tasks
- Defense in depth: per-invocation budget on top of pool-level budget tracking

Closes #226