### PR TITLE
feat(claudes): add RunOptionsBuilder and PlanOptionsBuilder

### DIFF
--- a/crates/claudes/src/planner.rs
+++ b/crates/claudes/src/planner.rs
@@ -56,6 +56,169 @@ impl PlanOptions {
     }
 }
 
+/// Builder for [`PlanOptions`].
+///
+/// `prompt()` is the repeatable entry point — call it once per task.
+/// All other setters apply to every generated task as overrides.
+///
+/// # Example
+///
+/// ```
+/// use claudes::planner::PlanOptionsBuilder;
+///
+/// let opts = PlanOptionsBuilder::new()
+///     .prompt("Fix the pagination bug")
+///     .prompt("Add export endpoint")
+///     .model("claude-opus-4-5")
+///     .max_turns(20)
+///     .build();
+/// assert_eq!(opts.prompts.len(), 2);
+/// ```
+#[derive(Debug, Default)]
+pub struct PlanOptionsBuilder {
+    prompts: Vec<String>,
+    model: Option<String>,
+    fallback_model: Option<String>,
+    max_turns: Option<u32>,
+    timeout_secs: Option<u64>,
+    max_budget_usd: Option<f64>,
+    effort: Option<String>,
+    permission_mode: Option<String>,
+    allowed_tools: Option<Vec<String>>,
+    disallowed_tools: Option<Vec<String>>,
+    append_system_prompt: Option<String>,
+    mcp_config: Option<String>,
+    strict_mcp_config: Option<bool>,
+    no_session_persistence: Option<bool>,
+    isolation: Option<String>,
+    isolation_base_dir: Option<String>,
+}
+
+impl PlanOptionsBuilder {
+    /// Create a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a prompt (one task per call).
+    pub fn prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.prompts.push(prompt.into());
+        self
+    }
+
+    /// Model override.
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Fallback model override.
+    pub fn fallback_model(mut self, fallback_model: impl Into<String>) -> Self {
+        self.fallback_model = Some(fallback_model.into());
+        self
+    }
+
+    /// Max turns override.
+    pub fn max_turns(mut self, max_turns: u32) -> Self {
+        self.max_turns = Some(max_turns);
+        self
+    }
+
+    /// Timeout override (in seconds).
+    pub fn timeout_secs(mut self, timeout_secs: u64) -> Self {
+        self.timeout_secs = Some(timeout_secs);
+        self
+    }
+
+    /// Budget override.
+    pub fn max_budget_usd(mut self, max_budget_usd: f64) -> Self {
+        self.max_budget_usd = Some(max_budget_usd);
+        self
+    }
+
+    /// Effort override (`"low"`, `"medium"`, or `"high"`).
+    pub fn effort(mut self, effort: impl Into<String>) -> Self {
+        self.effort = Some(effort.into());
+        self
+    }
+
+    /// Permission mode override.
+    pub fn permission_mode(mut self, permission_mode: impl Into<String>) -> Self {
+        self.permission_mode = Some(permission_mode.into());
+        self
+    }
+
+    /// Allowed tools override.
+    pub fn allowed_tools(mut self, allowed_tools: Vec<String>) -> Self {
+        self.allowed_tools = Some(allowed_tools);
+        self
+    }
+
+    /// Disallowed tools override.
+    pub fn disallowed_tools(mut self, disallowed_tools: Vec<String>) -> Self {
+        self.disallowed_tools = Some(disallowed_tools);
+        self
+    }
+
+    /// Append system prompt override.
+    pub fn append_system_prompt(mut self, append_system_prompt: impl Into<String>) -> Self {
+        self.append_system_prompt = Some(append_system_prompt.into());
+        self
+    }
+
+    /// MCP config override.
+    pub fn mcp_config(mut self, mcp_config: impl Into<String>) -> Self {
+        self.mcp_config = Some(mcp_config.into());
+        self
+    }
+
+    /// Strict MCP config override.
+    pub fn strict_mcp_config(mut self, strict_mcp_config: bool) -> Self {
+        self.strict_mcp_config = Some(strict_mcp_config);
+        self
+    }
+
+    /// No session persistence override.
+    pub fn no_session_persistence(mut self, no_session_persistence: bool) -> Self {
+        self.no_session_persistence = Some(no_session_persistence);
+        self
+    }
+
+    /// Isolation type override (`"worktree"`, `"clone"`, or `"none"`).
+    pub fn isolation(mut self, isolation: impl Into<String>) -> Self {
+        self.isolation = Some(isolation.into());
+        self
+    }
+
+    /// Isolation base directory override.
+    pub fn isolation_base_dir(mut self, isolation_base_dir: impl Into<String>) -> Self {
+        self.isolation_base_dir = Some(isolation_base_dir.into());
+        self
+    }
+
+    /// Build the [`PlanOptions`].
+    pub fn build(self) -> PlanOptions {
+        PlanOptions {
+            prompts: self.prompts,
+            model: self.model,
+            fallback_model: self.fallback_model,
+            max_turns: self.max_turns,
+            timeout_secs: self.timeout_secs,
+            max_budget_usd: self.max_budget_usd,
+            effort: self.effort,
+            permission_mode: self.permission_mode,
+            allowed_tools: self.allowed_tools,
+            disallowed_tools: self.disallowed_tools,
+            append_system_prompt: self.append_system_prompt,
+            mcp_config: self.mcp_config,
+            strict_mcp_config: self.strict_mcp_config,
+            no_session_persistence: self.no_session_persistence,
+            isolation: self.isolation,
+            isolation_base_dir: self.isolation_base_dir,
+        }
+    }
+}
+
 /// Generate a manifest from plan options.
 pub fn plan(options: &PlanOptions) -> Manifest {
     let tasks: Vec<Task> = options
@@ -229,5 +392,102 @@ mod tests {
         };
         let manifest = plan(&opts);
         assert!(matches!(manifest.tasks[0].isolation, Some(Isolation::None)));
+    }
+
+    #[test]
+    fn builder_single_prompt() {
+        let opts = PlanOptionsBuilder::new().prompt("Fix the bug").build();
+        assert_eq!(opts.prompts, vec!["Fix the bug"]);
+    }
+
+    #[test]
+    fn builder_multiple_prompts() {
+        let opts = PlanOptionsBuilder::new()
+            .prompt("Fix A")
+            .prompt("Fix B")
+            .prompt("Fix C")
+            .build();
+        assert_eq!(opts.prompts.len(), 3);
+        assert_eq!(opts.prompts[1], "Fix B");
+    }
+
+    #[test]
+    fn builder_defaults_are_none() {
+        let opts = PlanOptionsBuilder::new().prompt("task").build();
+        assert!(opts.model.is_none());
+        assert!(opts.fallback_model.is_none());
+        assert!(opts.max_turns.is_none());
+        assert!(opts.timeout_secs.is_none());
+        assert!(opts.max_budget_usd.is_none());
+        assert!(opts.effort.is_none());
+        assert!(opts.permission_mode.is_none());
+        assert!(opts.allowed_tools.is_none());
+        assert!(opts.disallowed_tools.is_none());
+        assert!(opts.append_system_prompt.is_none());
+        assert!(opts.mcp_config.is_none());
+        assert!(opts.strict_mcp_config.is_none());
+        assert!(opts.no_session_persistence.is_none());
+        assert!(opts.isolation.is_none());
+        assert!(opts.isolation_base_dir.is_none());
+    }
+
+    #[test]
+    fn builder_overrides() {
+        let opts = PlanOptionsBuilder::new()
+            .prompt("task")
+            .model("opus")
+            .fallback_model("sonnet")
+            .max_turns(10)
+            .timeout_secs(120)
+            .max_budget_usd(5.0)
+            .effort("high")
+            .permission_mode("bypassPermissions")
+            .allowed_tools(vec!["Edit".into()])
+            .disallowed_tools(vec!["Bash".into()])
+            .append_system_prompt("Be concise.")
+            .mcp_config("/path/to/mcp.json")
+            .strict_mcp_config(true)
+            .no_session_persistence(true)
+            .isolation("clone")
+            .isolation_base_dir(".clones")
+            .build();
+
+        assert_eq!(opts.model.as_deref(), Some("opus"));
+        assert_eq!(opts.fallback_model.as_deref(), Some("sonnet"));
+        assert_eq!(opts.max_turns, Some(10));
+        assert_eq!(opts.timeout_secs, Some(120));
+        assert_eq!(opts.max_budget_usd, Some(5.0));
+        assert_eq!(opts.effort.as_deref(), Some("high"));
+        assert_eq!(opts.permission_mode.as_deref(), Some("bypassPermissions"));
+        assert_eq!(
+            opts.allowed_tools.as_deref(),
+            Some(&["Edit".to_string()][..])
+        );
+        assert_eq!(
+            opts.disallowed_tools.as_deref(),
+            Some(&["Bash".to_string()][..])
+        );
+        assert_eq!(opts.append_system_prompt.as_deref(), Some("Be concise."));
+        assert_eq!(opts.mcp_config.as_deref(), Some("/path/to/mcp.json"));
+        assert_eq!(opts.strict_mcp_config, Some(true));
+        assert_eq!(opts.no_session_persistence, Some(true));
+        assert_eq!(opts.isolation.as_deref(), Some("clone"));
+        assert_eq!(opts.isolation_base_dir.as_deref(), Some(".clones"));
+    }
+
+    #[test]
+    fn builder_produces_valid_manifest() {
+        let opts = PlanOptionsBuilder::new()
+            .prompt("Fix the pagination bug")
+            .prompt("Add export endpoint")
+            .model("opus")
+            .max_turns(20)
+            .build();
+        let manifest = plan(&opts);
+        assert_eq!(manifest.tasks.len(), 2);
+        assert_eq!(manifest.tasks[0].prompt, "Fix the pagination bug");
+        assert_eq!(manifest.tasks[1].prompt, "Add export endpoint");
+        assert_eq!(manifest.tasks[0].model.as_deref(), Some("opus"));
+        assert_eq!(manifest.tasks[0].max_turns, Some(20));
     }
 }

--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -78,6 +78,78 @@ pub struct RunOptions {
     pub cleanup: CleanupPolicy,
 }
 
+/// Builder for [`RunOptions`].
+///
+/// `project_dir` is required and passed to [`RunOptionsBuilder::new`].
+/// All other fields are optional with sensible defaults.
+///
+/// # Example
+///
+/// ```no_run
+/// use claudes::runner::{CleanupPolicy, RunOptionsBuilder};
+///
+/// let options = RunOptionsBuilder::new("/path/to/project")
+///     .force(true)
+///     .cleanup(CleanupPolicy::OnSuccess)
+///     .build();
+/// ```
+#[derive(Debug)]
+pub struct RunOptionsBuilder {
+    project_dir: PathBuf,
+    force: bool,
+    binary: Option<PathBuf>,
+    env: Vec<(String, String)>,
+    cleanup: CleanupPolicy,
+}
+
+impl RunOptionsBuilder {
+    /// Create a new builder with the required project directory.
+    pub fn new(project_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            project_dir: project_dir.into(),
+            force: false,
+            binary: None,
+            env: Vec::new(),
+            cleanup: CleanupPolicy::None,
+        }
+    }
+
+    /// Force overwrite existing worktrees.
+    pub fn force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
+    }
+
+    /// Override the claude binary path.
+    pub fn binary(mut self, binary: impl Into<PathBuf>) -> Self {
+        self.binary = Some(binary.into());
+        self
+    }
+
+    /// Add an extra environment variable passed to every Claude process.
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.push((key.into(), value.into()));
+        self
+    }
+
+    /// Set the cleanup policy for worktrees after execution.
+    pub fn cleanup(mut self, cleanup: CleanupPolicy) -> Self {
+        self.cleanup = cleanup;
+        self
+    }
+
+    /// Build the [`RunOptions`].
+    pub fn build(self) -> RunOptions {
+        RunOptions {
+            project_dir: self.project_dir,
+            force: self.force,
+            binary: self.binary,
+            env: self.env,
+            cleanup: self.cleanup,
+        }
+    }
+}
+
 /// Execute a manifest.
 pub async fn run(manifest: &Manifest, options: &RunOptions) -> Result<RunResult> {
     // Validate first.
@@ -305,5 +377,65 @@ fn parse_effort(s: &str) -> claude_wrapper::Effort {
         "low" => claude_wrapper::Effort::Low,
         "high" => claude_wrapper::Effort::High,
         _ => claude_wrapper::Effort::Medium,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_defaults() {
+        let opts = RunOptionsBuilder::new("/tmp/project").build();
+        assert_eq!(opts.project_dir, PathBuf::from("/tmp/project"));
+        assert!(!opts.force);
+        assert!(opts.binary.is_none());
+        assert!(opts.env.is_empty());
+        assert_eq!(opts.cleanup, CleanupPolicy::None);
+    }
+
+    #[test]
+    fn builder_force() {
+        let opts = RunOptionsBuilder::new("/tmp/project").force(true).build();
+        assert!(opts.force);
+    }
+
+    #[test]
+    fn builder_binary() {
+        let opts = RunOptionsBuilder::new("/tmp/project")
+            .binary("/usr/local/bin/claude")
+            .build();
+        assert_eq!(opts.binary, Some(PathBuf::from("/usr/local/bin/claude")));
+    }
+
+    #[test]
+    fn builder_env_repeatable() {
+        let opts = RunOptionsBuilder::new("/tmp/project")
+            .env("FOO", "bar")
+            .env("BAZ", "qux")
+            .build();
+        assert_eq!(
+            opts.env,
+            vec![
+                ("FOO".to_string(), "bar".to_string()),
+                ("BAZ".to_string(), "qux".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn builder_cleanup() {
+        let opts = RunOptionsBuilder::new("/tmp/project")
+            .cleanup(CleanupPolicy::Always)
+            .build();
+        assert_eq!(opts.cleanup, CleanupPolicy::Always);
+    }
+
+    #[test]
+    fn builder_on_success_cleanup() {
+        let opts = RunOptionsBuilder::new("/tmp/project")
+            .cleanup(CleanupPolicy::OnSuccess)
+            .build();
+        assert_eq!(opts.cleanup, CleanupPolicy::OnSuccess);
     }
 }


### PR DESCRIPTION
## Summary

- Add `RunOptionsBuilder` in `runner.rs` with defaults (force=false, cleanup=None)
- Add `PlanOptionsBuilder` in `planner.rs` with repeatable `.prompt()` entry point
- Both follow consuming builder pattern
- 11 new unit tests

**Note:** This was generated by a `claudes run` dogfood session. Will need rebase after #330 and task-builder PR merge.

Closes #328 (remaining)

## Test plan

- [x] 39 unit tests pass
- [x] clippy clean