### PR TITLE
feat: add missing subcommands and MCP OAuth flags

### DIFF
--- a/crates/claude-wrapper/src/command/auth.rs
+++ b/crates/claude-wrapper/src/command/auth.rs
@@ -69,6 +69,143 @@ impl ClaudeCommand for AuthStatusCommand {
     }
 }
 
+/// Authenticate with Claude.
+///
+/// # Example
+///
+/// ```no_run
+/// use claude_wrapper::{Claude, ClaudeCommand, AuthLoginCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// AuthLoginCommand::new()
+///     .email("user@example.com")
+///     .execute(&claude)
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct AuthLoginCommand {
+    email: Option<String>,
+    sso: Option<String>,
+}
+
+impl AuthLoginCommand {
+    /// Create a new auth login command.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the email address for authentication.
+    #[must_use]
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.email = Some(email.into());
+        self
+    }
+
+    /// Set the SSO provider for authentication.
+    #[must_use]
+    pub fn sso(mut self, provider: impl Into<String>) -> Self {
+        self.sso = Some(provider.into());
+        self
+    }
+}
+
+impl ClaudeCommand for AuthLoginCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["auth".to_string(), "login".to_string()];
+        if let Some(ref email) = self.email {
+            args.push("--email".to_string());
+            args.push(email.clone());
+        }
+        if let Some(ref sso) = self.sso {
+            args.push("--sso".to_string());
+            args.push(sso.clone());
+        }
+        args
+    }
+
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
+/// Deauthenticate from Claude.
+///
+/// # Example
+///
+/// ```no_run
+/// use claude_wrapper::{Claude, ClaudeCommand, AuthLogoutCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// AuthLogoutCommand::new().execute(&claude).await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct AuthLogoutCommand;
+
+impl AuthLogoutCommand {
+    /// Create a new auth logout command.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ClaudeCommand for AuthLogoutCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["auth".to_string(), "logout".to_string()]
+    }
+
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
+/// Set up a long-lived authentication token.
+///
+/// # Example
+///
+/// ```no_run
+/// use claude_wrapper::{Claude, ClaudeCommand, SetupTokenCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// SetupTokenCommand::new().execute(&claude).await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct SetupTokenCommand;
+
+impl SetupTokenCommand {
+    /// Create a new setup-token command.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ClaudeCommand for SetupTokenCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["setup-token".to_string()]
+    }
+
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -83,5 +220,38 @@ mod tests {
     fn test_auth_status_text() {
         let cmd = AuthStatusCommand::new().text();
         assert_eq!(cmd.args(), vec!["auth", "status", "--text"]);
+    }
+
+    #[test]
+    fn test_auth_login_default() {
+        let cmd = AuthLoginCommand::new();
+        assert_eq!(cmd.args(), vec!["auth", "login"]);
+    }
+
+    #[test]
+    fn test_auth_login_with_email() {
+        let cmd = AuthLoginCommand::new().email("user@example.com");
+        assert_eq!(
+            cmd.args(),
+            vec!["auth", "login", "--email", "user@example.com"]
+        );
+    }
+
+    #[test]
+    fn test_auth_login_with_sso() {
+        let cmd = AuthLoginCommand::new().sso("okta");
+        assert_eq!(cmd.args(), vec!["auth", "login", "--sso", "okta"]);
+    }
+
+    #[test]
+    fn test_auth_logout() {
+        let cmd = AuthLogoutCommand::new();
+        assert_eq!(cmd.args(), vec!["auth", "logout"]);
+    }
+
+    #[test]
+    fn test_setup_token() {
+        let cmd = SetupTokenCommand::new();
+        assert_eq!(cmd.args(), vec!["setup-token"]);
     }
 }

--- a/crates/claude-wrapper/src/command/mcp.rs
+++ b/crates/claude-wrapper/src/command/mcp.rs
@@ -103,6 +103,9 @@ pub struct McpAddCommand {
     scope: Option<Scope>,
     env: Vec<(String, String)>,
     headers: Vec<String>,
+    callback_port: Option<u16>,
+    client_id: Option<String>,
+    client_secret: bool,
 }
 
 impl McpAddCommand {
@@ -117,6 +120,9 @@ impl McpAddCommand {
             scope: None,
             env: Vec::new(),
             headers: Vec::new(),
+            callback_port: None,
+            client_id: None,
+            client_secret: false,
         }
     }
 
@@ -154,6 +160,27 @@ impl McpAddCommand {
         self.server_args.extend(args.into_iter().map(Into::into));
         self
     }
+
+    /// Set a fixed port for OAuth callback.
+    #[must_use]
+    pub fn callback_port(mut self, port: u16) -> Self {
+        self.callback_port = Some(port);
+        self
+    }
+
+    /// Set the OAuth client ID for HTTP/SSE servers.
+    #[must_use]
+    pub fn client_id(mut self, id: impl Into<String>) -> Self {
+        self.client_id = Some(id.into());
+        self
+    }
+
+    /// Enable prompting for OAuth client secret.
+    #[must_use]
+    pub fn client_secret(mut self) -> Self {
+        self.client_secret = true;
+        self
+    }
 }
 
 impl ClaudeCommand for McpAddCommand {
@@ -180,6 +207,20 @@ impl ClaudeCommand for McpAddCommand {
         for header in &self.headers {
             args.push("-H".to_string());
             args.push(header.clone());
+        }
+
+        if let Some(port) = self.callback_port {
+            args.push("--callback-port".to_string());
+            args.push(port.to_string());
+        }
+
+        if let Some(ref id) = self.client_id {
+            args.push("--client-id".to_string());
+            args.push(id.clone());
+        }
+
+        if self.client_secret {
+            args.push("--client-secret".to_string());
         }
 
         args.push(self.name.clone());
@@ -331,6 +372,69 @@ impl ClaudeCommand for McpAddFromDesktopCommand {
     }
 }
 
+/// Start the Claude Code MCP server.
+///
+/// # Example
+///
+/// ```no_run
+/// use claude_wrapper::{Claude, ClaudeCommand, McpServeCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// McpServeCommand::new()
+///     .verbose()
+///     .execute(&claude)
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct McpServeCommand {
+    debug: bool,
+    verbose: bool,
+}
+
+impl McpServeCommand {
+    /// Create a new MCP serve command.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enable debug output.
+    #[must_use]
+    pub fn debug(mut self) -> Self {
+        self.debug = true;
+        self
+    }
+
+    /// Enable verbose output.
+    #[must_use]
+    pub fn verbose(mut self) -> Self {
+        self.verbose = true;
+        self
+    }
+}
+
+impl ClaudeCommand for McpServeCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["mcp".to_string(), "serve".to_string()];
+        if self.debug {
+            args.push("--debug".to_string());
+        }
+        if self.verbose {
+            args.push("--verbose".to_string());
+        }
+        args
+    }
+
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
 /// Reset all approved and rejected project-scoped MCP servers.
 #[derive(Debug, Clone, Default)]
 pub struct McpResetProjectChoicesCommand;
@@ -415,6 +519,33 @@ mod tests {
     }
 
     #[test]
+    fn test_mcp_add_oauth_flags() {
+        let cmd = McpAddCommand::new("my-server", "https://example.com/mcp")
+            .transport("http")
+            .callback_port(8080)
+            .client_id("my-app-id")
+            .client_secret();
+
+        let args = cmd.args();
+        assert_eq!(
+            args,
+            vec![
+                "mcp",
+                "add",
+                "--transport",
+                "http",
+                "--callback-port",
+                "8080",
+                "--client-id",
+                "my-app-id",
+                "--client-secret",
+                "my-server",
+                "https://example.com/mcp"
+            ]
+        );
+    }
+
+    #[test]
     fn test_mcp_remove_args() {
         let cmd = McpRemoveCommand::new("old-server").scope(Scope::Project);
         assert_eq!(
@@ -436,5 +567,17 @@ mod tests {
     fn test_mcp_reset_project_choices() {
         let cmd = McpResetProjectChoicesCommand::new();
         assert_eq!(cmd.args(), vec!["mcp", "reset-project-choices"]);
+    }
+
+    #[test]
+    fn test_mcp_serve_default() {
+        let cmd = McpServeCommand::new();
+        assert_eq!(cmd.args(), vec!["mcp", "serve"]);
+    }
+
+    #[test]
+    fn test_mcp_serve_with_flags() {
+        let cmd = McpServeCommand::new().debug().verbose();
+        assert_eq!(cmd.args(), vec!["mcp", "serve", "--debug", "--verbose"]);
     }
 }

--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -181,7 +181,9 @@ use std::time::Duration;
 
 pub use command::ClaudeCommand;
 pub use command::agents::AgentsCommand;
-pub use command::auth::AuthStatusCommand;
+pub use command::auth::{
+    AuthLoginCommand, AuthLogoutCommand, AuthStatusCommand, SetupTokenCommand,
+};
 pub use command::doctor::DoctorCommand;
 pub use command::marketplace::{
     MarketplaceAddCommand, MarketplaceListCommand, MarketplaceRemoveCommand,
@@ -189,7 +191,7 @@ pub use command::marketplace::{
 };
 pub use command::mcp::{
     McpAddCommand, McpAddFromDesktopCommand, McpAddJsonCommand, McpGetCommand, McpListCommand,
-    McpRemoveCommand, McpResetProjectChoicesCommand,
+    McpRemoveCommand, McpResetProjectChoicesCommand, McpServeCommand,
 };
 pub use command::plugin::{
     PluginDisableCommand, PluginEnableCommand, PluginInstallCommand, PluginListCommand,


### PR DESCRIPTION
## Summary

- Add `auth login` (--email, --sso), `auth logout`, `setup-token` commands (closes #255 medium priority items)
- Add `mcp serve` command with --debug and --verbose flags (closes #255)
- Add MCP OAuth flags: `--callback-port`, `--client-id`, `--client-secret` to `McpAddCommand` (closes #256)

Closes #255, closes #256

## Test plan

- [x] 8 new unit tests pass (auth login/logout/sso/email, setup-token, mcp serve default/flags, mcp add oauth)
- [x] All 93 wrapper unit tests pass
- [x] 39 doc tests pass (including 4 new doc examples)
- [x] clippy clean, fmt clean