### PR TITLE
docs: update READMEs and cleanup for release prep

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "claude-pool": {
-      "command": "/Users/joshrotenberg/Code/active/claude-wrapper/target/debug/claude-pool-mcp",
-      "args": ["-n", "2", "--model", "claude-haiku-4-5-20251001", "--permission-mode", "auto"],
+      "command": "cargo",
+      "args": ["run", "-p", "claude-pool-mcp", "--", "-n", "4", "--model", "claude-haiku-4-5-20251001", "--permission-mode", "auto"],
       "env": {
         "RUST_LOG": "claude_pool=debug,claude_pool_mcp=debug"
       }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ schemars = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-serde_yaml = "0.9"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rust tooling suite for the Claude Code CLI built around the coordinator/worker m
 ## Coordinator/Worker Model
 
 **claude-pool** implements coordinator/worker orchestration for Claude Code. A
-**coordinator** — an interactive Claude session with the pool in its MCP config —
+**coordinator** -- an interactive Claude session with the pool in its MCP config --
 schedules work, dispatches tasks to **worker** slots, monitors results, reviews
 outputs, and decides what merges. Workers are isolated Claude instances that
 execute one task at a time and return.
@@ -27,40 +27,40 @@ this into one dispatch/monitor cycle. Fan-outs run monitor in parallel.
 
 - **Session-scoped**: Slots live only as long as your process. No external state.
 - **Human-in-the-loop**: The coordinator reviews and approves worker output.
-- **Selective**: Choose what offloads — chains, fan-outs, or single tasks.
+- **Selective**: Choose what offloads -- chains, fan-outs, or single tasks.
 - **MCP-native**: Expose the pool as an MCP server and use it directly from Claude Code.
 
 ## The Three Crates
 
 ```
-┌─────────────────────────────────────────────────┐
-│  Your Application or Interactive Claude Session │
-└────────────────────┬────────────────────────────┘
-                     │
-                     │ MCP: claude-pool-server
-                     ▼
-      ┌──────────────────────────────────┐
-      │      claude-pool (library)       │
-      │  • Task submission & routing     │
-      │  • Slot pool (N slots)       │
-      │  • Budget tracking               │
-      │  • Chains, fan-out, skills       │
-      │  • Worktree isolation            │
-      └────────────┬─────────────────────┘
-                   │
-          ┌────────┼────────┐
-          ▼        ▼        ▼
-      Slot-0 Slot-1 Slot-N
-      (Claude CLI instances)
-          │        │        │
-         Uses: claude-wrapper (CLI wrapper)
++---------------------------------------------------+
+|  Your Application or Interactive Claude Session    |
++------------------------+--------------------------+
+                         |
+                         |  MCP: claude-pool-mcp
+                         v
+      +--------------------------------------+
+      |      claude-pool (library)           |
+      |  * Task submission & routing         |
+      |  * Slot pool (N slots)               |
+      |  * Budget tracking                   |
+      |  * Chains, fan-out, auto-routing     |
+      |  * Worktree isolation                |
+      +----------------+--------------------+
+                        |
+              +---------+---------+
+              v         v         v
+          Slot-0    Slot-1    Slot-N
+          (Claude CLI instances)
+              |         |         |
+             Uses: claude-wrapper (CLI wrapper)
 ```
 
 | Crate | Purpose | Docs |
 |-------|---------|------|
-| **[claude-wrapper](crates/claude-wrapper/)** | Type-safe Rust interface to Claude Code CLI | [README](crates/claude-wrapper/README.md) ⟡ [docs.rs](https://docs.rs/claude-wrapper) |
-| **[claude-pool](crates/claude-pool/)** | Coordinator/worker orchestration | [README](crates/claude-pool/README.md) ⟡ [docs.rs](https://docs.rs/claude-pool) |
-| **[claude-pool-server](crates/claude-pool-server/)** | MCP + REST server | [README](crates/claude-pool-server/README.md) ⟡ [docs.rs](https://docs.rs/claude-pool-server) |
+| **[claude-wrapper](crates/claude-wrapper/)** | Type-safe Rust interface to Claude Code CLI | [README](crates/claude-wrapper/README.md) |
+| **[claude-pool](crates/claude-pool/)** | Coordinator/worker orchestration | [README](crates/claude-pool/README.md) |
+| **[claude-pool-mcp](crates/claude-pool-mcp/)** | MCP server exposing pool as tools | [README](crates/claude-pool-mcp/README.md) |
 
 ## Quick Start
 
@@ -100,18 +100,28 @@ async fn main() -> claude_pool::Result<()> {
 }
 ```
 
-### 3. Launch the MCP server
+### 3. Use as an MCP server from Claude Code
 
-```bash
-claude-pool-server -n 4 --budget-usd 10.0 --model sonnet
-# Stdio transport. Add to .mcp.json and use from Claude.
+Add to your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "claude-pool": {
+      "command": "cargo",
+      "args": ["run", "-p", "claude-pool-mcp", "--", "-n", "4", "--model", "sonnet"]
+    }
+  }
+}
 ```
+
+Then use `pool_run`, `pool_fan_out`, `pool_chain`, `pool_auto`, and 27 other tools directly from Claude Code. See the [coordinator skill](crates/claude-pool-mcp/skills/pool-coordinator/SKILL.md) for tool selection guidance.
 
 ## Features
 
-- **claude-wrapper**: Type-safe CLI wrapper with full option coverage (28 options), MCP server management, plugin management, streaming NDJSON events, session management
-- **claude-pool**: Multi-slot coordination, synchronous/async task execution, parallel fan-out, sequential chains with failure policies, budget control, shared context injection, optional worktree isolation, reusable skills registry
-- **claude-pool-server**: Standalone MCP server binary, configurable via CLI flags, full pool tool exposure, MCP resources for state inspection
+- **claude-wrapper**: Type-safe CLI wrapper with full option coverage, MCP server management, plugin management, streaming NDJSON events, session management
+- **claude-pool**: Multi-slot coordination, synchronous/async task execution, parallel fan-out, sequential chains with failure policies, auto-routing (LLM picks single/parallel/chain), budget control, shared context injection, worktree isolation, review gates
+- **claude-pool-mcp**: 31-tool MCP server, stdio transport, configurable via CLI flags
 
 ## Installation
 
@@ -121,62 +131,22 @@ cargo add claude-wrapper
 
 # Library: slot pool orchestration
 cargo add claude-pool
-
-# Binary: MCP server for the pool
-cargo install claude-pool-server
 ```
 
-## Documentation
-
-- **API Docs**: [docs.rs/claude-wrapper](https://docs.rs/claude-wrapper), [docs.rs/claude-pool](https://docs.rs/claude-pool), [docs.rs/claude-pool-server](https://docs.rs/claude-pool-server)
-- **Crate READMEs**: See individual crate directories above
-- **Examples**: Each crate README contains detailed examples
-
-## Status
-
-**Production-ready.** All three crates are actively maintained with comprehensive test coverage (168+ lib tests, plus integration and doc tests).
-
-### Implemented
-
-- Full CLI wrapper (28 QueryCommand options + all subcommands)
-- Slot pool with task routing, budgets, and slot identity
-- MCP server binary with tools and resources
-- Sequential chains with failure policies
-- Parallel fan-out execution
-- Shared context injection across slots
-- Worktree isolation per slot
-- Reusable skills registry
-
 ## Development & Testing
-
-Pre-commit checks:
 
 ```bash
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --lib --all-features
-cargo test --test '*' --all-features
-```
-
-Doc tests:
-
-```bash
 cargo test --doc --all-features
+
+# Integration tests (requires fake-claude binary)
+cargo test --test pool_integration --test auto_route_tests -p claude-pool -- --ignored
+
+# Live routing accuracy test (requires real claude binary)
+cargo test --test route_stress -p claude-pool -- --ignored
 ```
-
-Full release checklist (before merging release PR):
-
-```bash
-cargo doc --no-deps --all-features  # Docs build without warnings
-cargo test --doc --all-features     # Doc tests pass
-cargo publish --dry-run -p claude-wrapper
-cargo publish --dry-run -p claude-pool
-cargo publish --dry-run -p claude-pool-server
-```
-
-## Contributing
-
-Issues and PRs welcome. Please ensure all checks pass before submitting.
 
 ## License
 

--- a/crates/claude-pool-mcp/README.md
+++ b/crates/claude-pool-mcp/README.md
@@ -1,0 +1,75 @@
+# claude-pool-mcp
+
+MCP server exposing claude-pool as tools for Claude Code.
+
+## Overview
+
+`claude-pool-mcp` is a thin MCP server that wraps `claude-pool` as 31 tools. Every tool maps 1:1 to a pool method -- no business logic, no planning. The client (your interactive Claude session) decides what to run; the server dispatches.
+
+## Usage
+
+Add to your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "claude-pool": {
+      "command": "cargo",
+      "args": ["run", "-p", "claude-pool-mcp", "--", "-n", "4", "--model", "sonnet"]
+    }
+  }
+}
+```
+
+Or run directly:
+
+```bash
+claude-pool-mcp -n 4 --model sonnet --budget-usd 10.0
+```
+
+## CLI Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-n`, `--slots` | 2 | Number of worker slots |
+| `-m`, `--model` | (none) | Default model for all slots |
+| `-e`, `--effort` | (none) | Effort level (low, medium, high, max) |
+| `-b`, `--budget-usd` | (none) | Total budget cap in USD |
+| `-s`, `--system-prompt` | (none) | System prompt for all slots |
+| `-p`, `--permission-mode` | plan | Permission mode (plan, auto, default, etc.) |
+| `--min-slots` | 1 | Minimum slot floor |
+| `--max-slots` | 16 | Maximum slot ceiling |
+
+## Available Tools
+
+### Execution
+`pool_run`, `pool_submit`, `pool_result`, `pool_cancel`, `pool_fan_out`
+
+### Auto-routing
+`pool_auto`, `pool_auto_with_hints`, `pool_route`, `pool_route_with_hints`
+
+### Chains
+`pool_chain`, `pool_submit_chain`, `pool_chain_result`, `pool_cancel_chain`
+
+### Review
+`pool_submit_with_review`, `pool_approve_result`, `pool_reject_result`
+
+### Status
+`pool_status`, `pool_session_metrics`, `pool_list_tasks`, `pool_find_slots`
+
+### Context
+`pool_set_context`, `pool_get_context`, `pool_delete_context`, `pool_list_context`
+
+### Messaging
+`pool_send_message`, `pool_broadcast`, `pool_read_messages`, `pool_peek_messages`
+
+### Scaling
+`pool_scale_up`, `pool_scale_down`, `pool_set_target_slots`, `pool_drain`
+
+## Coordinator Skill
+
+See [`skills/pool-coordinator/SKILL.md`](skills/pool-coordinator/SKILL.md) for a ready-made skill you can add to your `CLAUDE.md` to get Claude to prefer pool tools over built-in Agent() calls.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/claude-pool/README.md
+++ b/crates/claude-pool/README.md
@@ -11,27 +11,22 @@ Slot pool orchestration library for Claude CLI
 
 `claude-pool` manages N Claude CLI slots behind a unified interface. A coordinator (typically an interactive Claude session) submits work, and the pool routes tasks by availability, tracks budgets, and handles slot lifecycle and session management.
 
-Perfect for:
-- Scaling Claude work across multiple slots
-- Budget-aware task distribution
-- Parallel and sequential task orchestration
-- Slot isolation with optional Git worktrees
-
 ## Architecture
 
 ```
 Coordinator (your app or interactive session)
-  │
-  ├─ pool.run("task")           → synchronous
-  ├─ pool.submit("task")        → async, returns task ID
-  ├─ pool.fan_out([tasks])      → parallel execution
-  └─ execute_chain(steps)       → sequential pipeline
-        │
-        ├── Pool (task queue, context, budget)
-        │
-        ├── Slot-0 (Claude instance)
-        ├── Slot-1 (Claude instance)
-        └── Slot-N (Claude instance)
+  |
+  +-- pool.run("task")           -> synchronous
+  +-- pool.submit("task")        -> async, returns task ID
+  +-- pool.fan_out([tasks])      -> parallel execution
+  +-- pool.auto("task")          -> LLM picks single/parallel/chain
+  +-- pool.submit_chain(steps)   -> sequential pipeline
+        |
+        +-- Pool (task queue, context, budget)
+        |
+        +-- Slot-0 (Claude instance)
+        +-- Slot-1 (Claude instance)
+        +-- Slot-N (Claude instance)
 ```
 
 ## Installation
@@ -39,8 +34,6 @@ Coordinator (your app or interactive session)
 ```bash
 cargo add claude-pool
 ```
-
-Requires: `claude-wrapper` (included as dependency)
 
 ## Quick Start
 
@@ -51,10 +44,7 @@ use claude_wrapper::Claude;
 #[tokio::main]
 async fn main() -> claude_pool::Result<()> {
     let claude = Claude::builder().build()?;
-    let pool = Pool::builder(claude)
-        .slots(4)
-        .build()
-        .await?;
+    let pool = Pool::builder(claude).slots(4).build().await?;
 
     let result = pool.run("write a haiku about rust").await?;
     println!("{}", result.output);
@@ -64,496 +54,106 @@ async fn main() -> claude_pool::Result<()> {
 }
 ```
 
-## Core Concepts
-
-### Synchronous vs Asynchronous Tasks
-
-**Synchronous (blocking):**
-```rust
-let result = pool.run("your task here").await?;
-println!("{}", result.output);
-```
-
-**Asynchronous (non-blocking):**
-```rust
-let task_id = pool.submit("long-running task").await?;
-// Do other work...
-let result = pool.result(&task_id).await??;
-```
-
-### Budget Control
-
-Track and limit spending:
-
-```rust
-let pool = Pool::builder(claude)
-    .slots(4)
-    .config(
-        PoolConfig::default()
-            .with_budget_usd(50.0)  // Pool-level cap
-    )
-    .build()
-    .await?;
-```
-
-Budget is tracked atomically per task. When the pool reaches its cap, subsequent tasks are rejected.
-
-### Slot Identity
-
-Each slot has metadata for coordination:
-
-```rust
-pool.configure_slot("slot-0", "analyzer", "Code review specialist")
-    .await?;
-pool.configure_slot("slot-1", "writer", "Code generation specialist")
-    .await?;
-```
-
-Access slot info:
-```rust
-let status = pool.status().await?;
-for slot in status.slots {
-    println!("{}: {} ({} active)", slot.id, slot.role, slot.busy_tasks);
-}
-```
-
-### Shared Context
-
-Inject key-value pairs into all slot system prompts:
-
-```rust
-pool.context_set("language", "rust").await?;
-pool.context_set("framework", "tokio").await?;
-pool.context_set("style", "idiomatic").await?;
-
-// All slots now see these in their system prompts
-```
-
-Access context:
-```rust
-let value = pool.context_get("language").await??;
-pool.context_delete("framework").await?;
-let all = pool.context_list().await?;
-```
-
-## Pool Builder Configuration
-
-```rust
-use claude_pool::{Pool, PoolConfig, Effort, PermissionMode};
-
-let pool = Pool::builder(claude)
-    .slots(8)
-    .config(
-        PoolConfig::default()
-            .with_model("sonnet")
-            .with_effort(Effort::High)
-            .with_budget_usd(100.0)
-            .with_permission_mode(PermissionMode::Plan)
-            .with_system_prompt("You are a Rust expert")
-            .with_worktree(true)
-    )
-    .build()
-    .await?;
-```
-
-Available config options:
-- `with_model(name)` - Default model for all slots
-- `with_effort(level)` - Effort: Min, Low, Medium, High, Max
-- `with_budget_usd(amount)` - Total pool budget
-- `with_permission_mode(mode)` - Permission defaults
-- `with_system_prompt(text)` - Base system prompt
-- `with_worktree(true)` - Enable Git worktree per slot
-
 ## Execution Patterns
 
-### Single Task (Synchronous)
+### Single Task
 
 ```rust
+// Synchronous (blocking)
 let result = pool.run("fix the bug in main.rs").await?;
-println!("Output:\n{}", result.output);
-println!("Spend: ${}", result.spend_usd);
-```
 
-Result includes:
-- `output` - Claude's response
-- `spend_usd` - Cost of this task
-- `tokens_used` - Input and output tokens
-
-### Async Task Submission
-
-```rust
-// Submit and get task ID immediately
+// Asynchronous (non-blocking)
 let task_id = pool.submit("long-running analysis").await?;
-
-// Do other work...
-
-// Poll for result later
-let result = pool.result(&task_id).await??;
+// ... do other work ...
+if let Some(result) = pool.result(&task_id).await? {
+    println!("{}", result.output);
+}
 ```
 
 ### Parallel Fan-Out
 
-Execute multiple prompts in parallel, all at once:
-
 ```rust
-let prompts = vec![
-    "write a poem",
-    "write a haiku",
-    "write a limerick",
-];
-
-let results = pool.fan_out(&prompts).await?;
-for (i, result) in results.iter().enumerate() {
-    println!("Result {}: {}", i, result.output);
-}
+let results = pool.fan_out(&[
+    "review file1.rs",
+    "review file2.rs",
+    "review file3.rs",
+]).await?;
 ```
 
-All tasks run concurrently. Returns when all complete (or timeout).
-
-### Sequential Chains with Failure Policies
-
-Execute steps in order, with control over failures:
+### Sequential Chains
 
 ```rust
-use claude_pool::{ChainStep, StepAction, StepFailurePolicy};
+use claude_pool::{ChainStep, StepAction, ChainOptions};
 
 let steps = vec![
     ChainStep {
         name: "analyze".into(),
         action: StepAction::Prompt { prompt: "analyze the error".into() },
         config: None,
-        failure_policy: StepFailurePolicy::default(),
+        failure_policy: Default::default(),
         output_vars: Default::default(),
     },
     ChainStep {
         name: "fix".into(),
-        action: StepAction::Prompt { prompt: "write a fix based on {previous_output}".into() },
-        config: None,
-        failure_policy: StepFailurePolicy { retries: 2, recovery_prompt: None },
-        output_vars: Default::default(),
-    },
-];
-
-let task_id = pool.submit_chain(steps, &skills, ChainOptions::default()).await?;
-let result = pool.result(&task_id).await?;
-```
-
-Failure policies:
-- **retries** - Number of retries before failing (default: 0)
-- **recovery_prompt** - Optional prompt to run on failure instead of aborting
-
-Access chain progress:
-```rust
-let progress = pool.chain_result(&chain_id).await?;
-for step in progress.steps {
-    println!("{}: {}", step.name, step.status);
-}
-```
-
-## Skills System
-
-Skills are reusable prompt templates that define how to approach a task. The pool discovers and references them by name in chains or direct calls.
-
-### SKILL.md Format
-
-Skills follow the [Agent Skills](https://agentskills.io) standard. Each skill lives in its own directory with a `SKILL.md` file:
-
-```
-.claude-pool/skills/
-  code_review/
-    SKILL.md          # Required: frontmatter + prompt
-    scripts/          # Optional: bundled scripts
-      lint.sh
-    templates/        # Optional: templates
-      report.md
-    examples/         # Optional: examples
-      input.py
-```
-
-The `SKILL.md` file contains YAML frontmatter followed by the prompt body:
-
-```yaml
----
-name: code_review
-description: Review code for bugs and style issues
-argument-hint: "<path> [criteria]"
-allowed-tools: Read, Grep, Glob, Bash
-metadata:
-  arguments:
-    - name: path
-      description: File path to review
-      required: true
-    - name: criteria
-      description: What to focus on (bugs, style, performance)
-      required: false
----
-
-Review the code at {path} for the following criteria: {criteria}
-
-Report issues found with severity and suggestions.
-```
-
-Standard fields (`argument-hint`, `allowed-tools`) live at the top level.
-Pool-specific extensions (`scope`, `arguments`, `config`) live under `metadata`.
-Arguments are available as `{arg_name}` or `$ARGUMENTS` / `$0` / `$1` in the prompt.
-
-### Skill Resolution
-
-Skills are discovered in priority order (first match wins):
-
-1. **Runtime skills** - Added via code (ephemeral, lost on restart)
-2. **Project skills** - Loaded from `.claude-pool/skills/` (checked into repo)
-3. **Global skills** - Loaded from `~/.claude-pool/skills/` (user-wide)
-4. **Builtin skills** - Shipped with the pool binary
-
-### CLAUDE_SKILL_DIR Substitution
-
-Skills can reference supporting files using the `${CLAUDE_SKILL_DIR}` variable:
-
-```
-Run linting:
-bash ${CLAUDE_SKILL_DIR}/scripts/lint.sh .
-
-Generate report from template:
-python -c "..." < ${CLAUDE_SKILL_DIR}/templates/report.md
-```
-
-The variable resolves to the skill's directory path at render time. Available for project and global skills only (not builtins or runtime skills).
-
-### Using Skills in Chains
-
-Reference skills in chain steps:
-
-```rust
-use claude_pool::{ChainStep, StepAction};
-
-let steps = vec![
-    ChainStep {
-        name: "review".into(),
-        action: StepAction::Skill {
-            skill: "code_review".into(),
-            arguments: [
-                ("path", "src/main.rs"),
-                ("criteria", "performance"),
-            ].iter().map(|(k, v)| (k.to_string(), v.to_string())).collect(),
+        action: StepAction::Prompt {
+            prompt: "write a fix based on {previous_output}".into(),
         },
         config: None,
         failure_policy: Default::default(),
         output_vars: Default::default(),
     },
 ];
+
+let task_id = pool.submit_chain(steps, ChainOptions::default()).await?;
 ```
 
-### Programmatic Registration
+### Auto-Routing
 
-Register skills at runtime:
+Let an LLM classify the task as single, parallel, or chain:
 
 ```rust
-use claude_pool::{Skill, SkillArgument, SkillRegistry, SkillSource};
-
-let mut registry = SkillRegistry::new();
-registry.register(
-    Skill {
-        name: "code_review".to_string(),
-        description: "Review code for bugs and style".to_string(),
-        prompt: "Review the code at {path} for {criteria}".to_string(),
-        arguments: vec![
-            SkillArgument {
-                name: "path".to_string(),
-                description: "File to review".to_string(),
-                required: true,
-            },
-        ],
-        config: None,
-        scope: Default::default(),
-        argument_hint: Some("<path> [criteria]".to_string()),
-        skill_dir: None,
-    },
-    SkillSource::Runtime,
-);
+let result = pool.auto("translate hello into French, Spanish, and German").await?;
+// Router decides this is parallel and fans out automatically.
 ```
 
-## Worktree Isolation
-
-Enable optional Git worktree per slot for safe, isolated execution:
+## Configuration
 
 ```rust
+use claude_pool::{Pool, PoolConfig};
+
 let pool = Pool::builder(claude)
-    .slots(4)
-    .config(
-        PoolConfig::default()
-            .with_worktree(true)
-    )
+    .slots(8)
+    .config(PoolConfig {
+        model: Some("sonnet".into()),
+        budget_microdollars: Some(50_000_000), // $50
+        ..Default::default()
+    })
     .build()
     .await?;
 ```
 
-Each slot gets an isolated worktree:
-- Independent filesystem
-- Safe for parallel edits
-- Cleanup on drain
+## Features
 
-Benefits:
-- Parallel file edits without conflicts
-- Isolated git state
-- Safe cleanup
-
-## Quality Gates
-
-The pool supports a human-in-the-loop review workflow. Tasks submitted with
-`submit_with_review` transition to `PendingReview` on completion instead of
-`Completed`, allowing a coordinator to inspect results before accepting them.
-
-```rust
-// Submit a task that requires approval before it's considered done.
-let task_id = pool.submit_with_review(
-    "refactor the auth module",
-    None,           // optional SlotConfig override
-    vec![],         // tags
-    Some(3),        // max_rejections (default: 3)
-).await?;
-
-// ... task runs, completes, enters PendingReview ...
-
-// Inspect the result.
-let result = pool.result(&task_id).await?;
-
-// Approve: transitions PendingReview -> Completed.
-pool.approve_result(&task_id).await?;
-
-// Or reject with feedback: re-queues the task with feedback appended
-// to the original prompt. Fails after max_rejections.
-pool.reject_result(&task_id, "missing error handling for timeout case").await?;
-```
-
-### Via MCP tools
-
-The same workflow is available through the MCP server:
-
-- `pool_submit_with_review` -- submit a task requiring approval
-- `pool_approve_result` -- accept the result
-- `pool_reject_result` -- reject with feedback, task re-runs
-
-### Task states
-
-```
-Pending -> Running -> PendingReview -> Completed  (approved)
-                          |
-                          +-> Running  (rejected, re-queued with feedback)
-                          |
-                          +-> Failed   (max rejections reached)
-```
-
-Rejection appends feedback to the original prompt so the slot sees what went
-wrong and can address it on the next attempt.
-
-## Slot Lifecycle
-
-### Spawning
-
-Slots are created during `build()` and remain alive until `drain()`.
-
-### Session Resumption
-
-Slots automatically resume sessions if available, reducing startup cost.
-
-### Graceful Shutdown
-
-```rust
-let summary = pool.drain().await?;
-println!("Processed {} tasks", summary.total_tasks);
-println!("Total spend: ${}", summary.total_spend_usd);
-println!("Errors: {}", summary.error_count);
-```
-
-All pending tasks are cancelled. Active tasks complete gracefully.
-
-## Status & Monitoring
-
-Get current pool state:
-
-```rust
-let status = pool.status().await?;
-println!("Slots: {}", status.slots.len());
-println!("Active tasks: {}", status.active_tasks);
-println!("Budget: ${} / ${}", status.spend_usd, status.budget_usd);
-println!("Remaining: ${}", status.budget_usd - status.spend_usd);
-```
-
-Status includes:
-- Slot list with ID, status, and active task count
-- Active and pending task counts
-- Total spend and budget
-- Budget remaining
-
-## Error Handling
-
-All operations return `Result<T>`:
-
-```rust
-use claude_pool::Error;
-
-match pool.run("task").await {
-    Ok(result) => println!("{}", result.output),
-    Err(Error::TaskFailed(msg)) => eprintln!("Task error: {}", msg),
-    Err(Error::BudgetExceeded) => eprintln!("Out of budget"),
-    Err(Error::NoSlotsAvailable) => eprintln!("All slots busy"),
-    Err(e) => eprintln!("Other error: {}", e),
-}
-```
-
-Common errors:
-- `TaskFailed` - Task execution failed
-- `BudgetExceeded` - Pool exceeded spending cap
-- `NoSlotsAvailable` - All slots busy/offline
-- `TaskNotFound` - Invalid task ID
-
-## Durable Storage
-
-By default the pool uses `InMemoryStore` (all state lost on exit). For persistence across restarts, use `JsonFileStore`:
-
-```rust
-use claude_pool::{Pool, JsonFileStore};
-
-let store = JsonFileStore::new("/tmp/my-pool-state").await?;
-let pool = Pool::builder_with_store(claude, store)
-    .slots(4)
-    .build()
-    .await?;
-
-// Tasks and slot state persist as JSON files under the directory.
-// A new Pool instance pointed at the same directory picks up where you left off.
-```
+- **Task execution**: synchronous (`run`), async (`submit`/`result`), parallel (`fan_out`)
+- **Chains**: sequential pipelines with `{previous_output}` threading, failure policies, retries
+- **Auto-routing**: LLM classifies tasks as single/parallel/chain with structured hints
+- **Budget control**: pool-level and per-task spending caps
+- **Shared context**: inject key-value pairs into all slot system prompts
+- **Review gates**: `submit_with_review` / `approve_result` / `reject_result`
+- **Worktree isolation**: optional git worktree per slot or per chain
+- **Messaging**: inter-slot messaging with broadcast support
+- **Scaling**: dynamic slot scaling (`scale_up`, `scale_down`, `set_target_slots`)
+- **Supervisor**: background health monitoring with automatic slot restarts
+- **Storage**: `InMemoryStore` (default) or `JsonFileStore` for persistence
 
 ## Examples
 
-Runnable examples in `examples/`:
-
 ```bash
 cargo run -p claude-pool --example basic_pool     # Single task, status, drain
-cargo run -p claude-pool --example fan_out         # Parallel execution across slots
-cargo run -p claude-pool --example chain           # Sequential pipeline with per-step models
-cargo run -p claude-pool --example budget_batch    # Async submission with budget caps
-```
-
-## Feature Flags
-
-Currently no optional features. The crate includes full functionality by default.
-
-Future features may include:
-- `redis-store` - Redis backend for distributed pool state
-- `prometheus` - Metrics export for monitoring
-
-## API Documentation
-
-For detailed API documentation, see [docs.rs/claude-pool](https://docs.rs/claude-pool).
-
-## Testing
-
-Requires the `claude` CLI binary:
-
-```bash
-cargo test --lib --all-features
+cargo run -p claude-pool --example fan_out         # Parallel execution
+cargo run -p claude-pool --example chain           # Sequential pipeline
+cargo run -p claude-pool --example auto_route      # Auto-routing demonstration
+cargo run -p claude-pool --example route_stress    # Routing accuracy test
 ```
 
 ## License


### PR DESCRIPTION
## Summary

Comprehensive update to all project documentation and configuration for release readiness.

### READMEs
- **Top-level**: replaced claude-pool-server with claude-pool-mcp, updated architecture diagram, features, Quick Start, test commands
- **claude-pool**: removed ~150 lines of skills system docs (SkillRegistry, StepAction::Skill, skill resolution, CLAUDE_SKILL_DIR), updated chain API, added auto-routing section
- **claude-pool-mcp** (new): CLI options, all 31 tools, .mcp.json setup, link to coordinator skill

### Configuration
- `.mcp.json`: replaced hardcoded binary path with `cargo run -p claude-pool-mcp`, bumped slots 2->4
- `Cargo.toml`: removed unused `serde_yaml` workspace dependency

Closes #289

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (236 pass)