### PR TITLE
feat: add fallback_model to PoolConfig and SlotConfig

### DIFF
--- a/crates/claude-pool/src/config.rs
+++ b/crates/claude-pool/src/config.rs
@@ -17,6 +17,7 @@ use crate::types::{PoolConfig, SlotConfig, TaskOverrides};
 #[derive(Debug, Clone)]
 pub struct ResolvedConfig {
     pub model: Option<String>,
+    pub fallback_model: Option<String>,
     pub permission_mode: PermissionMode,
     pub max_turns: Option<u32>,
     pub system_prompt: Option<String>,
@@ -46,6 +47,11 @@ impl ResolvedConfig {
             .and_then(|t| t.model.clone())
             .or_else(|| slot.model.clone())
             .or_else(|| global.model.clone());
+
+        let fallback_model = task
+            .and_then(|t| t.fallback_model.clone())
+            .or_else(|| slot.fallback_model.clone())
+            .or_else(|| global.fallback_model.clone());
 
         let permission_mode = task
             .and_then(|t| t.permission_mode)
@@ -112,6 +118,7 @@ impl ResolvedConfig {
 
         Self {
             model,
+            fallback_model,
             permission_mode,
             max_turns,
             system_prompt,

--- a/crates/claude-pool/src/types.rs
+++ b/crates/claude-pool/src/types.rs
@@ -83,6 +83,9 @@ pub struct PoolConfig {
     /// Default effort level for slots (maps to `--effort`).
     pub effort: Option<Effort>,
 
+    /// Fallback model to use if the primary model fails.
+    pub fallback_model: Option<String>,
+
     /// Total budget cap for the pool in microdollars.
     /// When cumulative spend across all slots reaches this limit,
     /// new tasks are rejected with [`crate::Error::BudgetExhausted`].
@@ -139,6 +142,7 @@ impl Default for PoolConfig {
             allowed_tools: Vec::new(),
             mcp_servers: HashMap::new(),
             effort: None,
+            fallback_model: None,
             budget_microdollars: None,
             slot_mode: SlotMode::default(),
             max_restarts: 3,
@@ -180,6 +184,9 @@ pub struct SlotConfig {
 
     /// Override effort level for this slot.
     pub effort: Option<Effort>,
+
+    /// Override fallback model for this slot.
+    pub fallback_model: Option<String>,
 
     /// Optional name/role for this slot (e.g. "reviewer", "coder").
     pub role: Option<String>,
@@ -227,6 +234,9 @@ pub struct TaskOverrides {
 
     /// Override effort level for this task.
     pub effort: Option<Effort>,
+
+    /// Override fallback model for this task.
+    pub fallback_model: Option<String>,
 
     /// JSON schema for structured output validation.
     pub json_schema: Option<serde_json::Value>,


### PR DESCRIPTION
Implements issue #227 - adds fallback_model configuration support to PoolConfig, SlotConfig, and TaskOverrides, allowing specifying a fallback model to use if the primary model fails.