### PR TITLE
feat(claudes): per-task colored output prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -311,6 +311,7 @@ dependencies = [
  "chrono",
  "clap",
  "claude-wrapper",
+ "crossterm",
  "serde",
  "serde_json",
  "tempfile",
@@ -347,6 +348,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -407,7 +433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -752,6 +778,12 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -805,8 +837,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -815,7 +848,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1018,6 +1051,19 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1025,8 +1071,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1191,6 +1237,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,7 +1286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1254,8 +1321,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1301,7 +1368,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1705,6 +1772,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,12 +1854,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/crates/claudes/Cargo.toml
+++ b/crates/claudes/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
+crossterm = "0.28"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/claudes/src/cli.rs
+++ b/crates/claudes/src/cli.rs
@@ -108,6 +108,10 @@ pub struct RunArgs {
     /// Increase output verbosity (repeat for more detail: -v, -vv).
     #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count)]
     pub verbose: u8,
+
+    /// Disable colored output.
+    #[arg(long)]
+    pub no_color: bool,
 }
 
 /// Arguments for `claudes status`.

--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -169,7 +169,11 @@ async fn execute_manifest(
     let stream_handle = if format == OutputFormat::Text {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         options.event_sender = Some(tx);
-        Some(tokio::spawn(output::render_stream(rx, verbosity)))
+        Some(tokio::spawn(output::render_stream(
+            rx,
+            verbosity,
+            args.no_color,
+        )))
     } else {
         None
     };

--- a/crates/claudes/src/output.rs
+++ b/crates/claudes/src/output.rs
@@ -1,11 +1,22 @@
 //! Output formatting for task execution results.
 
-use std::io::Write;
+use std::collections::HashMap;
+use std::io::{IsTerminal, Write};
 
+use crossterm::style::{Color, Stylize};
 use tokio::sync::mpsc;
 
 use crate::runner::{RunResult, TaskEvent, TaskResult};
 use crate::state::is_timeout;
+
+const COLOR_PALETTE: &[Color] = &[
+    Color::Cyan,
+    Color::Green,
+    Color::Yellow,
+    Color::Magenta,
+    Color::Blue,
+    Color::Red,
+];
 
 /// Verbosity level for streaming output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -130,23 +141,50 @@ fn print_json_summary(result: &RunResult) {
 /// Render streaming events from tasks as they arrive.
 ///
 /// Runs until the channel is closed (all senders dropped).
-pub async fn render_stream(mut rx: mpsc::UnboundedReceiver<TaskEvent>, verbosity: Verbosity) {
+pub async fn render_stream(
+    mut rx: mpsc::UnboundedReceiver<TaskEvent>,
+    verbosity: Verbosity,
+    no_color: bool,
+) {
     if verbosity == Verbosity::Quiet {
         while rx.recv().await.is_some() {}
         return;
     }
 
     let stderr = std::io::stderr();
+    let use_color = !no_color && std::env::var_os("NO_COLOR").is_none() && stderr.is_terminal();
+
+    let mut color_map: HashMap<String, Color> = HashMap::new();
+    let mut color_index: usize = 0;
 
     while let Some(event) = rx.recv().await {
         let task = &event.task_name;
         let data = &event.event.data;
         let event_type = event.event.event_type().unwrap_or("");
 
+        let color_opt = if use_color {
+            if !color_map.contains_key(task.as_str()) {
+                let c = COLOR_PALETTE[color_index % COLOR_PALETTE.len()];
+                color_map.insert(task.clone(), c);
+                color_index += 1;
+            }
+            color_map.get(task.as_str()).copied()
+        } else {
+            None
+        };
+
+        let prefix = {
+            let padded = format!("{task:<20}");
+            match color_opt {
+                Some(color) => format!("{}", padded.with(color)),
+                None => padded,
+            }
+        };
+
         match event_type {
             "claudes_task_start" => {
                 let mut out = stderr.lock();
-                let _ = writeln!(out, "  | {task:<20} | starting");
+                let _ = writeln!(out, "  | {prefix} | starting");
             }
             "result" => {
                 let status = data
@@ -159,7 +197,7 @@ pub async fn render_stream(mut rx: mpsc::UnboundedReceiver<TaskEvent>, verbosity
                     .and_then(|c| c.as_f64());
                 let cost_str = cost.map(|c| format!(" ${c:.4}")).unwrap_or_default();
                 let mut out = stderr.lock();
-                let _ = writeln!(out, "  | {task:<20} | {status}{cost_str}");
+                let _ = writeln!(out, "  | {prefix} | {status}{cost_str}");
             }
             "assistant" if verbosity >= Verbosity::Verbose => {
                 if let Some(content) = data
@@ -196,15 +234,15 @@ pub async fn render_stream(mut rx: mpsc::UnboundedReceiver<TaskEvent>, verbosity
                                     .unwrap_or_default();
                                 let mut out = stderr.lock();
                                 if first_arg.is_empty() {
-                                    let _ = writeln!(out, "  | {task:<20} | {tool}");
+                                    let _ = writeln!(out, "  | {prefix} | {tool}");
                                 } else {
-                                    let _ = writeln!(out, "  | {task:<20} | {tool}({first_arg})");
+                                    let _ = writeln!(out, "  | {prefix} | {tool}({first_arg})");
                                 }
                             }
                             Some("text") if verbosity >= Verbosity::VeryVerbose => {
                                 if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
                                     let mut out = stderr.lock();
-                                    let _ = writeln!(out, "  | {task:<20} | {text}");
+                                    let _ = writeln!(out, "  | {prefix} | {text}");
                                 }
                             }
                             _ => {}


### PR DESCRIPTION
## Summary

Each task gets a distinct color for its prefix in streaming output, docker-compose style. Colors cycle through a 6-color palette. Respects NO_COLOR env var and --no-color flag. Only colorizes when stderr is a TTY.

## Test plan
- Visual: run with multiple tasks and verify distinct colors
- --no-color disables colors
- Non-TTY output has no color codes

Partial fix for #323