### PR TITLE
docs: coordinator workflow as first-class concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
 # claude-wrapper
 
-A comprehensive Rust tooling suite for the Claude Code CLI: type-safe wrapper, slot pool orchestration, and MCP server.
+Rust tooling suite for the Claude Code CLI built around the coordinator/worker model.
 
 [![Crates.io](https://img.shields.io/crates/v/claude-wrapper.svg)](https://crates.io/crates/claude-wrapper)
 [![Documentation](https://docs.rs/claude-wrapper/badge.svg)](https://docs.rs/claude-wrapper)
 [![CI](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml)
 [![License](https://img.shields.io/crates/l/claude-wrapper.svg)](LICENSE-MIT)
 
-## What is claude-pool?
+## Coordinator/Worker Model
 
-**claude-pool** is measured parallelism for Claude Code: selective, human-in-the-loop slot coordination. Run multiple Claude CLI instances simultaneously without orchestration overhead. Sit between solo Claude sessions and full automation platforms.
+**claude-pool** implements coordinator/worker orchestration for Claude Code. A
+**coordinator** — an interactive Claude session with the pool in its MCP config —
+schedules work, dispatches tasks to **worker** slots, monitors results, reviews
+outputs, and decides what merges. Workers are isolated Claude instances that
+execute one task at a time and return.
 
-**Not** a full orchestration framework or a leave-it-running daemon. This is for applications, scripts, and interactive sessions that need occasional parallel execution under human control—submit tasks, get results, stay in the loop.
+This is measured parallelism under human control. The human sits at the
+coordinator level and decides what offloads, when, and how. Not a
+leave-it-running daemon or full automation platform.
 
-### Key Differentiators
+The coordinator follows a repeating rhythm: **dispatch** tasks, **monitor**
+results (tick loop), **review** output, **merge** what passes. Chains compress
+this into one dispatch/monitor cycle. Fan-outs run monitor in parallel.
 
-- **Session-scoped**: Slots live only as long as your application. No external state.
-- **Conversation-first**: Inject shared context across slots. Slots inherit your session state.
-- **Selective**: Choose what offloads—chains, parallel tasks, or isolated execution. Human decides when to parallelize.
-- **MCP-native**: Expose the pool as an MCP server for use directly from Claude Code.
+### Key Properties
+
+- **Session-scoped**: Slots live only as long as your process. No external state.
+- **Human-in-the-loop**: The coordinator reviews and approves worker output.
+- **Selective**: Choose what offloads — chains, fan-outs, or single tasks.
+- **MCP-native**: Expose the pool as an MCP server and use it directly from Claude Code.
 
 ## The Three Crates
 
@@ -48,9 +58,9 @@ A comprehensive Rust tooling suite for the Claude Code CLI: type-safe wrapper, s
 
 | Crate | Purpose | Docs |
 |-------|---------|------|
-| **[claude-wrapper](crates/claude-wrapper/)** | Type-safe CLI wrapper with builder pattern | [README](crates/claude-wrapper/README.md) ⟡ [docs.rs](https://docs.rs/claude-wrapper) |
-| **[claude-pool](crates/claude-pool/)** | Slot pool, orchestration, budget control | [README](crates/claude-pool/README.md) ⟡ [docs.rs](https://docs.rs/claude-pool) |
-| **[claude-pool-server](crates/claude-pool-server/)** | MCP server exposing the pool | [README](crates/claude-pool-server/README.md) ⟡ [docs.rs](https://docs.rs/claude-pool-server) |
+| **[claude-wrapper](crates/claude-wrapper/)** | Type-safe Rust interface to Claude Code CLI | [README](crates/claude-wrapper/README.md) ⟡ [docs.rs](https://docs.rs/claude-wrapper) |
+| **[claude-pool](crates/claude-pool/)** | Coordinator/worker orchestration | [README](crates/claude-pool/README.md) ⟡ [docs.rs](https://docs.rs/claude-pool) |
+| **[claude-pool-server](crates/claude-pool-server/)** | MCP + REST server | [README](crates/claude-pool-server/README.md) ⟡ [docs.rs](https://docs.rs/claude-pool-server) |
 
 ## Quick Start
 

--- a/crates/claude-pool/src/lib.rs
+++ b/crates/claude-pool/src/lib.rs
@@ -1,9 +1,111 @@
-//! MCP server for managing a pool of Claude CLI slots.
+//! Coordinator/worker orchestration for Claude Code.
 //!
-//! `claude-pool` manages N Claude CLI instances behind an MCP server interface.
-//! A coordinator (typically an interactive Claude session) calls MCP tools to
-//! submit work, fan out tasks, chain pipelines, and track budgets. The pool
-//! handles slot lifecycle, session resumption, restarts, and shared context.
+//! `claude-pool` manages N Claude CLI instances behind a pool. A **coordinator**
+//! (an interactive Claude session with the pool MCP server in its `.mcp.json`)
+//! dispatches work to **worker** slots, monitors results, reviews outputs, and
+//! decides what merges. Workers are isolated Claude instances that execute one
+//! task at a time.
+//!
+//! This crate provides the pool library. For the MCP server binary, see
+//! `claude-pool-server`.
+//!
+//! # The Coordinator/Worker Model
+//!
+//! The coordinator/worker split is the central organizing principle:
+//!
+//! - **Coordinator**: A long-running interactive Claude session. It holds the
+//!   human's context, makes sequencing decisions, reviews outputs, and calls
+//!   `pool_*` MCP tools to delegate work. It does not execute tasks directly;
+//!   it schedules work and acts on results.
+//! - **Worker**: A Claude slot executing a single task (a `pool_run`, a chain
+//!   step, or a fan-out branch). Workers are stateless between tasks; they
+//!   receive a prompt, do the work, and return output. The pool handles slot
+//!   assignment, session resumption, and restarts.
+//!
+//! This model matters because it separates *what to do* (coordinator) from
+//! *how to do it* (worker). The coordinator stays responsive; workers run in
+//! parallel without blocking the human's session.
+//!
+//! # Vocabulary
+//!
+//! ## Nouns
+//!
+//! | Term | Meaning |
+//! |------|---------|
+//! | Coordinator | Interactive Claude session that schedules and reviews work |
+//! | Worker | A slot executing one task; returns output to the coordinator |
+//! | Slot | A managed Claude CLI instance; the execution unit |
+//! | Chain | Ordered pipeline of steps where each step feeds the next |
+//! | Fan-out | N independent tasks running in parallel across slots |
+//! | Task | A single unit of work submitted to the pool |
+//! | Tick | One iteration of the coordinator's monitor loop |
+//! | Skill | A reusable SKILL.md-format prompt template |
+//!
+//! ## Verbs
+//!
+//! | Term | Meaning |
+//! |------|---------|
+//! | schedule | Coordinator decides what work to dispatch next |
+//! | execute | A worker carries out the scheduled task |
+//! | monitor | Coordinator polls for results (tick loop) |
+//! | review | Coordinator inspects worker output before acting |
+//! | merge | Coordinator accepts a worker result into the main branch |
+//! | dispatch | Coordinator sends a task to the pool |
+//! | fan out | Submit N independent tasks in parallel |
+//! | chain | Submit an ordered pipeline of dependent steps |
+//!
+//! # When to Use What
+//!
+//! **Inline**: Do the work yourself without the pool. Use when the task is
+//! fast, single-step, or requires coordinator context that is impractical to
+//! inject.
+//!
+//! **`pool_run` / run**: One task, one result, blocks until done. Use for
+//! single bounded operations (file a ticket, run a check, rebase a branch).
+//!
+//! **`pool_chain` / chain**: Ordered pipeline where each step depends on the
+//! previous. Use when work has a clear linear dependency graph: draft ->
+//! review -> revise -> commit, or scaffold -> implement -> test -> PR. If you
+//! find yourself writing "and then" more than once, chain instead of run.
+//!
+//! **`pool_fan_out` / fan out**: N independent tasks in parallel. Use when the
+//! same operation applies to N independent targets (audit N crates, refactor N
+//! modules). No step depends on another; all run simultaneously.
+//!
+//! # Coordinator Rhythm
+//!
+//! A coordinator session follows a repeating rhythm:
+//!
+//! 1. **Dispatch**: Submit tasks (`pool_submit`, `pool_submit_chain`,
+//!    `pool_fan_out`). Receive task or chain IDs.
+//! 2. **Monitor**: Poll for results (`pool_result`, `pool_chain_result`).
+//!    Repeat until complete. Each poll is a tick.
+//! 3. **Review**: Inspect output. Check diffs, test results, summaries.
+//!    Decide whether to accept, reject with feedback, or escalate.
+//! 4. **Merge**: Accept the result (`pool_approve_result` for reviewed tasks,
+//!    or direct merge for unreviewed chains). Update coordinator state.
+//!
+//! Chains compress this into a single dispatch/monitor cycle. Fan-outs run
+//! monitor in parallel. With `pool_submit_with_review`, the coordinator
+//! explicitly gates on the review step before the result is finalized.
+//!
+//! # Model Selection
+//!
+//! Workers do not need the most capable model for every task. Match the model
+//! to the task complexity:
+//!
+//! - **Haiku**: Bounded single tasks -- file a ticket, run checks, tag a
+//!   release, rebase. High-volume fan-outs where throughput matters more than
+//!   depth.
+//! - **Sonnet**: Multi-file changes, code review needing judgment, planning
+//!   steps where quality matters, most chain steps.
+//! - **Opus**: Large mechanical refactors where one error breaks compilation,
+//!   complex architectural reasoning, tasks where you would send a senior
+//!   engineer.
+//!
+//! Override per-task or per-chain-step with the `model` field in
+//! [`RunOptions`]. The coordinator itself typically runs on Sonnet or Opus;
+//! workers can use cheaper models for routine work.
 //!
 //! # Architecture
 //!


### PR DESCRIPTION
Closes #235

Add coordinator workflow documentation:
- Crate-level rustdoc for coordinator/worker model
- README positioning update
- Coordinator vocabulary table

Draft — human marks ready for review.