### PR TITLE
docs: comprehensive rustdoc for all public command builders

### DIFF
--- a/crates/claude-wrapper/src/command/marketplace.rs
+++ b/crates/claude-wrapper/src/command/marketplace.rs
@@ -24,6 +24,7 @@ pub struct MarketplaceListCommand {
 }
 
 impl MarketplaceListCommand {
+    /// Creates a new marketplace list command.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -81,6 +82,7 @@ pub struct MarketplaceAddCommand {
 }
 
 impl MarketplaceAddCommand {
+    /// Creates a command to add a marketplace by URL, path, or GitHub repo.
     #[must_use]
     pub fn new(source: impl Into<String>) -> Self {
         Self {
@@ -138,6 +140,7 @@ pub struct MarketplaceRemoveCommand {
 }
 
 impl MarketplaceRemoveCommand {
+    /// Creates a command to remove a marketplace by name.
     #[must_use]
     pub fn new(name: impl Into<String>) -> Self {
         Self { name: name.into() }
@@ -174,7 +177,7 @@ impl MarketplaceUpdateCommand {
         Self { name: None }
     }
 
-    /// Update a specific marketplace.
+    /// Creates a command to update a specific marketplace catalog.
     #[must_use]
     pub fn new(name: impl Into<String>) -> Self {
         Self {

--- a/crates/claude-wrapper/src/command/mcp.rs
+++ b/crates/claude-wrapper/src/command/mcp.rs
@@ -22,6 +22,7 @@ use crate::types::Scope;
 pub struct McpListCommand;
 
 impl McpListCommand {
+    /// Creates a new MCP list command.
     #[must_use]
     pub fn new() -> Self {
         Self
@@ -47,6 +48,7 @@ pub struct McpGetCommand {
 }
 
 impl McpGetCommand {
+    /// Creates a command to get details for a named MCP server.
     #[must_use]
     pub fn new(name: impl Into<String>) -> Self {
         Self { name: name.into() }
@@ -253,6 +255,7 @@ pub struct McpRemoveCommand {
 }
 
 impl McpRemoveCommand {
+    /// Creates a command to remove a named MCP server.
     #[must_use]
     pub fn new(name: impl Into<String>) -> Self {
         Self {
@@ -297,6 +300,7 @@ pub struct McpAddFromDesktopCommand {
 }
 
 impl McpAddFromDesktopCommand {
+    /// Creates a command to import MCP servers from the Claude Desktop config.
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/crates/claude-wrapper/src/command/plugin.rs
+++ b/crates/claude-wrapper/src/command/plugin.rs
@@ -25,6 +25,7 @@ pub struct PluginListCommand {
 }
 
 impl PluginListCommand {
+    /// Creates a new plugin list command.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -87,6 +88,7 @@ pub struct PluginInstallCommand {
 }
 
 impl PluginInstallCommand {
+    /// Creates a command to install a plugin by name.
     #[must_use]
     pub fn new(plugin: impl Into<String>) -> Self {
         Self {
@@ -129,6 +131,7 @@ pub struct PluginUninstallCommand {
 }
 
 impl PluginUninstallCommand {
+    /// Creates a command to uninstall a plugin by name.
     #[must_use]
     pub fn new(plugin: impl Into<String>) -> Self {
         Self {
@@ -171,6 +174,7 @@ pub struct PluginEnableCommand {
 }
 
 impl PluginEnableCommand {
+    /// Creates a command to enable a plugin by name.
     #[must_use]
     pub fn new(plugin: impl Into<String>) -> Self {
         Self {
@@ -214,7 +218,7 @@ pub struct PluginDisableCommand {
 }
 
 impl PluginDisableCommand {
-    /// Disable a specific plugin.
+    /// Creates a command to disable a plugin by name. To disable all plugins, use [`PluginDisableCommand::all`].
     #[must_use]
     pub fn new(plugin: impl Into<String>) -> Self {
         Self {
@@ -273,6 +277,7 @@ pub struct PluginUpdateCommand {
 }
 
 impl PluginUpdateCommand {
+    /// Creates a command to update a plugin to the latest version.
     #[must_use]
     pub fn new(plugin: impl Into<String>) -> Self {
         Self {
@@ -314,6 +319,7 @@ pub struct PluginValidateCommand {
 }
 
 impl PluginValidateCommand {
+    /// Creates a command to validate a plugin manifest at the given path.
     #[must_use]
     pub fn new(path: impl Into<String>) -> Self {
         Self { path: path.into() }

--- a/crates/claude-wrapper/src/types.rs
+++ b/crates/claude-wrapper/src/types.rs
@@ -166,14 +166,17 @@ pub struct AuthStatus {
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
-/// A message in the query JSON output.
+/// A message from a query result, representing one turn in the conversation.
 #[cfg(feature = "json")]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct QueryMessage {
+    /// The role of the message sender (e.g., "user", "assistant").
     #[serde(default)]
     pub role: String,
+    /// The text content of the message.
     #[serde(default)]
     pub content: serde_json::Value,
+    /// Additional fields returned by the CLI not captured in typed fields.
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
@@ -182,18 +185,25 @@ pub struct QueryMessage {
 #[cfg(feature = "json")]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct QueryResult {
+    /// The text content of the query response.
     #[serde(default)]
     pub result: String,
+    /// The session ID for continuing conversations.
     #[serde(default)]
     pub session_id: String,
+    /// Total cost of the query in USD.
     #[serde(default, rename = "total_cost_usd", alias = "cost_usd")]
     pub cost_usd: Option<f64>,
+    /// Duration of the query in milliseconds.
     #[serde(default)]
     pub duration_ms: Option<u64>,
+    /// Number of conversation turns in the query.
     #[serde(default)]
     pub num_turns: Option<u32>,
+    /// Whether the query resulted in an error.
     #[serde(default)]
     pub is_error: bool,
+    /// Additional fields returned by the CLI not captured in typed fields.
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }


### PR DESCRIPTION
Closes #248

Add doc comments to all public items that are currently undocumented:
- plugin.rs: 7 new() methods
- marketplace.rs: 4 new() methods
- mcp.rs: 4 new() methods
- types.rs: QueryResult/QueryMessage field docs

Draft - human marks ready for review.