### PR TITLE
feat: add Transport enum for MCP type safety

### DIFF
--- a/crates/claude-wrapper/src/command/mcp.rs
+++ b/crates/claude-wrapper/src/command/mcp.rs
@@ -2,7 +2,7 @@ use crate::Claude;
 use crate::command::ClaudeCommand;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
-use crate::types::Scope;
+use crate::types::{Scope, Transport};
 
 /// List configured MCP servers.
 ///
@@ -97,7 +97,7 @@ pub struct McpAddCommand {
     name: String,
     command_or_url: String,
     server_args: Vec<String>,
-    transport: Option<String>,
+    transport: Option<Transport>,
     scope: Option<Scope>,
     env: Vec<(String, String)>,
     headers: Vec<String>,
@@ -118,9 +118,9 @@ impl McpAddCommand {
         }
     }
 
-    /// Set the transport type (stdio, sse, http).
+    /// Set the transport type.
     #[must_use]
-    pub fn transport(mut self, transport: impl Into<String>) -> Self {
+    pub fn transport(mut self, transport: impl Into<Transport>) -> Self {
         self.transport = Some(transport.into());
         self
     }
@@ -160,9 +160,9 @@ impl ClaudeCommand for McpAddCommand {
     fn args(&self) -> Vec<String> {
         let mut args = vec!["mcp".to_string(), "add".to_string()];
 
-        if let Some(ref transport) = self.transport {
+        if let Some(transport) = self.transport {
             args.push("--transport".to_string());
-            args.push(transport.clone());
+            args.push(transport.to_string());
         }
 
         if let Some(ref scope) = self.scope {

--- a/crates/claude-wrapper/src/types.rs
+++ b/crates/claude-wrapper/src/types.rs
@@ -1,4 +1,73 @@
+use std::fmt;
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
+
+/// Transport type for MCP server connections.
+///
+/// # Example
+///
+/// ```
+/// use claude_wrapper::Transport;
+/// use std::str::FromStr;
+///
+/// let t = Transport::from_str("stdio").unwrap();
+/// assert_eq!(t, Transport::Stdio);
+/// assert_eq!(t.to_string(), "stdio");
+///
+/// let t: Transport = "http".parse().unwrap();
+/// assert_eq!(t, Transport::Http);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Transport {
+    /// Standard I/O transport — server runs as a subprocess.
+    Stdio,
+    /// HTTP transport — server accessible via URL.
+    Http,
+    /// Server-Sent Events transport — server accessible via URL with SSE.
+    Sse,
+}
+
+impl fmt::Display for Transport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Stdio => write!(f, "stdio"),
+            Self::Http => write!(f, "http"),
+            Self::Sse => write!(f, "sse"),
+        }
+    }
+}
+
+/// Error returned when parsing an unknown transport string.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("unknown transport: {0}")]
+pub struct TransportParseError(pub String);
+
+impl FromStr for Transport {
+    type Err = TransportParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "stdio" => Ok(Self::Stdio),
+            "http" => Ok(Self::Http),
+            "sse" => Ok(Self::Sse),
+            other => Err(TransportParseError(other.to_string())),
+        }
+    }
+}
+
+impl From<&str> for Transport {
+    /// Convert a string slice to a `Transport`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the string is not a recognized transport type.
+    /// Valid values are: `"stdio"`, `"http"`, `"sse"`.
+    fn from(s: &str) -> Self {
+        s.parse().unwrap_or_else(|e| panic!("{e}"))
+    }
+}
 
 /// Output format for `--output-format`.
 #[derive(Debug, Clone, Copy, Default)]


### PR DESCRIPTION
Closes #249

Add a Transport enum (Stdio, Http, Sse) to replace raw strings in McpAddCommand and McpConfigBuilder.

Draft - human marks ready for review.