### PR TITLE
feat(claudes): add output verbosity levels

### DIFF
--- a/crates/claudes/src/cli.rs
+++ b/crates/claudes/src/cli.rs
@@ -104,6 +104,10 @@ pub struct RunArgs {
     /// Auto-cleanup worktrees after run (none|on-success|always; default: none).
     #[arg(long, default_value = "none")]
     pub cleanup: String,
+
+    /// Increase output verbosity (repeat for more detail: -v, -vv).
+    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count)]
+    pub verbose: u8,
 }
 
 /// Arguments for `claudes status`.

--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
 use claudes::cli::{Cli, Command, parse_timeout};
-use claudes::output::{self, OutputFormat};
+use claudes::output::{self, OutputFormat, Verbosity};
 use claudes::planner::PlanOptions;
 
 #[tokio::main]
@@ -113,6 +113,7 @@ async fn execute_manifest(
         _ => OutputFormat::Text,
     };
 
+    let verbosity = Verbosity::from(args.verbose);
     let started_at = chrono::Utc::now();
 
     // Set up streaming if we're in text mode.
@@ -120,7 +121,7 @@ async fn execute_manifest(
     let stream_handle = if format == OutputFormat::Text {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         options.event_sender = Some(tx);
-        Some(tokio::spawn(output::render_stream(rx)))
+        Some(tokio::spawn(output::render_stream(rx, verbosity)))
     } else {
         None
     };

--- a/crates/claudes/src/output.rs
+++ b/crates/claudes/src/output.rs
@@ -6,6 +6,33 @@ use tokio::sync::mpsc;
 
 use crate::runner::{RunResult, TaskEvent, TaskResult};
 
+/// Verbosity level for streaming output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum Verbosity {
+    /// No streaming output.
+    Quiet,
+    /// Show task start and task complete with cost (default).
+    #[default]
+    Default,
+    /// Show tool calls with their first argument.
+    Verbose,
+    /// Show full event stream including assistant text.
+    VeryVerbose,
+    /// Show full event stream (same as VeryVerbose).
+    Debug,
+}
+
+impl From<u8> for Verbosity {
+    fn from(count: u8) -> Self {
+        match count {
+            0 => Verbosity::Default,
+            1 => Verbosity::Verbose,
+            2 => Verbosity::VeryVerbose,
+            _ => Verbosity::Debug,
+        }
+    }
+}
+
 /// Format style for output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputFormat {
@@ -96,17 +123,24 @@ fn print_json_summary(result: &RunResult) {
 /// Render streaming events from tasks as they arrive.
 ///
 /// Runs until the channel is closed (all senders dropped).
-pub async fn render_stream(mut rx: mpsc::UnboundedReceiver<TaskEvent>) {
+pub async fn render_stream(mut rx: mpsc::UnboundedReceiver<TaskEvent>, verbosity: Verbosity) {
+    if verbosity == Verbosity::Quiet {
+        while rx.recv().await.is_some() {}
+        return;
+    }
+
     let stderr = std::io::stderr();
 
     while let Some(event) = rx.recv().await {
         let task = &event.task_name;
         let data = &event.event.data;
-
-        // Filter to interesting events: tool use, result, errors.
         let event_type = event.event.event_type().unwrap_or("");
 
         match event_type {
+            "claudes_task_start" => {
+                let mut out = stderr.lock();
+                let _ = writeln!(out, "  | {task:<20} | starting");
+            }
             "result" => {
                 let status = data
                     .get("subtype")
@@ -117,25 +151,56 @@ pub async fn render_stream(mut rx: mpsc::UnboundedReceiver<TaskEvent>) {
                     .or_else(|| data.get("cost_usd"))
                     .and_then(|c| c.as_f64());
                 let cost_str = cost.map(|c| format!(" ${c:.4}")).unwrap_or_default();
-
                 let mut out = stderr.lock();
                 let _ = writeln!(out, "  | {task:<20} | {status}{cost_str}");
             }
-            "assistant" => {
-                // Extract tool use from assistant messages.
+            "assistant" if verbosity >= Verbosity::Verbose => {
                 if let Some(content) = data
                     .get("message")
                     .and_then(|m| m.get("content"))
                     .and_then(|c| c.as_array())
                 {
                     for block in content {
-                        if block.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
-                            let tool = block
-                                .get("name")
-                                .and_then(|n| n.as_str())
-                                .unwrap_or("unknown");
-                            let mut out = stderr.lock();
-                            let _ = writeln!(out, "  | {task:<20} | {tool}");
+                        let block_type = block.get("type").and_then(|t| t.as_str());
+                        match block_type {
+                            Some("tool_use") => {
+                                let tool = block
+                                    .get("name")
+                                    .and_then(|n| n.as_str())
+                                    .unwrap_or("unknown");
+                                let first_arg = block
+                                    .get("input")
+                                    .and_then(|i| i.as_object())
+                                    .and_then(|obj| obj.values().next())
+                                    .map(|v| {
+                                        let s = if let Some(s) = v.as_str() {
+                                            s.to_string()
+                                        } else {
+                                            v.to_string()
+                                        };
+                                        let mut chars = s.chars();
+                                        let truncated: String = chars.by_ref().take(40).collect();
+                                        if chars.next().is_some() {
+                                            format!("{truncated}...")
+                                        } else {
+                                            truncated
+                                        }
+                                    })
+                                    .unwrap_or_default();
+                                let mut out = stderr.lock();
+                                if first_arg.is_empty() {
+                                    let _ = writeln!(out, "  | {task:<20} | {tool}");
+                                } else {
+                                    let _ = writeln!(out, "  | {task:<20} | {tool}({first_arg})");
+                                }
+                            }
+                            Some("text") if verbosity >= Verbosity::VeryVerbose => {
+                                if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                                    let mut out = stderr.lock();
+                                    let _ = writeln!(out, "  | {task:<20} | {text}");
+                                }
+                            }
+                            _ => {}
                         }
                     }
                 }

--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -330,6 +330,18 @@ async fn run_task_inner(
     let output = if let Some(sender) = &options.event_sender {
         let task_name = task.name.clone();
         let sender = sender.clone();
+
+        // Signal that the task has started.
+        let _ = sender.send(TaskEvent {
+            task_name: task_name.clone(),
+            event: StreamEvent {
+                data: serde_json::json!({
+                    "type": "claudes_task_start",
+                    "task_name": task_name,
+                }),
+            },
+        });
+
         let mut result_json = String::new();
 
         let output = claude_wrapper::streaming::stream_query(&claude, &cmd, |event| {


### PR DESCRIPTION
## Summary

Adds `-v`/`--verbose` flag (stackable) for controlling streaming output detail level.

- Default: task start/complete with cost
- `-v`: tool calls with arguments
- `-vv`: full event stream including assistant text

## Changes

- `Verbosity` enum in output.rs with `From<u8>` for clap count
- Task-start events emitted from runner before `stream_query`
- `render_stream` filters events based on verbosity level
- CLI wiring in cli.rs and main.rs

## Notes

Task ran out of turns (35) before it could push/PR — rebased and pushed manually. The code is complete and all checks pass.

Closes #323

## Test plan

- [x] 68 unit tests pass
- [x] clippy clean, fmt clean
- [ ] Manual: `claudes run` shows start/complete only
- [ ] Manual: `claudes run -v` shows tool calls
- [ ] Manual: `claudes run -vv` shows everything