### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.5.0...v0.5.1) - 2026-04-10
+
+### Other
+
+- deprecation banners on unmaintained crates; audit wrapper README ([#531](https://github.com/joshrotenberg/claude-wrapper/pull/531))
+- exclude deprecated crates from workspace ([#530](https://github.com/joshrotenberg/claude-wrapper/pull/530))
+
 ## [0.5.0] - 2026-04-10
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.5.0...v0.5.1) - 2026-04-10

### Other

- deprecation banners on unmaintained crates; audit wrapper README ([#531](https://github.com/joshrotenberg/claude-wrapper/pull/531))
- exclude deprecated crates from workspace ([#530](https://github.com/joshrotenberg/claude-wrapper/pull/530))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).