### PR TITLE
feat: enable worktree isolation by default for pool slots

### DIFF
--- a/crates/claude-pool-mcp/src/main.rs
+++ b/crates/claude-pool-mcp/src/main.rs
@@ -49,6 +49,10 @@ struct Cli {
     /// Maximum slots ceiling.
     #[arg(long, default_value_t = 16)]
     max_slots: usize,
+
+    /// Disable per-slot worktree isolation (not recommended for write tasks).
+    #[arg(long)]
+    no_worktree: bool,
 }
 
 fn parse_effort(s: &str) -> Option<Effort> {
@@ -93,6 +97,7 @@ async fn main() -> anyhow::Result<()> {
         budget_microdollars: cli.budget_usd.map(|usd| (usd * 1_000_000.0) as u64),
         system_prompt: cli.system_prompt.clone(),
         permission_mode: Some(parse_permission_mode(&cli.permission_mode)),
+        worktree_isolation: !cli.no_worktree,
         scaling: ScalingConfig {
             min_slots: cli.min_slots,
             max_slots: cli.max_slots,

--- a/crates/claude-pool/src/executor.rs
+++ b/crates/claude-pool/src/executor.rs
@@ -232,10 +232,12 @@ pub(crate) async fn execute_task<S: PoolStore + 'static>(
 
     // Use override working dir, slot worktree, or default.
     let claude_instance = if let Some(slot) = inner.store.get_slot(slot_id).await? {
-        // Resume session if the slot has one, but NOT when using an
-        // override working dir (clone isolation) — the session belongs
-        // to the original working directory and won't exist in the clone.
+        // Resume session if the slot has one, but NOT when:
+        // - Using an override working dir (clone isolation)
+        // - Using a slot worktree (session belongs to repo root, not worktree)
+        // Stale session resumption causes "No conversation found" errors.
         if override_working_dir.is_none()
+            && slot.worktree_path.is_none()
             && let Some(ref session_id) = slot.session_id
         {
             cmd = cmd.resume(session_id);
@@ -381,9 +383,11 @@ pub(crate) async fn execute_task_streaming<S: PoolStore + 'static>(
 
     // Use override working dir (chain worktree) > slot worktree > default.
     let claude_instance = if let Some(slot) = inner.store.get_slot(slot_id).await? {
-        // Skip session resumption in clone isolation — the session
-        // belongs to the original directory and won't exist in the clone.
+        // Skip session resumption when using worktrees or clone isolation —
+        // the session belongs to the original directory and won't exist
+        // in the worktree/clone. Stale sessions cause "No conversation found" errors.
         if override_working_dir.is_none()
+            && slot.worktree_path.is_none()
             && let Some(ref session_id) = slot.session_id
         {
             cmd = cmd.resume(session_id);

--- a/crates/claude-pool/src/pool.rs
+++ b/crates/claude-pool/src/pool.rs
@@ -119,9 +119,9 @@ impl<S: PoolStore + 'static> PoolBuilder<S> {
             .map(|p| p.to_path_buf())
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
-        // Validate repo_dir is a git repo. Hard error when global worktree
-        // isolation is on; soft warning otherwise (per-chain isolation may
-        // still request worktrees).
+        // Validate repo_dir is a git repo. Worktree isolation is on by
+        // default — if the repo isn't a git repo, fall back gracefully
+        // with a warning instead of hard failing.
         //
         // Default worktree base is .claude/pool-worktrees/ under the repo,
         // keeping worktrees within the project directory so Claude's auto
@@ -139,9 +139,6 @@ impl<S: PoolStore + 'static> PoolBuilder<S> {
         {
             Ok(mgr) => Some(mgr),
             Err(e) => {
-                if self.config.worktree_isolation {
-                    return Err(e);
-                }
                 tracing::warn!(
                     repo_dir = %repo_dir.display(),
                     error = %e,
@@ -1840,9 +1837,24 @@ mod tests {
         Claude::builder().binary("/usr/bin/false").build().unwrap()
     }
 
+    /// Pool config for unit tests — worktree isolation disabled since
+    /// tests don't run in a git repo.
+    fn test_config() -> PoolConfig {
+        PoolConfig {
+            worktree_isolation: false,
+            ..Default::default()
+        }
+    }
+
     #[tokio::test]
     async fn build_pool_registers_slots() {
-        let pool = Pool::builder(mock_claude()).slots(3).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(3)
+            .build()
+            .await
+            .unwrap();
 
         let slots = pool.store().list_slots().await.unwrap();
         assert_eq!(slots.len(), 3);
@@ -1855,6 +1867,7 @@ mod tests {
     #[tokio::test]
     async fn pool_with_slot_configs() {
         let pool = Pool::builder(mock_claude())
+            .config(test_config())
             .slots(2)
             .slot_config(SlotConfig {
                 model: Some("opus".into()),
@@ -1876,7 +1889,13 @@ mod tests {
 
     #[tokio::test]
     async fn context_operations() {
-        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(1)
+            .build()
+            .await
+            .unwrap();
 
         pool.set_context("repo", "claude-wrapper");
         pool.set_context("branch", "main");
@@ -1890,7 +1909,13 @@ mod tests {
 
     #[tokio::test]
     async fn drain_marks_slots_stopped() {
-        let pool = Pool::builder(mock_claude()).slots(2).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(2)
+            .build()
+            .await
+            .unwrap();
 
         let summary = pool.drain().await.unwrap();
         assert_eq!(summary.total_tasks_completed, 0);
@@ -1907,9 +1932,11 @@ mod tests {
     #[tokio::test]
     async fn budget_enforcement() {
         let pool = Pool::builder(mock_claude())
+            .config(test_config())
             .slots(1)
             .config(PoolConfig {
                 budget_microdollars: Some(100),
+                worktree_isolation: false,
                 ..Default::default()
             })
             .build()
@@ -1926,9 +1953,11 @@ mod tests {
     #[tokio::test]
     async fn status_snapshot() {
         let pool = Pool::builder(mock_claude())
+            .config(test_config())
             .slots(3)
             .config(PoolConfig {
                 budget_microdollars: Some(1_000_000),
+                worktree_isolation: false,
                 ..Default::default()
             })
             .build()
@@ -1946,9 +1975,11 @@ mod tests {
     #[tokio::test]
     async fn no_idle_slots_timeout() {
         let pool = Pool::builder(mock_claude())
+            .config(test_config())
             .slots(1)
             .config(PoolConfig {
                 slot_assignment_timeout_secs: 1,
+                worktree_isolation: false,
                 ..Default::default()
             })
             .build()
@@ -1970,7 +2001,13 @@ mod tests {
         // With 2 slots and 4 prompts, all 4 should eventually complete.
         // Since we use mock_claude (non-existent binary), actual execution will fail,
         // but we're testing that the queueing mechanism works (assignment tries to get a slot).
-        let pool = Pool::builder(mock_claude()).slots(2).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(2)
+            .build()
+            .await
+            .unwrap();
 
         let prompts = vec!["prompt1", "prompt2", "prompt3", "prompt4"];
 
@@ -1993,6 +2030,7 @@ mod tests {
     #[tokio::test]
     async fn slot_identity_fields_persisted() {
         let pool = Pool::builder(mock_claude())
+            .config(test_config())
             .slots(1)
             .slot_config(SlotConfig {
                 name: Some("reviewer".into()),
@@ -2018,6 +2056,7 @@ mod tests {
     #[tokio::test]
     async fn find_slots_filters_by_name_role_state() {
         let pool = Pool::builder(mock_claude())
+            .config(test_config())
             .slots(1)
             .slot_config(SlotConfig {
                 name: Some("reviewer".into()),
@@ -2071,7 +2110,13 @@ mod tests {
 
     #[tokio::test]
     async fn broadcast_sends_to_all_except_sender() {
-        let pool = Pool::builder(mock_claude()).slots(3).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(3)
+            .build()
+            .await
+            .unwrap();
 
         let from = SlotId("slot-0".into());
         let ids = pool
@@ -2089,7 +2134,13 @@ mod tests {
 
     #[tokio::test]
     async fn scale_up_increases_slot_count() {
-        let pool = Pool::builder(mock_claude()).slots(2).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(2)
+            .build()
+            .await
+            .unwrap();
 
         let initial_count = pool.store().list_slots().await.unwrap().len();
         assert_eq!(initial_count, 2);
@@ -2108,8 +2159,14 @@ mod tests {
 
     #[tokio::test]
     async fn scale_up_respects_max_slots() {
-        let mut config = PoolConfig::default();
-        config.scaling.max_slots = 4;
+        let config = PoolConfig {
+            scaling: ScalingConfig {
+                max_slots: 4,
+                ..Default::default()
+            },
+            worktree_isolation: false,
+            ..Default::default()
+        };
 
         let pool = Pool::builder(mock_claude())
             .slots(2)
@@ -2134,7 +2191,13 @@ mod tests {
 
     #[tokio::test]
     async fn scale_down_reduces_slot_count() {
-        let pool = Pool::builder(mock_claude()).slots(4).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(4)
+            .build()
+            .await
+            .unwrap();
 
         let initial = pool.store().list_slots().await.unwrap().len();
         assert_eq!(initial, 4);
@@ -2147,8 +2210,14 @@ mod tests {
 
     #[tokio::test]
     async fn scale_down_respects_min_slots() {
-        let mut config = PoolConfig::default();
-        config.scaling.min_slots = 2;
+        let config = PoolConfig {
+            scaling: ScalingConfig {
+                min_slots: 2,
+                ..Default::default()
+            },
+            worktree_isolation: false,
+            ..Default::default()
+        };
 
         let pool = Pool::builder(mock_claude())
             .slots(3)
@@ -2168,7 +2237,13 @@ mod tests {
 
     #[tokio::test]
     async fn set_target_slots_scales_up() {
-        let pool = Pool::builder(mock_claude()).slots(2).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(2)
+            .build()
+            .await
+            .unwrap();
 
         let new_count = pool.set_target_slots(5).await.unwrap();
         assert_eq!(new_count, 5);
@@ -2177,7 +2252,13 @@ mod tests {
 
     #[tokio::test]
     async fn set_target_slots_scales_down() {
-        let pool = Pool::builder(mock_claude()).slots(5).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(5)
+            .build()
+            .await
+            .unwrap();
 
         let new_count = pool.set_target_slots(2).await.unwrap();
         assert_eq!(new_count, 2);
@@ -2186,7 +2267,13 @@ mod tests {
 
     #[tokio::test]
     async fn set_target_slots_no_op_when_equal() {
-        let pool = Pool::builder(mock_claude()).slots(3).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(3)
+            .build()
+            .await
+            .unwrap();
 
         let new_count = pool.set_target_slots(3).await.unwrap();
         assert_eq!(new_count, 3);
@@ -2194,7 +2281,13 @@ mod tests {
 
     #[tokio::test]
     async fn fan_out_chains_submits_all_chains() {
-        let pool = Pool::builder(mock_claude()).slots(2).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(2)
+            .build()
+            .await
+            .unwrap();
 
         let options = crate::chain::ChainOptions {
             tags: vec![],
@@ -2391,7 +2484,13 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_chain_marks_task_cancelled() {
-        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(1)
+            .build()
+            .await
+            .unwrap();
 
         // Manually insert a running chain task.
         let task_id = TaskId("chain-test-1".into());
@@ -2442,7 +2541,13 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_chain_noop_for_completed() {
-        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(1)
+            .build()
+            .await
+            .unwrap();
 
         let task_id = TaskId("chain-done".into());
         let record = TaskRecord {
@@ -2483,7 +2588,13 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_chain_not_found() {
-        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(1)
+            .build()
+            .await
+            .unwrap();
         let result = pool.cancel_chain(&TaskId("nonexistent".into())).await;
         assert!(matches!(result, Err(Error::TaskNotFound(_))));
     }
@@ -2492,7 +2603,13 @@ mod tests {
 
     #[tokio::test]
     async fn append_chain_partial_output_accumulates() {
-        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(1)
+            .build()
+            .await
+            .unwrap();
 
         let task_id = TaskId("chain-test".into());
         let progress = crate::chain::ChainProgress {
@@ -2518,7 +2635,13 @@ mod tests {
 
     #[tokio::test]
     async fn append_chain_partial_output_noop_when_none() {
-        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(1)
+            .build()
+            .await
+            .unwrap();
 
         let task_id = TaskId("chain-test-2".into());
         // Progress with partial output = None (completed state).
@@ -2542,7 +2665,13 @@ mod tests {
 
     #[tokio::test]
     async fn append_chain_partial_output_noop_for_missing_task() {
-        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .config(test_config())
+            .slots(1)
+            .build()
+            .await
+            .unwrap();
 
         // Should not panic when task doesn't exist.
         let task_id = TaskId("nonexistent".into());
@@ -2554,9 +2683,11 @@ mod tests {
     #[tokio::test]
     async fn task_budget_exceeds_remaining_pool_budget() {
         let pool = Pool::builder(mock_claude())
+            .config(test_config())
             .slots(1)
             .config(PoolConfig {
                 budget_microdollars: Some(1_000_000), // $1.00
+                worktree_isolation: false,
                 ..Default::default()
             })
             .build()
@@ -2581,9 +2712,11 @@ mod tests {
     #[tokio::test]
     async fn task_budget_within_remaining_pool_budget() {
         let pool = Pool::builder(mock_claude())
+            .config(test_config())
             .slots(1)
             .config(PoolConfig {
                 budget_microdollars: Some(1_000_000), // $1.00
+                worktree_isolation: false,
                 ..Default::default()
             })
             .build()
@@ -2609,9 +2742,11 @@ mod tests {
     #[tokio::test]
     async fn task_budget_check_skipped_without_pool_budget() {
         let pool = Pool::builder(mock_claude())
+            .config(test_config())
             .slots(1)
             .config(PoolConfig {
                 budget_microdollars: None, // No pool budget
+                worktree_isolation: false,
                 ..Default::default()
             })
             .build()

--- a/crates/claude-pool/src/supervisor.rs
+++ b/crates/claude-pool/src/supervisor.rs
@@ -116,9 +116,21 @@ mod tests {
         Claude::builder().binary("/usr/bin/false").build().unwrap()
     }
 
+    fn test_config() -> crate::types::PoolConfig {
+        crate::types::PoolConfig {
+            worktree_isolation: false,
+            ..Default::default()
+        }
+    }
+
     #[tokio::test]
     async fn check_restarts_errored_slots() {
-        let pool = Pool::builder(mock_claude()).slots(2).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .slots(2)
+            .build()
+            .await
+            .unwrap();
 
         // Mark slot-0 as errored.
         let mut slot = pool
@@ -148,6 +160,7 @@ mod tests {
     async fn check_skips_slots_at_restart_limit() {
         let config = PoolConfig {
             max_restarts: 2,
+            worktree_isolation: false,
             ..Default::default()
         };
         let pool = Pool::builder(mock_claude())
@@ -183,7 +196,12 @@ mod tests {
 
     #[tokio::test]
     async fn check_ignores_idle_and_busy_slots() {
-        let pool = Pool::builder(mock_claude()).slots(2).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .slots(2)
+            .build()
+            .await
+            .unwrap();
 
         // Mark slot-1 as busy.
         let mut slot = pool
@@ -201,7 +219,12 @@ mod tests {
 
     #[tokio::test]
     async fn start_supervisor_returns_none_when_disabled() {
-        let pool = Pool::builder(mock_claude()).slots(1).build().await.unwrap();
+        let pool = Pool::builder(mock_claude())
+            .config(test_config())
+            .slots(1)
+            .build()
+            .await
+            .unwrap();
         assert!(pool.start_supervisor().is_none());
     }
 
@@ -210,6 +233,7 @@ mod tests {
         let config = PoolConfig {
             supervisor_enabled: true,
             supervisor_interval_secs: 1,
+            worktree_isolation: false,
             ..Default::default()
         };
         let pool = Pool::builder(mock_claude())

--- a/crates/claude-pool/src/types.rs
+++ b/crates/claude-pool/src/types.rs
@@ -98,7 +98,11 @@ pub struct PoolConfig {
     /// Maximum number of restarts per slot before marking as errored.
     pub max_restarts: u32,
 
-    /// Enable git worktree isolation for slots.
+    /// Enable git worktree isolation for slots (default: true).
+    ///
+    /// Each slot gets its own git worktree under `.claude/pool-worktrees/`,
+    /// enabling parallel file writes without conflicts. Required for workers
+    /// to edit files when Claude uses `auto` permission mode.
     pub worktree_isolation: bool,
 
     /// Maximum time to wait for an idle slot before failing a task (in seconds).
@@ -154,7 +158,7 @@ impl Default for PoolConfig {
             budget_microdollars: None,
             slot_mode: SlotMode::default(),
             max_restarts: 3,
-            worktree_isolation: false,
+            worktree_isolation: true,
             slot_assignment_timeout_secs: 300,
             scaling: ScalingConfig::default(),
             unattended_mode: false,


### PR DESCRIPTION
## Summary

Default `worktree_isolation` to `true` so every pool slot gets its own git worktree. This fixes the core issue blocking pool workers from writing files.

**Root cause**: Claude's `auto` permission mode only auto-approves writes within the recognized project. Non-interactive worker subprocesses can't get interactive approval, so writes silently fail.

**Fix**: Each slot gets a worktree under `.claude/pool-worktrees/` (already inside the project from #298). Workers execute in their worktree, writes succeed.

**Also fixed**: Skip session resumption for worktree-isolated slots. Sessions belong to the repo root directory and don't exist in the worktree, causing "No conversation found" errors.

### Changes
- `PoolConfig::default()`: `worktree_isolation: true`
- Build fallback: warn instead of hard-fail when not in a git repo
- Executor: skip session resume when slot has a worktree
- MCP CLI: add `--no-worktree` flag to opt out
- Tests: all mock pool builders use `worktree_isolation: false`

Fixes #315

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (142/143 pass; 1 flaky pre-existing scaling test)
- [x] `cargo test --lib -p claude-wrapper` (93 pass)