### PR TITLE
feat(claudes): add per-task NDJSON log persistence

### DIFF
--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -11,7 +11,7 @@ use claude_wrapper::streaming::StreamEvent;
 use claude_wrapper::{Claude, ClaudeCommand, OutputFormat, QueryCommand};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::error::{Error, Result};
 use crate::isolation::{self, IsolatedEnv};
@@ -337,6 +337,38 @@ async fn run_task_inner(
         let task_name = task.name.clone();
         let sender = sender.clone();
 
+        // Determine the log path based on isolation type.
+        let log_path = if matches!(env.kind, isolation::IsolationKind::None) {
+            env.work_dir
+                .join(".claudes")
+                .join("logs")
+                .join(format!("{}.jsonl", task.name))
+        } else {
+            env.work_dir.join(".claudes").join("run.jsonl")
+        };
+
+        // Create log directory and open the append-only log file.
+        let mut log_file: Option<std::fs::File> = None;
+        if let Some(log_dir) = log_path.parent() {
+            match tokio::fs::create_dir_all(log_dir).await {
+                Ok(()) => {
+                    match std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(&log_path)
+                    {
+                        Ok(f) => log_file = Some(f),
+                        Err(e) => {
+                            warn!(task = task.name, path = %log_path.display(), error = %e, "failed to open log file");
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(task = task.name, path = %log_path.display(), error = %e, "failed to create log dir");
+                }
+            }
+        }
+
         // Signal that the task has started.
         let _ = sender.send(TaskEvent {
             task_name: task_name.clone(),
@@ -351,6 +383,21 @@ async fn run_task_inner(
         let mut result_json = String::new();
 
         let output = claude_wrapper::streaming::stream_query(&claude, &cmd, |event| {
+            // Write the raw JSON event to the NDJSON log file.
+            if let Some(ref mut file) = log_file {
+                match serde_json::to_string(&event.data) {
+                    Ok(json) => {
+                        use std::io::Write;
+                        if let Err(e) = writeln!(file, "{json}") {
+                            warn!(task = task_name, error = %e, "failed to write event to log");
+                        }
+                    }
+                    Err(e) => {
+                        warn!(task = task_name, error = %e, "failed to serialize event for log");
+                    }
+                }
+            }
+
             // Capture the result event's JSON for the TaskResult stdout.
             if event.is_result() {
                 result_json = serde_json::to_string(&event.data).unwrap_or_default();

--- a/crates/claudes/src/state.rs
+++ b/crates/claudes/src/state.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::manifest::Manifest;
+use crate::manifest::{Isolation, Manifest};
 use crate::runner::RunResult;
 
 /// The default state directory, relative to the project root.
@@ -83,6 +83,10 @@ pub struct TaskState {
     /// Error message (if task failed).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+
+    /// Path to the NDJSON log file for this task.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_path: Option<String>,
 }
 
 /// Task completion status.
@@ -142,12 +146,25 @@ pub fn build_state(manifest: &Manifest, result: &RunResult, started_at: DateTime
             // Try to parse cost/session/result from the JSON output.
             let (cost_usd, session_id, result_text) = parse_task_output(&t.stdout);
 
-            // Find the matching manifest task for branch info.
-            let branch = manifest
-                .tasks
-                .iter()
-                .find(|mt| mt.name == t.name)
-                .and_then(|mt| mt.branch.clone());
+            // Find the matching manifest task for branch and isolation info.
+            let task_manifest = manifest.tasks.iter().find(|mt| mt.name == t.name);
+            let branch = task_manifest.and_then(|mt| mt.branch.clone());
+
+            // Compute the log path based on isolation type.
+            let no_isolation = task_manifest
+                .map(|mt| matches!(mt.isolation, Some(Isolation::None) | None))
+                .unwrap_or(false);
+            let log_path = if no_isolation {
+                PathBuf::from(&t.work_dir)
+                    .join(".claudes")
+                    .join("logs")
+                    .join(format!("{}.jsonl", t.name))
+            } else {
+                PathBuf::from(&t.work_dir)
+                    .join(".claudes")
+                    .join("run.jsonl")
+            };
+            let log_path = Some(log_path.to_string_lossy().to_string());
 
             let status = if t.success {
                 TaskStatus::Success
@@ -173,6 +190,7 @@ pub fn build_state(manifest: &Manifest, result: &RunResult, started_at: DateTime
                 session_id,
                 result_text,
                 error,
+                log_path,
             }
         })
         .collect();
@@ -386,6 +404,11 @@ pub fn print_status(state: &RunState) {
             for line in err.lines().take(3) {
                 println!("    {line}");
             }
+        }
+        if let Some(ref log_path) = task.log_path
+            && std::path::Path::new(log_path).exists()
+        {
+            println!("    log: {log_path}");
         }
     }
 }


### PR DESCRIPTION
## Summary

Each task's full NDJSON stream is now persisted to a log file for post-hoc analysis.

- Worktree tasks: .claudes/run.jsonl in the worktree
- Non-isolated tasks: .claudes/logs/<task-name>.jsonl
- Log path recorded in state file
- Non-fatal: log write failures are warned, not errors

## Test plan
- Verify log files created during fake-claude integration tests
- State file includes log_path

Partial fix for #324