### PR TITLE
chore: remove stale CLI flags

### DIFF
--- a/crates/claude-wrapper/src/command/agents.rs
+++ b/crates/claude-wrapper/src/command/agents.rs
@@ -23,7 +23,6 @@ use crate::exec::{self, CommandOutput};
 #[derive(Debug, Clone, Default)]
 pub struct AgentsCommand {
     setting_sources: Option<String>,
-    json: bool,
 }
 
 impl AgentsCommand {
@@ -38,13 +37,6 @@ impl AgentsCommand {
         self.setting_sources = Some(sources.into());
         self
     }
-
-    /// Output as JSON.
-    #[must_use]
-    pub fn json(mut self) -> Self {
-        self.json = true;
-        self
-    }
 }
 
 impl ClaudeCommand for AgentsCommand {
@@ -52,9 +44,6 @@ impl ClaudeCommand for AgentsCommand {
 
     fn args(&self) -> Vec<String> {
         let mut args = vec!["agents".to_string()];
-        if self.json {
-            args.push("--json".to_string());
-        }
         if let Some(ref sources) = self.setting_sources {
             args.push("--setting-sources".to_string());
             args.push(sources.clone());
@@ -85,11 +74,5 @@ mod tests {
             ClaudeCommand::args(&cmd),
             vec!["agents", "--setting-sources", "user,project"]
         );
-    }
-
-    #[test]
-    fn test_agents_json_flag() {
-        let cmd = AgentsCommand::new().json();
-        assert_eq!(ClaudeCommand::args(&cmd), vec!["agents", "--json"]);
     }
 }

--- a/crates/claude-wrapper/src/command/doctor.rs
+++ b/crates/claude-wrapper/src/command/doctor.rs
@@ -18,21 +18,12 @@ use crate::exec::{self, CommandOutput};
 /// # }
 /// ```
 #[derive(Debug, Clone, Default)]
-pub struct DoctorCommand {
-    json: bool,
-}
+pub struct DoctorCommand {}
 
 impl DoctorCommand {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Output as JSON.
-    #[must_use]
-    pub fn json(mut self) -> Self {
-        self.json = true;
-        self
     }
 }
 
@@ -40,11 +31,7 @@ impl ClaudeCommand for DoctorCommand {
     type Output = CommandOutput;
 
     fn args(&self) -> Vec<String> {
-        let mut args = vec!["doctor".to_string()];
-        if self.json {
-            args.push("--json".to_string());
-        }
-        args
+        vec!["doctor".to_string()]
     }
 
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
@@ -60,11 +47,5 @@ mod tests {
     fn test_doctor_args() {
         let cmd = DoctorCommand::new();
         assert_eq!(cmd.args(), vec!["doctor"]);
-    }
-
-    #[test]
-    fn test_doctor_json_flag() {
-        let cmd = DoctorCommand::new().json();
-        assert_eq!(cmd.args(), vec!["doctor", "--json"]);
     }
 }

--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -402,26 +402,6 @@ impl ClaudeBuilder {
         self
     }
 
-    /// Suppress non-essential output for all commands (`--quiet`).
-    #[must_use]
-    pub fn quiet(mut self) -> Self {
-        self.global_args.push("--quiet".into());
-        self
-    }
-
-    /// Control color output for all commands.
-    ///
-    /// Passes `--color` when `enabled` is `true`, `--no-color` when `false`.
-    #[must_use]
-    pub fn color(mut self, enabled: bool) -> Self {
-        if enabled {
-            self.global_args.push("--color".into());
-        } else {
-            self.global_args.push("--no-color".into());
-        }
-        self
-    }
-
     /// Set a default retry policy for all commands.
     ///
     /// Individual commands can override this via their own retry settings.
@@ -514,37 +494,5 @@ mod tests {
             .build()
             .unwrap();
         assert!(claude.global_args.contains(&"--debug".to_string()));
-    }
-
-    #[test]
-    fn test_builder_quiet() {
-        let claude = Claude::builder()
-            .binary("/usr/local/bin/claude")
-            .quiet()
-            .build()
-            .unwrap();
-        assert!(claude.global_args.contains(&"--quiet".to_string()));
-    }
-
-    #[test]
-    fn test_builder_color_enabled() {
-        let claude = Claude::builder()
-            .binary("/usr/local/bin/claude")
-            .color(true)
-            .build()
-            .unwrap();
-        assert!(claude.global_args.contains(&"--color".to_string()));
-        assert!(!claude.global_args.contains(&"--no-color".to_string()));
-    }
-
-    #[test]
-    fn test_builder_color_disabled() {
-        let claude = Claude::builder()
-            .binary("/usr/local/bin/claude")
-            .color(false)
-            .build()
-            .unwrap();
-        assert!(claude.global_args.contains(&"--no-color".to_string()));
-        assert!(!claude.global_args.contains(&"--color".to_string()));
     }
 }


### PR DESCRIPTION
Closes #254

Remove wrapper methods for CLI flags that are no longer accepted:
- `ClaudeBuilder::quiet()` -- `--quiet` rejected by CLI
- `ClaudeBuilder::color()` -- `--color`/`--no-color` rejected by CLI
- `DoctorCommand::json()` -- `--json` rejected by `doctor` subcommand
- `AgentsCommand::json()` -- `--json` rejected by `agents` subcommand

Kept `QueryCommand::max_turns()` -- `--max-turns` is undocumented but accepted.

Verified each flag against `claude` CLI v1.x with `CLAUDECODE` env vars unset.