### PR TITLE
test: enable fake-binary integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
       - name: Doc tests
         run: cargo test --doc --all-features
 
+      - name: Integration tests (fake binary)
+        if: matrix.os != 'windows-latest'
+        run: |
+          chmod +x crates/test-helpers/fake-claude.sh
+          cargo test --test pool_integration --test auto_route_tests --test worktree_tests -p claude-pool
+
   security:
     name: Security audit
     runs-on: ubuntu-latest

--- a/crates/claude-pool/tests/auto_route_tests.rs
+++ b/crates/claude-pool/tests/auto_route_tests.rs
@@ -4,11 +4,6 @@
 //! These tests verify the full `route()` pipeline: prompt assembly, CLI
 //! invocation, output parsing, and normalization. The fake binary returns
 //! pre-canned JSON routing decisions via `FAKE_CLAUDE_OUTPUT`.
-//!
-//! Run with:
-//! ```sh
-//! cargo test --test auto_route_tests -p claude-pool -- --ignored
-//! ```
 
 mod helpers;
 
@@ -59,7 +54,6 @@ fn assert_chain(route: &AutoRoute) -> &[claude_pool::AutoStep] {
 // ── Single route tests ───────────────────────────────────────────────────────
 
 #[tokio::test]
-#[ignore]
 async fn route_single_basic() {
     let output = r#"{"route": "single", "prompt": "What is 2+2?"}"#;
     let pool = pool_with_output(output).await;
@@ -69,7 +63,6 @@ async fn route_single_basic() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_single_vague_prompt() {
     let output = r#"{"route": "single", "prompt": "Refactor."}"#;
     let pool = pool_with_output(output).await;
@@ -79,7 +72,6 @@ async fn route_single_vague_prompt() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_single_coherent_task() {
     let output = r#"{"route": "single", "prompt": "Write a blog post about Rust error handling."}"#;
     let pool = pool_with_output(output).await;
@@ -94,7 +86,6 @@ async fn route_single_coherent_task() {
 // ── Parallel route tests ─────────────────────────────────────────────────────
 
 #[tokio::test]
-#[ignore]
 async fn route_parallel_basic() {
     let output = r#"{"route": "parallel", "prompts": ["Translate 'hello' into French", "Translate 'hello' into Spanish", "Translate 'hello' into German", "Translate 'hello' into Japanese"]}"#;
     let pool = pool_with_output(output).await;
@@ -108,7 +99,6 @@ async fn route_parallel_basic() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_parallel_many_independent_items() {
     let prompts: Vec<String> = (1..=10)
         .map(|i| format!("Review file{i}.rs for bugs"))
@@ -127,7 +117,6 @@ async fn route_parallel_many_independent_items() {
 // ── Chain route tests ────────────────────────────────────────────────────────
 
 #[tokio::test]
-#[ignore]
 async fn route_chain_basic() {
     let output = r#"{"route": "chain", "steps": [{"name": "write", "prompt": "Write a function that sorts a list"}, {"name": "test", "prompt": "Write tests for {previous_output}"}, {"name": "review", "prompt": "Review tests for coverage gaps based on {previous_output}"}]}"#;
     let pool = pool_with_output(output).await;
@@ -143,7 +132,6 @@ async fn route_chain_basic() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_chain_dependent_steps() {
     let output = r#"{"route": "chain", "steps": [{"name": "migrate", "prompt": "Migrate the database schema"}, {"name": "update_orm", "prompt": "Update the ORM models based on {previous_output}"}, {"name": "fix_queries", "prompt": "Fix all broken queries based on {previous_output}"}, {"name": "test", "prompt": "Run the test suite"}]}"#;
     let pool = pool_with_output(output).await;
@@ -157,7 +145,6 @@ async fn route_chain_dependent_steps() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_chain_hidden_dependency() {
     let output = r#"{"route": "chain", "steps": [{"name": "refactor", "prompt": "Refactor the auth module"}, {"name": "update_callers", "prompt": "Update all callers based on {previous_output}"}]}"#;
     let pool = pool_with_output(output).await;
@@ -171,7 +158,6 @@ async fn route_chain_hidden_dependency() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_chain_mixed_independent_and_dependent() {
     let output = r#"{"route": "chain", "steps": [{"name": "lint", "prompt": "Lint src/a.rs and src/b.rs"}, {"name": "summarize", "prompt": "Combine results into a summary based on {previous_output}"}]}"#;
     let pool = pool_with_output(output).await;
@@ -187,7 +173,6 @@ async fn route_chain_mixed_independent_and_dependent() {
 // ── Hint-influenced routing ──────────────────────────────────────────────────
 
 #[tokio::test]
-#[ignore]
 async fn route_with_prefer_single_hint() {
     let output = r#"{"route": "single", "prompt": "Check all modules for unused imports."}"#;
     let pool = pool_with_output(output).await;
@@ -204,7 +189,6 @@ async fn route_with_prefer_single_hint() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_with_prefer_parallel_and_decomposition() {
     let output = r#"{"route": "parallel", "prompts": ["Audit input validation", "Audit authentication", "Audit data storage"]}"#;
     let pool = pool_with_output(output).await;
@@ -227,7 +211,6 @@ async fn route_with_prefer_parallel_and_decomposition() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_with_max_parallel_cap() {
     // Even though 6 files, max_parallel=3 should be respected by the router.
     let output = r#"{"route": "parallel", "prompts": ["Review a.rs and b.rs", "Review c.rs and d.rs", "Review e.rs and f.rs"]}"#;
@@ -253,7 +236,6 @@ async fn route_with_max_parallel_cap() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_with_max_chain_steps_compresses() {
     // 5 dependent steps compressed to max 2 is ambiguous: chain(2) or single
     // are both reasonable. We test that the router returns *something* valid.
@@ -285,7 +267,6 @@ async fn route_with_max_chain_steps_compresses() {
 // ── Adversarial inputs ───────────────────────────────────────────────────────
 
 #[tokio::test]
-#[ignore]
 async fn route_prompt_injection_still_routes() {
     let output = r#"{"route": "single", "prompt": "Review main.rs"}"#;
     let pool = pool_with_output(output).await;
@@ -298,7 +279,6 @@ async fn route_prompt_injection_still_routes() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_non_json_output_request_still_routes() {
     let output = r#"{"route": "single", "prompt": "Fix the bug in auth.rs"}"#;
     let pool = pool_with_output(output).await;
@@ -317,7 +297,6 @@ async fn route_non_json_output_request_still_routes() {
 // binary wraps output in a QueryResult JSON envelope.
 
 #[tokio::test]
-#[ignore]
 async fn route_parallel_single_item_normalized_to_single() {
     // Router returns parallel with one item; execute_route normalizes to single.
     // route() only classifies, so normalization happens at execute_route level.
@@ -331,7 +310,6 @@ async fn route_parallel_single_item_normalized_to_single() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_chain_single_step_parsed() {
     let output = r#"{"route": "chain", "steps": [{"name": "only", "prompt": "do it"}]}"#;
     let pool = pool_with_output(output).await;
@@ -343,7 +321,6 @@ async fn route_chain_single_step_parsed() {
 // ── Domain hint routing ──────────────────────────────────────────────────────
 
 #[tokio::test]
-#[ignore]
 async fn route_with_domain_hint() {
     let output = r#"{"route": "parallel", "prompts": ["Review crate-a", "Review crate-b"]}"#;
     let pool = pool_with_output(output).await;
@@ -361,7 +338,6 @@ async fn route_with_domain_hint() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn route_with_prefer_chain_hint() {
     let output = r#"{"route": "chain", "steps": [{"name": "plan", "prompt": "Create a migration plan"}, {"name": "execute", "prompt": "Execute the migration based on {previous_output}"}]}"#;
     let pool = pool_with_output(output).await;

--- a/crates/claude-pool/tests/pool_integration.rs
+++ b/crates/claude-pool/tests/pool_integration.rs
@@ -1,12 +1,7 @@
 #![cfg(unix)]
 //! Integration tests for claude-pool using the fake-claude binary.
 //!
-//! All tests are marked `#[ignore]` because they require the fake-claude.sh
-//! script (which behaves as a real binary). Run with:
-//!
-//! ```sh
-//! cargo test --test pool_integration -p claude-pool -- --ignored
-//! ```
+//! These tests require the fake-claude.sh script (which behaves as a real binary).
 
 mod helpers;
 
@@ -64,7 +59,6 @@ macro_rules! poll_result {
 
 /// Submit a task asynchronously, poll until complete, verify output/cost/session_id.
 #[tokio::test]
-#[ignore]
 async fn pool_submit_and_retrieve_result() {
     let claude = claude_with_fake_binary(&fake_claude_path());
     let pool = Pool::builder(claude).slots(1).build().await.unwrap();
@@ -80,7 +74,6 @@ async fn pool_submit_and_retrieve_result() {
 
 /// Run a 2-step chain. Both steps should complete, cost accumulates, step names preserved.
 #[tokio::test]
-#[ignore]
 async fn pool_chain_executes_all_steps() {
     let claude = claude_with_fake_binary(&fake_claude_path());
     let pool = Pool::builder(claude).slots(2).build().await.unwrap();
@@ -108,7 +101,6 @@ async fn pool_chain_executes_all_steps() {
 
 /// Step 1 returns JSON; output_vars extracts a field; step 2 uses it via template.
 #[tokio::test]
-#[ignore]
 async fn pool_chain_output_vars_flow() {
     // Wrapper that makes fake-claude output JSON with a "summary" field.
     let json_output = r#"{"summary": "all good"}"#;
@@ -156,7 +148,6 @@ async fn pool_chain_output_vars_flow() {
 /// Submit a 3-step chain with a 1-second delay per step. Cancel after step 1 starts.
 /// Remaining steps should be skipped.
 #[tokio::test]
-#[ignore]
 async fn pool_chain_cancellation_skips_remaining() {
     // Wrapper: each invocation sleeps 1 second before responding.
     let wrapper = write_env_wrapper(&[("FAKE_CLAUDE_DELAY", "1")], &fake_claude_path());
@@ -199,7 +190,6 @@ async fn pool_chain_cancellation_skips_remaining() {
 
 /// Fan out 3 single-step chains. All should complete with distinct task IDs.
 #[tokio::test]
-#[ignore]
 async fn pool_fan_out_parallel() {
     let claude = claude_with_fake_binary(&fake_claude_path());
     let pool = Pool::builder(claude).slots(3).build().await.unwrap();
@@ -238,7 +228,6 @@ async fn pool_fan_out_parallel() {
 
 /// Chain with Worktree isolation: worktree is created during execution and cleaned up after.
 #[tokio::test]
-#[ignore]
 async fn pool_chain_worktree_creates_and_cleans() {
     let repo = helpers::temp_git_repo();
     let fake = fake_claude_path();
@@ -298,7 +287,6 @@ async fn pool_chain_worktree_creates_and_cleans() {
 
 /// Mark a slot as errored, run check_and_restart_slots, verify recovery. Then run a task.
 #[tokio::test]
-#[ignore]
 async fn supervisor_restarts_errored_slot_integration() {
     let claude = claude_with_fake_binary(&fake_claude_path());
     let pool = Pool::builder(claude).slots(2).build().await.unwrap();


### PR DESCRIPTION
Remove #[ignore] from fake-binary integration tests and add CI step. These tests use fake-claude.sh, not a real binary. route_stress.rs remains ignored (needs real Claude). Fixes #265