### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.4.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.3.1...v0.4.0) - 2026-03-16
+
+### Added
+
+- add pool examples and document examples in READMEs ([#276](https://github.com/joshrotenberg/claude-wrapper/pull/276))
+- add missing subcommands and MCP OAuth flags ([#261](https://github.com/joshrotenberg/claude-wrapper/pull/261))
+- add missing high-priority CLI flags to QueryCommand ([#258](https://github.com/joshrotenberg/claude-wrapper/pull/258))
+- add Transport enum for MCP type safety ([#251](https://github.com/joshrotenberg/claude-wrapper/pull/251))
+
+### Fixed
+
+- streaming timeout + gitignore .claude-pool ([#202](https://github.com/joshrotenberg/claude-wrapper/pull/202))
+
+### Other
+
+- add CI-runnable fake-binary tests for wrapper commands and retry ([#273](https://github.com/joshrotenberg/claude-wrapper/pull/273))
+- remove stale CLI flags (quiet, color, doctor --json, agents --json) ([#259](https://github.com/joshrotenberg/claude-wrapper/pull/259))
+- comprehensive rustdoc for all public command builders ([#252](https://github.com/joshrotenberg/claude-wrapper/pull/252))
+
 ## [0.3.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.3.0...v0.3.1) - 2026-03-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-pool"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "claude-wrapper"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/claude-wrapper"
 
 [workspace.dependencies]
-claude-wrapper = { path = "crates/claude-wrapper", version = "0.3" }
-claude-pool = { path = "crates/claude-pool", version = "0.3" }
+claude-wrapper = { path = "crates/claude-wrapper", version = "0.4" }
+claude-pool = { path = "crates/claude-pool", version = "0.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/claude-pool-mcp/CHANGELOG.md
+++ b/crates/claude-pool-mcp/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/joshrotenberg/claude-wrapper/releases/tag/claude-pool-mcp-v0.1.0) - 2026-03-16
+
+### Added
+
+- ship pool coordinator skill and remove old skill infrastructure ([#299](https://github.com/joshrotenberg/claude-wrapper/pull/299))
+- add claude-pool-mcp crate (tower-mcp based pool server) ([#282](https://github.com/joshrotenberg/claude-wrapper/pull/282))
+
+### Other
+
+- update READMEs, .mcp.json, and workspace for release prep ([#301](https://github.com/joshrotenberg/claude-wrapper/pull/301))
+- [**breaking**] remove dead code — skills, workflows, pool-server, claudes ([#283](https://github.com/joshrotenberg/claude-wrapper/pull/283))

--- a/crates/claude-pool/CHANGELOG.md
+++ b/crates/claude-pool/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.3.0...claude-pool-v0.4.0) - 2026-03-16
+
+### Added
+
+- use system prompt and XML tags for auto-routing ([#296](https://github.com/joshrotenberg/claude-wrapper/pull/296))
+- harden routing prompt with decision tree, examples, and anti-patterns ([#294](https://github.com/joshrotenberg/claude-wrapper/pull/294))
+- add routing test harness with structured output ([#293](https://github.com/joshrotenberg/claude-wrapper/pull/293))
+- improve route_stress diagnostics and document system prompt findings ([#291](https://github.com/joshrotenberg/claude-wrapper/pull/291))
+- prompt refinement, route normalization, and stress test ([#281](https://github.com/joshrotenberg/claude-wrapper/pull/281))
+- structured auto-routing hints and modular prompt ([#280](https://github.com/joshrotenberg/claude-wrapper/pull/280))
+- add auto-routing — LLM picks run/fan_out/chain ([#278](https://github.com/joshrotenberg/claude-wrapper/pull/278))
+- add pool examples and document examples in READMEs ([#276](https://github.com/joshrotenberg/claude-wrapper/pull/276))
+- pool polish — worktree cleanup, workflow disk loading, JSON file store ([#275](https://github.com/joshrotenberg/claude-wrapper/pull/275))
+- add per-task budget enforcement to pool ([#272](https://github.com/joshrotenberg/claude-wrapper/pull/272))
+- add fallback_model to PoolConfig and SlotConfig ([#236](https://github.com/joshrotenberg/claude-wrapper/pull/236))
+- add max_budget_usd to TaskOverrides for per-task budget caps ([#232](https://github.com/joshrotenberg/claude-wrapper/pull/232))
+- add disallowed_tools and tools to TaskOverrides for tool scoping ([#231](https://github.com/joshrotenberg/claude-wrapper/pull/231))
+- add json_schema to TaskOverrides for structured output ([#230](https://github.com/joshrotenberg/claude-wrapper/pull/230))
+- task execution metrics, session aggregation, and REST/MCP endpoints ([#216](https://github.com/joshrotenberg/claude-wrapper/pull/216))
+- SSE streaming endpoints for REST API (Phase 2) ([#213](https://github.com/joshrotenberg/claude-wrapper/pull/213))
+
+### Fixed
+
+- create worktrees under repo instead of temp dir ([#298](https://github.com/joshrotenberg/claude-wrapper/pull/298))
+- prevent routing LLM from using tools instead of classifying ([#284](https://github.com/joshrotenberg/claude-wrapper/pull/284))
+
+### Other
+
+- update READMEs, .mcp.json, and workspace for release prep ([#301](https://github.com/joshrotenberg/claude-wrapper/pull/301))
+- add route_stress as ignored integration test ([#297](https://github.com/joshrotenberg/claude-wrapper/pull/297))
+- [**breaking**] remove dead code — skills, workflows, pool-server, claudes ([#283](https://github.com/joshrotenberg/claude-wrapper/pull/283))
+- coordinator workflow as first-class concept ([#247](https://github.com/joshrotenberg/claude-wrapper/pull/247))
+- TaskOverrides + RunOptions builder ([#209](https://github.com/joshrotenberg/claude-wrapper/pull/209))
+- organize lib.rs re-exports with prelude module ([#208](https://github.com/joshrotenberg/claude-wrapper/pull/208))
+- centralize ID generation ([#207](https://github.com/joshrotenberg/claude-wrapper/pull/207))
+- add comprehensive rustdoc to pool server tools ([#205](https://github.com/joshrotenberg/claude-wrapper/pull/205))
+
 ## [0.3.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.2.0...claude-pool-v0.3.0) - 2026-03-11
 
 ### Added

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-pool"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)
* `claude-pool`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `claude-pool-mcp`: 0.1.0

### ⚠ `claude-wrapper` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  ClaudeBuilder::quiet, previously in file /tmp/.tmpr2aORi/claude-wrapper/src/lib.rs:407
  ClaudeBuilder::color, previously in file /tmp/.tmpr2aORi/claude-wrapper/src/lib.rs:416
  DoctorCommand::json, previously in file /tmp/.tmpr2aORi/claude-wrapper/src/command/doctor.rs:33
  DoctorCommand::json, previously in file /tmp/.tmpr2aORi/claude-wrapper/src/command/doctor.rs:33
  AgentsCommand::json, previously in file /tmp/.tmpr2aORi/claude-wrapper/src/command/agents.rs:44
  AgentsCommand::json, previously in file /tmp/.tmpr2aORi/claude-wrapper/src/command/agents.rs:44
```

### ⚠ `claude-pool` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TaskRecord.created_at_ms in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:371
  field TaskRecord.started_at_ms in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:375
  field TaskRecord.completed_at_ms in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:379
  field TaskRecord.created_at_ms in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:371
  field TaskRecord.started_at_ms in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:375
  field TaskRecord.completed_at_ms in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:379
  field TaskResult.elapsed_ms in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:403
  field TaskResult.model in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:407
  field TaskResult.budget_exceeded in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:431
  field TaskResult.elapsed_ms in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:403
  field TaskResult.model in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:407
  field TaskResult.budget_exceeded in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:431
  field PoolConfig.fallback_model in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:88
  field PoolConfig.worktree_base_dir in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:140
  field PoolConfig.fallback_model in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:88
  field PoolConfig.worktree_base_dir in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:140
  field PoolStatus.completed_tasks in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:1815
  field PoolStatus.failed_tasks in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:1817
  field PoolStatus.cancelled_tasks in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:1819
  field PoolStatus.completed_tasks in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:1815
  field PoolStatus.failed_tasks in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:1817
  field PoolStatus.cancelled_tasks in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:1819
  field ResolvedConfig.fallback_model in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/config.rs:20
  field ResolvedConfig.disallowed_tools in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/config.rs:25
  field ResolvedConfig.tools in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/config.rs:26
  field ResolvedConfig.json_schema in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/config.rs:34
  field ResolvedConfig.max_budget_usd in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/config.rs:36
  field SlotConfig.fallback_model in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:198
  field SlotConfig.fallback_model in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/types.rs:198

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum claude_pool::skill::SkillScope, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:86
  enum claude_pool::SkillScope, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:86
  enum claude_pool::skill::SkillSource, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:49
  enum claude_pool::SkillSource, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:49

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:TaskBudgetExceedsRemaining in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/error.rs:33
  variant Error:TaskBudgetExceedsRemaining in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/error.rs:33

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant StepAction::Skill, previously in file /tmp/.tmpr2aORi/claude-pool/src/chain.rs:62
  variant StepAction::Skill, previously in file /tmp/.tmpr2aORi/claude-pool/src/chain.rs:62

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function claude_pool::workflow::builtin_workflows, previously in file /tmp/.tmpr2aORi/claude-pool/src/workflow.rs:157
  function claude_pool::skill::builtin_skills, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:500

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  claude_pool::chain::execute_chain now takes 2 parameters instead of 3, in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/chain.rs:201
  claude_pool::execute_chain now takes 2 parameters instead of 3, in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/chain.rs:201
  claude_pool::chain::execute_chain_with_progress now takes 4 parameters instead of 5, in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/chain.rs:215

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Pool::submit_workflow, previously in file /tmp/.tmpr2aORi/claude-pool/src/pool.rs:1091
  Pool::submit_workflow, previously in file /tmp/.tmpr2aORi/claude-pool/src/pool.rs:1091

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  claude_pool::pool::Pool::submit_chain now takes 2 parameters instead of 3, in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:907
  claude_pool::pool::Pool::fan_out_chains now takes 2 parameters instead of 3, in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:1062
  claude_pool::Pool::submit_chain now takes 2 parameters instead of 3, in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:907
  claude_pool::Pool::fan_out_chains now takes 2 parameters instead of 3, in /tmp/.tmpSOf6Ow/claude-wrapper/crates/claude-pool/src/pool.rs:1062

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod claude_pool::skill, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:1
  mod claude_pool::workflow, previously in file /tmp/.tmpr2aORi/claude-pool/src/workflow.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct claude_pool::skill::SkillArgument, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:151
  struct claude_pool::SkillArgument, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:151
  struct claude_pool::workflow::WorkflowStep, previously in file /tmp/.tmpr2aORi/claude-pool/src/workflow.rs:32
  struct claude_pool::skill::RegisteredSkill, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:73
  struct claude_pool::RegisteredSkill, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:73
  struct claude_pool::workflow::Workflow, previously in file /tmp/.tmpr2aORi/claude-pool/src/workflow.rs:16
  struct claude_pool::Workflow, previously in file /tmp/.tmpr2aORi/claude-pool/src/workflow.rs:16
  struct claude_pool::workflow::WorkflowArgument, previously in file /tmp/.tmpr2aORi/claude-pool/src/workflow.rs:49
  struct claude_pool::WorkflowArgument, previously in file /tmp/.tmpr2aORi/claude-pool/src/workflow.rs:49
  struct claude_pool::workflow::WorkflowRegistry, previously in file /tmp/.tmpr2aORi/claude-pool/src/workflow.rs:116
  struct claude_pool::WorkflowRegistry, previously in file /tmp/.tmpr2aORi/claude-pool/src/workflow.rs:116
  struct claude_pool::skill::Skill, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:112
  struct claude_pool::Skill, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:112
  struct claude_pool::skill::SkillRegistry, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:369
  struct claude_pool::SkillRegistry, previously in file /tmp/.tmpr2aORi/claude-pool/src/skill.rs:369
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-wrapper`

<blockquote>

## [0.4.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.3.1...v0.4.0) - 2026-03-16

### Added

- add pool examples and document examples in READMEs ([#276](https://github.com/joshrotenberg/claude-wrapper/pull/276))
- add missing subcommands and MCP OAuth flags ([#261](https://github.com/joshrotenberg/claude-wrapper/pull/261))
- add missing high-priority CLI flags to QueryCommand ([#258](https://github.com/joshrotenberg/claude-wrapper/pull/258))
- add Transport enum for MCP type safety ([#251](https://github.com/joshrotenberg/claude-wrapper/pull/251))

### Fixed

- streaming timeout + gitignore .claude-pool ([#202](https://github.com/joshrotenberg/claude-wrapper/pull/202))

### Other

- add CI-runnable fake-binary tests for wrapper commands and retry ([#273](https://github.com/joshrotenberg/claude-wrapper/pull/273))
- remove stale CLI flags (quiet, color, doctor --json, agents --json) ([#259](https://github.com/joshrotenberg/claude-wrapper/pull/259))
- comprehensive rustdoc for all public command builders ([#252](https://github.com/joshrotenberg/claude-wrapper/pull/252))
</blockquote>

## `claude-pool`

<blockquote>

## [0.4.0](https://github.com/joshrotenberg/claude-wrapper/compare/claude-pool-v0.3.0...claude-pool-v0.4.0) - 2026-03-16

### Added

- use system prompt and XML tags for auto-routing ([#296](https://github.com/joshrotenberg/claude-wrapper/pull/296))
- harden routing prompt with decision tree, examples, and anti-patterns ([#294](https://github.com/joshrotenberg/claude-wrapper/pull/294))
- add routing test harness with structured output ([#293](https://github.com/joshrotenberg/claude-wrapper/pull/293))
- improve route_stress diagnostics and document system prompt findings ([#291](https://github.com/joshrotenberg/claude-wrapper/pull/291))
- prompt refinement, route normalization, and stress test ([#281](https://github.com/joshrotenberg/claude-wrapper/pull/281))
- structured auto-routing hints and modular prompt ([#280](https://github.com/joshrotenberg/claude-wrapper/pull/280))
- add auto-routing — LLM picks run/fan_out/chain ([#278](https://github.com/joshrotenberg/claude-wrapper/pull/278))
- add pool examples and document examples in READMEs ([#276](https://github.com/joshrotenberg/claude-wrapper/pull/276))
- pool polish — worktree cleanup, workflow disk loading, JSON file store ([#275](https://github.com/joshrotenberg/claude-wrapper/pull/275))
- add per-task budget enforcement to pool ([#272](https://github.com/joshrotenberg/claude-wrapper/pull/272))
- add fallback_model to PoolConfig and SlotConfig ([#236](https://github.com/joshrotenberg/claude-wrapper/pull/236))
- add max_budget_usd to TaskOverrides for per-task budget caps ([#232](https://github.com/joshrotenberg/claude-wrapper/pull/232))
- add disallowed_tools and tools to TaskOverrides for tool scoping ([#231](https://github.com/joshrotenberg/claude-wrapper/pull/231))
- add json_schema to TaskOverrides for structured output ([#230](https://github.com/joshrotenberg/claude-wrapper/pull/230))
- task execution metrics, session aggregation, and REST/MCP endpoints ([#216](https://github.com/joshrotenberg/claude-wrapper/pull/216))
- SSE streaming endpoints for REST API (Phase 2) ([#213](https://github.com/joshrotenberg/claude-wrapper/pull/213))

### Fixed

- create worktrees under repo instead of temp dir ([#298](https://github.com/joshrotenberg/claude-wrapper/pull/298))
- prevent routing LLM from using tools instead of classifying ([#284](https://github.com/joshrotenberg/claude-wrapper/pull/284))

### Other

- update READMEs, .mcp.json, and workspace for release prep ([#301](https://github.com/joshrotenberg/claude-wrapper/pull/301))
- add route_stress as ignored integration test ([#297](https://github.com/joshrotenberg/claude-wrapper/pull/297))
- [**breaking**] remove dead code — skills, workflows, pool-server, claudes ([#283](https://github.com/joshrotenberg/claude-wrapper/pull/283))
- coordinator workflow as first-class concept ([#247](https://github.com/joshrotenberg/claude-wrapper/pull/247))
- TaskOverrides + RunOptions builder ([#209](https://github.com/joshrotenberg/claude-wrapper/pull/209))
- organize lib.rs re-exports with prelude module ([#208](https://github.com/joshrotenberg/claude-wrapper/pull/208))
- centralize ID generation ([#207](https://github.com/joshrotenberg/claude-wrapper/pull/207))
- add comprehensive rustdoc to pool server tools ([#205](https://github.com/joshrotenberg/claude-wrapper/pull/205))
</blockquote>

## `claude-pool-mcp`

<blockquote>

## [0.1.0](https://github.com/joshrotenberg/claude-wrapper/releases/tag/claude-pool-mcp-v0.1.0) - 2026-03-16

### Added

- ship pool coordinator skill and remove old skill infrastructure ([#299](https://github.com/joshrotenberg/claude-wrapper/pull/299))
- add claude-pool-mcp crate (tower-mcp based pool server) ([#282](https://github.com/joshrotenberg/claude-wrapper/pull/282))

### Other

- update READMEs, .mcp.json, and workspace for release prep ([#301](https://github.com/joshrotenberg/claude-wrapper/pull/301))
- [**breaking**] remove dead code — skills, workflows, pool-server, claudes ([#283](https://github.com/joshrotenberg/claude-wrapper/pull/283))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).