### PR TITLE
chore: deprecate claude-pool and claude-pool-mcp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@ Run format, lint, unit tests, and doc tests before every commit.
 - No emojis in code, commits, or documentation
 - Prefer editing existing files over creating new ones
 
+## Deprecation Notice
+
+`claude-pool` and `claude-pool-mcp` are deprecated. Use the `claudes` crate for parallel task execution.
+
 ## Architecture
 
 **claude-wrapper** uses a two-layer builder:

--- a/crates/claude-pool-mcp/Cargo.toml
+++ b/crates/claude-pool-mcp/Cargo.toml
@@ -6,7 +6,10 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Thin MCP server exposing claude-pool as tools"
+description = "Thin MCP server exposing claude-pool as tools (DEPRECATED: use claudes instead)"
+
+[badges]
+maintenance = { status = "deprecated" }
 
 [[bin]]
 name = "claude-pool-mcp"

--- a/crates/claude-pool-mcp/src/main.rs
+++ b/crates/claude-pool-mcp/src/main.rs
@@ -1,3 +1,4 @@
+#![deprecated(since = "0.5.0", note = "use the claudes crate instead")]
 //! claude-pool-mcp: thin MCP server exposing claude-pool as tools.
 //!
 //! Every tool maps 1:1 to a pool method. No business logic, no planning,

--- a/crates/claude-pool/Cargo.toml
+++ b/crates/claude-pool/Cargo.toml
@@ -6,11 +6,14 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Slot pool orchestration library for Claude CLI"
+description = "Slot pool orchestration library for Claude CLI (DEPRECATED: use claudes instead)"
 documentation = "https://docs.rs/claude-pool"
 readme = "README.md"
 keywords = ["claude", "mcp", "pool", "ai", "orchestration"]
 categories = ["development-tools", "asynchronous"]
+
+[badges]
+maintenance = { status = "deprecated" }
 
 [dependencies]
 claude-wrapper = { workspace = true }

--- a/crates/claude-pool/src/lib.rs
+++ b/crates/claude-pool/src/lib.rs
@@ -1,5 +1,7 @@
 //! Coordinator/worker orchestration for Claude Code.
 //!
+//! **Deprecated**: Use the `claudes` crate instead for parallel task execution.
+//!
 //! `claude-pool` manages N Claude CLI instances behind a pool. A **coordinator**
 //! (an interactive Claude session with the pool MCP server in its `.mcp.json`)
 //! dispatches work to **worker** slots, monitors results, reviews outputs, and


### PR DESCRIPTION
## Summary

Marks claude-pool and claude-pool-mcp as deprecated in favor of claudes.

- Cargo.toml badges and description updates
- Crate-level deprecation attributes
- Documentation update

Closes #359