### PR TITLE
fix: changelog workflow creates PR instead of direct push

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   changelog:
@@ -29,14 +30,12 @@ jobs:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}
 
-      - name: Commit changelog
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet CHANGELOG.md; then
-            echo "No changelog changes to commit"
-          else
-            git add CHANGELOG.md
-            git commit -m "chore: update changelog"
-            git push
-          fi
+      - name: Create changelog PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.COMMITTER_TOKEN }}
+          commit-message: "chore: update changelog"
+          branch: chore/update-changelog
+          title: "chore: update changelog"
+          body: "Auto-generated changelog update from git-cliff."
+          delete-branch: true


### PR DESCRIPTION
Replace direct push to main with peter-evans/create-pull-request action to comply with branch protection rules. Fixes #200