### PR TITLE
feat(claudes): add finally_hooks (always-run hooks)

### DIFF
--- a/crates/claudes/src/manifest.rs
+++ b/crates/claudes/src/manifest.rs
@@ -222,6 +222,11 @@ impl Manifest {
                         profile.and_then(|p| p.post_hooks.as_ref()),
                         task.post_hooks.as_ref(),
                     ),
+                    finally_hooks: merge_hooks(
+                        shared.and_then(|s| s.finally_hooks.as_ref()),
+                        profile.and_then(|p| p.finally_hooks.as_ref()),
+                        task.finally_hooks.as_ref(),
+                    ),
                 }
             })
             .collect();
@@ -565,6 +570,10 @@ pub struct Shared {
     /// These are **prepended** to any task-level post_hooks.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_hooks: Option<Vec<String>>,
+
+    /// Shell commands that always run after task completion, regardless of outcome.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finally_hooks: Option<Vec<String>>,
 }
 
 /// A fully resolved task. Every field is explicit.
@@ -668,6 +677,10 @@ pub struct Task {
     /// Shell commands to run after the task completes successfully.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_hooks: Option<Vec<String>>,
+
+    /// Shell commands that always run after task completion, regardless of outcome.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finally_hooks: Option<Vec<String>>,
 }
 
 impl Task {
@@ -699,6 +712,7 @@ impl Task {
             env: None,
             pre_hooks: None,
             post_hooks: None,
+            finally_hooks: None,
         }
     }
 
@@ -921,6 +935,12 @@ impl TaskBuilder {
     /// Set shell commands to run after the task completes successfully.
     pub fn post_hooks(mut self, post_hooks: Vec<String>) -> Self {
         self.task.post_hooks = Some(post_hooks);
+        self
+    }
+
+    /// Set the finally hooks (always run, regardless of outcome).
+    pub fn finally_hooks(mut self, finally_hooks: Vec<String>) -> Self {
+        self.task.finally_hooks = Some(finally_hooks);
         self
     }
 

--- a/crates/claudes/src/planner.rs
+++ b/crates/claudes/src/planner.rs
@@ -281,6 +281,7 @@ pub fn plan(options: &PlanOptions) -> Manifest {
                 env: None,
                 pre_hooks: None,
                 post_hooks: None,
+                finally_hooks: None,
             }
         })
         .collect();

--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -449,13 +449,55 @@ async fn run_task_inner(
     let (output, env, stream_cost) = execution_result;
 
     // Run post-hooks if the session succeeded.
-    if output.success
+    let post_result = if output.success
         && let Some(hooks) = &task.post_hooks
     {
-        run_hooks(&task.name, hooks, &env.work_dir, "post").await?;
+        run_hooks(&task.name, hooks, &env.work_dir, "post").await
+    } else {
+        Ok(())
+    };
+
+    // Always run finally_hooks regardless of session/post_hook outcome.
+    if let Some(hooks) = &task.finally_hooks {
+        info!(task = task.name, "running finally hooks");
+        run_finally_hooks(&task.name, hooks, &env.work_dir).await;
     }
 
+    // Propagate post_hook errors after finally_hooks have run.
+    post_result?;
+
     Ok((output, env, stream_cost))
+}
+
+/// Run finally_hooks — always executes all hooks, logging failures without propagating.
+async fn run_finally_hooks(task_name: &str, hooks: &[String], work_dir: &std::path::Path) {
+    for hook in hooks {
+        info!(task = task_name, hook = hook, "running finally hook");
+        match tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(hook)
+            .current_dir(work_dir)
+            .output()
+            .await
+        {
+            Ok(output) if !output.status.success() => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                tracing::warn!(
+                    task = task_name,
+                    hook = hook,
+                    "finally hook failed (continuing): {stderr}"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    task = task_name,
+                    hook = hook,
+                    "finally hook failed to spawn (continuing): {e}"
+                );
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Execute hooks (pre or post) for a task in the given working directory.


### PR DESCRIPTION
## Summary

Adds finally_hooks that run regardless of task outcome — success, failure, or timeout. Useful for cleanup, artifact collection, or validation-even-on-failure.

- finally_hooks on Task and Shared
- Run after post_hooks (or after error)
- Failures logged but do not change task status
- Shared finally_hooks prepend to task-level

## Test plan
- Unit tests for finally_hooks execution
- Merge with shared tests
- Existing hook tests pass

Partial fix for #335