### PR TITLE
feat(claudes): auto-discover project manifest files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1143,6 +1144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1351,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1719,6 +1770,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ claude-wrapper = { path = "crates/claude-wrapper", version = "0.4" }
 claude-pool = { path = "crates/claude-pool", version = "0.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/crates/claudes/Cargo.toml
+++ b/crates/claudes/Cargo.toml
@@ -12,13 +12,13 @@ description = "Manifest-driven execution engine for headless Claude Code session
 claude-wrapper = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
-toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -62,10 +62,58 @@ async fn cmd_run(args: claudes::cli::RunArgs) -> ExitCode {
         return execute_manifest(&manifest, &options, &args).await;
     }
 
-    // Otherwise, generate a manifest from CLI args.
+    // Otherwise, generate a manifest from CLI args or auto-discover one.
     let prompts = collect_prompts(&args.prompt, args.stdin).await;
     if prompts.is_empty() {
-        eprintln!("error: no prompts provided (use -p or --stdin)");
+        // No -p prompts — try auto-discovering a project manifest.
+        if let Some(manifest_path) = claudes::manifest::Manifest::discover(&project_dir) {
+            let content = match std::fs::read_to_string(&manifest_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("error: cannot read manifest: {e}");
+                    return ExitCode::FAILURE;
+                }
+            };
+            let manifest: claudes::Manifest =
+                if manifest_path.extension().and_then(|e| e.to_str()) == Some("toml") {
+                    match toml::from_str(&content) {
+                        Ok(m) => m,
+                        Err(e) => {
+                            eprintln!("error: invalid manifest TOML: {e}");
+                            return ExitCode::FAILURE;
+                        }
+                    }
+                } else {
+                    match serde_json::from_str(&content) {
+                        Ok(m) => m,
+                        Err(e) => {
+                            eprintln!("error: invalid manifest JSON: {e}");
+                            return ExitCode::FAILURE;
+                        }
+                    }
+                };
+
+            let options = claudes::RunOptions {
+                project_dir,
+                force: args.force,
+                binary: None,
+                env: vec![],
+                cleanup: parse_cleanup(&args.cleanup),
+                event_sender: None,
+            };
+
+            if args.dry_run {
+                println!("{}", serde_json::to_string_pretty(&manifest).unwrap());
+                return ExitCode::SUCCESS;
+            }
+
+            return execute_manifest(&manifest, &options, &args).await;
+        }
+
+        eprintln!(
+            "error: no prompts provided and no manifest file found \
+             (use -p, --manifest, or create claudes.toml)"
+        );
         return ExitCode::FAILURE;
     }
 

--- a/crates/claudes/src/manifest.rs
+++ b/crates/claudes/src/manifest.rs
@@ -5,7 +5,7 @@
 //! What you see is what executes.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -137,6 +137,25 @@ impl Manifest {
                 path.display()
             ))),
         }
+    }
+
+    /// Search for a manifest file in `dir`, returning the path to the first one found.
+    ///
+    /// Searched in order: `claudes.toml`, `.claudes.toml`, `claudes.json`, `.claudes.json`.
+    pub fn discover(dir: &Path) -> Option<PathBuf> {
+        const CANDIDATES: &[&str] = &[
+            "claudes.toml",
+            ".claudes.toml",
+            "claudes.json",
+            ".claudes.json",
+        ];
+        for name in CANDIDATES {
+            let path = dir.join(name);
+            if path.exists() {
+                return Some(path);
+            }
+        }
+        None
     }
 
     /// Validate the manifest, returning errors for any problems.
@@ -1101,6 +1120,35 @@ prompt = "do it"
         let manifest = Manifest::new(vec![Task::new("t", "p")]);
         let json = serde_json::to_value(&manifest).unwrap();
         assert!(!json.as_object().unwrap().contains_key("shared"));
+    }
+
+    #[test]
+    fn discover_finds_files_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+
+        // Nothing present — returns None.
+        assert!(Manifest::discover(base).is_none());
+
+        // .claudes.json present — found.
+        let json_hidden = base.join(".claudes.json");
+        std::fs::write(&json_hidden, "{}").unwrap();
+        assert_eq!(Manifest::discover(base).unwrap(), json_hidden);
+
+        // claudes.json present — takes priority over .claudes.json.
+        let json = base.join("claudes.json");
+        std::fs::write(&json, "{}").unwrap();
+        assert_eq!(Manifest::discover(base).unwrap(), json);
+
+        // .claudes.toml present — takes priority over claudes.json.
+        let toml_hidden = base.join(".claudes.toml");
+        std::fs::write(&toml_hidden, "").unwrap();
+        assert_eq!(Manifest::discover(base).unwrap(), toml_hidden);
+
+        // claudes.toml present — highest priority.
+        let toml = base.join("claudes.toml");
+        std::fs::write(&toml, "").unwrap();
+        assert_eq!(Manifest::discover(base).unwrap(), toml);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When running without --manifest or -p, claudes now searches for a project manifest file (claudes.toml, .claudes.toml, claudes.json, .claudes.json).

## Test plan
- Unit test for discovery order
- Existing CLI behavior preserved when using -p or --manifest

Partial fix for #320