### PR TITLE
feat(claudes): add per-task execution metrics to state

### DIFF
--- a/crates/claudes/src/cli.rs
+++ b/crates/claudes/src/cli.rs
@@ -28,6 +28,9 @@ pub enum Command {
 
     /// Remove worktrees and temporary state.
     Clean(CleanArgs),
+
+    /// Re-run failed or timed-out tasks from a previous run.
+    Fix(FixArgs),
 }
 
 /// Arguments for `claudes run`.
@@ -235,6 +238,26 @@ pub struct CleanArgs {
     /// Remove local claudes/* branches that have been merged into main.
     #[arg(long)]
     pub branches: bool,
+}
+
+/// Arguments for `claudes fix`.
+#[derive(Debug, Parser)]
+pub struct FixArgs {
+    /// Run ID to fix (default: latest run).
+    #[arg(long)]
+    pub run: Option<String>,
+
+    /// Re-run only these task(s) (repeatable; default: all failed/timed-out).
+    #[arg(long)]
+    pub task: Vec<String>,
+
+    /// Additional guidance to append to the fix prompt.
+    #[arg(short = 'p')]
+    pub prompt: Option<String>,
+
+    /// Force overwrite if worktree state is inconsistent.
+    #[arg(long)]
+    pub force: bool,
 }
 
 /// Parse a timeout string like "30m", "1h", "3600" into seconds.

--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -22,6 +22,7 @@ async fn main() -> ExitCode {
         Command::Init(args) => cmd_init(args).await,
         Command::Status(args) => cmd_status(args).await,
         Command::Clean(args) => cmd_clean(args).await,
+        Command::Fix(args) => cmd_fix(args).await,
     }
 }
 
@@ -383,6 +384,136 @@ async fn cmd_clean(args: claudes::cli::CleanArgs) -> ExitCode {
     }
 
     ExitCode::SUCCESS
+}
+
+async fn cmd_fix(args: claudes::cli::FixArgs) -> ExitCode {
+    let project_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+    let state = if let Some(ref run_id) = args.run {
+        claudes::state::load_run(&project_dir, run_id)
+    } else {
+        claudes::state::load(&project_dir)
+    };
+
+    let state = match state {
+        Some(s) => s,
+        None => {
+            eprintln!("error: no run state found (run `claudes run` first)");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let tasks_to_fix: Vec<&claudes::state::TaskState> = state
+        .results
+        .iter()
+        .filter(|t| {
+            if args.task.is_empty() {
+                matches!(
+                    t.status,
+                    claudes::state::TaskStatus::Failed | claudes::state::TaskStatus::Timeout
+                )
+            } else {
+                args.task.contains(&t.name)
+            }
+        })
+        .collect();
+
+    if tasks_to_fix.is_empty() {
+        eprintln!("no failed or timed-out tasks to fix");
+        return ExitCode::SUCCESS;
+    }
+
+    let mut all_succeeded = true;
+
+    for task_state in tasks_to_fix {
+        eprintln!("fixing task: {}", task_state.name);
+
+        let original_task = state
+            .manifest
+            .tasks
+            .iter()
+            .find(|t| t.name == task_state.name);
+
+        let original_prompt = original_task
+            .map(|t| t.prompt.as_str())
+            .unwrap_or("[unknown]");
+
+        let error_context = task_state
+            .error
+            .as_deref()
+            .unwrap_or("task timed out or failed with no error output");
+
+        let mut fix_prompt = format!(
+            "The previous task failed. Original prompt: {original_prompt}. \
+             Error: {error_context}. Fix the issue."
+        );
+        if let Some(ref guidance) = args.prompt {
+            fix_prompt.push_str(&format!(" {guidance}"));
+        }
+
+        let mut fix_task = original_task
+            .cloned()
+            .unwrap_or_else(|| claudes::Task::new(&task_state.name, ""));
+        fix_task.prompt = fix_prompt;
+        fix_task.isolation = Some(claudes::Isolation::None);
+
+        let fix_manifest = claudes::Manifest::new(vec![fix_task]);
+
+        let work_dir = PathBuf::from(&task_state.work_dir);
+        if !work_dir.exists() {
+            eprintln!(
+                "error: work_dir for task '{}' no longer exists: {}",
+                task_state.name, task_state.work_dir
+            );
+            all_succeeded = false;
+            continue;
+        }
+
+        let started_at = chrono::Utc::now();
+
+        let mut options = claudes::RunOptions {
+            project_dir: work_dir,
+            force: args.force,
+            binary: None,
+            env: vec![],
+            cleanup: claudes::CleanupPolicy::default(),
+            event_sender: None,
+        };
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        options.event_sender = Some(tx);
+        let stream_handle =
+            tokio::spawn(output::render_stream(rx, output::Verbosity::Default, false));
+
+        let result = match claudes::run(&fix_manifest, &options).await {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("error: {e}");
+                all_succeeded = false;
+                continue;
+            }
+        };
+
+        options.event_sender = None;
+        let _ = stream_handle.await;
+
+        let fix_state = claudes::state::build_state(&fix_manifest, &result, started_at);
+        if let Err(e) = claudes::state::save(&project_dir, &fix_state) {
+            tracing::warn!("failed to write fix state file: {e}");
+        }
+
+        output::print_summary(&result, output::OutputFormat::Text);
+
+        if !result.all_succeeded() {
+            all_succeeded = false;
+        }
+    }
+
+    if all_succeeded {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
 }
 
 async fn clean_worktrees_impl(project_dir: &Path, force: bool) -> ExitCode {

--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -34,6 +34,10 @@ pub struct TaskResult {
     pub work_dir: PathBuf,
     /// Cost in USD aggregated from stream events (or parsed from stdout as fallback).
     pub cost_usd: Option<f64>,
+    /// Number of files modified (from git diff --stat HEAD in worktree, if applicable).
+    pub files_modified: Option<u32>,
+    /// Number of lines changed (insertions + deletions, from git diff --stat HEAD in worktree).
+    pub lines_changed: Option<u32>,
 }
 
 /// Result of executing an entire manifest.
@@ -242,6 +246,15 @@ async fn run_task(task: &Task, options: &RunOptions) -> TaskResult {
                             .and_then(|c| c.as_f64())
                     })
             });
+
+            // Collect git diff metrics if running in a worktree.
+            let (files_modified, lines_changed) =
+                if matches!(env.kind, isolation::IsolationKind::Worktree { .. }) {
+                    git_diff_stats(&env.work_dir).await
+                } else {
+                    (None, None)
+                };
+
             TaskResult {
                 name: task_name,
                 success: output.success,
@@ -250,6 +263,8 @@ async fn run_task(task: &Task, options: &RunOptions) -> TaskResult {
                 duration: start.elapsed(),
                 work_dir: env.work_dir,
                 cost_usd,
+                files_modified,
+                lines_changed,
             }
         }
         Err(e) => {
@@ -262,6 +277,8 @@ async fn run_task(task: &Task, options: &RunOptions) -> TaskResult {
                 duration: start.elapsed(),
                 work_dir: options.project_dir.to_path_buf(),
                 cost_usd: None,
+                files_modified: None,
+                lines_changed: None,
             }
         }
     }
@@ -601,6 +618,55 @@ fn parse_effort(s: &str) -> claude_wrapper::Effort {
     }
 }
 
+/// Run `git diff --stat HEAD` in the worktree and return (files_modified, lines_changed).
+/// Non-fatal: returns (None, None) if git is unavailable or output cannot be parsed.
+async fn git_diff_stats(work_dir: &std::path::Path) -> (Option<u32>, Option<u32>) {
+    let Ok(output) = tokio::process::Command::new("git")
+        .args(["diff", "--stat", "HEAD"])
+        .current_dir(work_dir)
+        .output()
+        .await
+    else {
+        return (None, None);
+    };
+    if !output.status.success() {
+        return (None, None);
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    parse_diff_stat_summary(&text)
+}
+
+/// Parse the summary line of `git diff --stat` output.
+///
+/// Expects a line like: " 3 files changed, 77 insertions(+), 14 deletions(-)"
+/// Returns (files_modified, lines_changed) where lines_changed = insertions + deletions.
+fn parse_diff_stat_summary(output: &str) -> (Option<u32>, Option<u32>) {
+    let Some(summary) = output.lines().rev().find(|l| !l.trim().is_empty()) else {
+        return (None, None);
+    };
+    let summary = summary.trim();
+
+    let mut files: Option<u32> = None;
+    let mut lines: u32 = 0;
+    let mut has_lines = false;
+
+    for part in summary.split(',') {
+        let part = part.trim();
+        let n: u32 = match part.split_whitespace().next().and_then(|s| s.parse().ok()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if part.contains("file") {
+            files = Some(n);
+        } else if part.contains("insertion") || part.contains("deletion") {
+            lines += n;
+            has_lines = true;
+        }
+    }
+
+    (files, if has_lines { Some(lines) } else { None })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -683,6 +749,45 @@ mod tests {
         run_hooks("test-task", &[], dir.path(), "post")
             .await
             .unwrap();
+    }
+
+    #[test]
+    fn parse_diff_stat_full_summary() {
+        let output = " file1.rs | 10 ++++++++++\n file2.rs |  5 -----\n 2 files changed, 10 insertions(+), 5 deletions(-)\n";
+        let (files, lines) = parse_diff_stat_summary(output);
+        assert_eq!(files, Some(2));
+        assert_eq!(lines, Some(15));
+    }
+
+    #[test]
+    fn parse_diff_stat_insertions_only() {
+        let output = " file.rs | 7 +++++++\n 1 file changed, 7 insertions(+)\n";
+        let (files, lines) = parse_diff_stat_summary(output);
+        assert_eq!(files, Some(1));
+        assert_eq!(lines, Some(7));
+    }
+
+    #[test]
+    fn parse_diff_stat_deletions_only() {
+        let output = " file.rs | 3 ---\n 1 file changed, 3 deletions(-)\n";
+        let (files, lines) = parse_diff_stat_summary(output);
+        assert_eq!(files, Some(1));
+        assert_eq!(lines, Some(3));
+    }
+
+    #[test]
+    fn parse_diff_stat_empty_output() {
+        let (files, lines) = parse_diff_stat_summary("");
+        assert_eq!(files, None);
+        assert_eq!(lines, None);
+    }
+
+    #[test]
+    fn parse_diff_stat_no_changes() {
+        // git diff --stat HEAD on a clean tree produces no output
+        let (files, lines) = parse_diff_stat_summary("   \n");
+        assert_eq!(files, None);
+        assert_eq!(lines, None);
     }
 
     #[test]

--- a/crates/claudes/src/state.rs
+++ b/crates/claudes/src/state.rs
@@ -87,6 +87,22 @@ pub struct TaskState {
     /// Path to the NDJSON log file for this task.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_path: Option<String>,
+
+    /// Number of turns used (parsed from result JSON `num_turns` field).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turns_used: Option<u32>,
+
+    /// Number of files modified (from git diff --stat HEAD in worktree after execution).
+    /// None if the task did not use worktree isolation or git diff could not be parsed.
+    // Note: not computed in build_state — populated by the runner via TaskResult.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files_modified: Option<u32>,
+
+    /// Number of lines changed (insertions + deletions, from git diff --stat HEAD in worktree).
+    /// None if the task did not use worktree isolation or git diff could not be parsed.
+    // Note: not computed in build_state — populated by the runner via TaskResult.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lines_changed: Option<u32>,
 }
 
 /// Task completion status.
@@ -118,6 +134,10 @@ pub struct RunSummary {
     /// Total cost across all tasks (if available).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_cost_usd: Option<f64>,
+
+    /// Average number of turns used per task (only set if at least one task reported turns).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_turns_used: Option<f64>,
 }
 
 /// Generate a run ID like "run-a3b2f1" (prefix + 6 hex chars from timestamp).
@@ -143,8 +163,8 @@ pub fn build_state(manifest: &Manifest, result: &RunResult, started_at: DateTime
         .tasks
         .iter()
         .map(|t| {
-            // Parse session/result from the JSON output; prefer stream-aggregated cost.
-            let (stdout_cost, session_id, result_text) = parse_task_output(&t.stdout);
+            // Parse session/result/turns from the JSON output; prefer stream-aggregated cost.
+            let (stdout_cost, session_id, result_text, turns_used) = parse_task_output(&t.stdout);
             let cost_usd = t.cost_usd.or(stdout_cost);
 
             // Find the matching manifest task for branch and isolation info.
@@ -192,6 +212,12 @@ pub fn build_state(manifest: &Manifest, result: &RunResult, started_at: DateTime
                 result_text,
                 error,
                 log_path,
+                turns_used,
+                // files_modified and lines_changed cannot be derived in build_state (no git
+                // access); they are populated by the runner via git diff --stat HEAD after
+                // worktree task execution and passed through TaskResult.
+                files_modified: t.files_modified,
+                lines_changed: t.lines_changed,
             }
         })
         .collect();
@@ -221,6 +247,15 @@ pub fn build_state(manifest: &Manifest, result: &RunResult, started_at: DateTime
         .filter(|r| r.status == TaskStatus::Failed)
         .count();
 
+    let avg_turns_used = {
+        let turns: Vec<u32> = results.iter().filter_map(|r| r.turns_used).collect();
+        if turns.is_empty() {
+            None
+        } else {
+            Some(turns.iter().map(|&t| t as f64).sum::<f64>() / turns.len() as f64)
+        }
+    };
+
     let summary = RunSummary {
         total: result.tasks.len(),
         succeeded: result.success_count(),
@@ -228,6 +263,7 @@ pub fn build_state(manifest: &Manifest, result: &RunResult, started_at: DateTime
         timed_out,
         wall_time_secs: wall_time,
         total_cost_usd: total_cost,
+        avg_turns_used,
     };
 
     RunState {
@@ -310,10 +346,10 @@ pub(crate) fn is_timeout(stdout: &str, stderr: &str) -> bool {
     false
 }
 
-/// Try to parse cost, session_id, and result text from claude JSON output.
-fn parse_task_output(stdout: &str) -> (Option<f64>, Option<String>, Option<String>) {
+/// Try to parse cost, session_id, result text, and turns from claude JSON output.
+fn parse_task_output(stdout: &str) -> (Option<f64>, Option<String>, Option<String>, Option<u32>) {
     let Ok(v) = serde_json::from_str::<serde_json::Value>(stdout) else {
-        return (None, None, None);
+        return (None, None, None, None);
     };
 
     let cost = v
@@ -328,7 +364,12 @@ fn parse_task_output(stdout: &str) -> (Option<f64>, Option<String>, Option<Strin
 
     let result_text = v.get("result").and_then(|r| r.as_str()).map(String::from);
 
-    (cost, session_id, result_text)
+    let turns_used = v
+        .get("num_turns")
+        .and_then(|n| n.as_u64())
+        .map(|n| n as u32);
+
+    (cost, session_id, result_text, turns_used)
 }
 
 /// Print a summary table of all runs.
@@ -377,11 +418,14 @@ pub fn print_status(state: &RunState) {
     if let Some(cost) = state.summary.total_cost_usd {
         println!("Cost: ${cost:.4}");
     }
+    if let Some(avg_turns) = state.summary.avg_turns_used {
+        println!("Avg turns: {avg_turns:.1}");
+    }
     println!();
-    let header_sep = "-".repeat(80);
+    let header_sep = "-".repeat(88);
     println!(
-        "  {:<30} {:<10} {:>8}  {:>8}  Branch",
-        "Task", "Status", "Time", "Cost"
+        "  {:<30} {:<10} {:>8}  {:>8}  {:>6}  Branch",
+        "Task", "Status", "Time", "Cost", "Turns"
     );
     println!("  {header_sep}");
 
@@ -397,9 +441,10 @@ pub fn print_status(state: &RunState) {
             .unwrap_or_default();
         let branch = task.branch.as_deref().unwrap_or("-");
         let time = format!("{:.1}s", task.duration_secs);
+        let turns = task.turns_used.map(|t| t.to_string()).unwrap_or_default();
 
         let name = &task.name;
-        println!("  {name:<30} {status:<10} {time:>8}  {cost:>8}  {branch}");
+        println!("  {name:<30} {status:<10} {time:>8}  {cost:>8}  {turns:>6}  {branch}");
 
         if let Some(err) = &task.error {
             for line in err.lines().take(3) {
@@ -442,6 +487,8 @@ mod tests {
             duration: Duration::from_secs(1),
             work_dir: PathBuf::from("/tmp"),
             cost_usd: None,
+            files_modified: None,
+            lines_changed: None,
         }
     }
 
@@ -463,6 +510,8 @@ mod tests {
                 duration: Duration::from_secs(5),
                 work_dir: PathBuf::from("/tmp/test"),
                 cost_usd: None,
+                files_modified: None,
+                lines_changed: None,
             }],
         };
 
@@ -501,6 +550,8 @@ mod tests {
                     duration: Duration::from_secs(3),
                     work_dir: PathBuf::from("/tmp/ok"),
                     cost_usd: None,
+                    files_modified: None,
+                    lines_changed: None,
                 },
                 TaskResult {
                     name: "bad-task".into(),
@@ -510,6 +561,8 @@ mod tests {
                     duration: Duration::from_secs(1),
                     work_dir: PathBuf::from("/tmp/bad"),
                     cost_usd: None,
+                    files_modified: None,
+                    lines_changed: None,
                 },
             ],
         };
@@ -537,6 +590,8 @@ mod tests {
                 duration: Duration::from_secs(2),
                 work_dir: PathBuf::from("/tmp"),
                 cost_usd: None,
+                files_modified: None,
+                lines_changed: None,
             }],
         };
 
@@ -665,6 +720,8 @@ mod tests {
                 duration: Duration::from_secs(60),
                 work_dir: PathBuf::from("/tmp"),
                 cost_usd: None,
+                files_modified: None,
+                lines_changed: None,
             }],
         };
         let state = build_state(&manifest, &result_stderr, Utc::now());
@@ -682,6 +739,8 @@ mod tests {
                 duration: Duration::from_secs(60),
                 work_dir: PathBuf::from("/tmp"),
                 cost_usd: None,
+                files_modified: None,
+                lines_changed: None,
             }],
         };
         let state2 = build_state(&manifest, &result_stdout, Utc::now());
@@ -693,25 +752,87 @@ mod tests {
     #[test]
     fn parse_output_extracts_fields() {
         let stdout = r#"{"result":"hello","session_id":"s1","total_cost_usd":0.123,"num_turns":3}"#;
-        let (cost, session, result) = parse_task_output(stdout);
+        let (cost, session, result, turns) = parse_task_output(stdout);
         assert_eq!(cost, Some(0.123));
         assert_eq!(session.as_deref(), Some("s1"));
         assert_eq!(result.as_deref(), Some("hello"));
+        assert_eq!(turns, Some(3));
     }
 
     #[test]
     fn parse_output_handles_missing_fields() {
-        let (cost, session, result) = parse_task_output("{}");
+        let (cost, session, result, turns) = parse_task_output("{}");
         assert_eq!(cost, None);
         assert_eq!(session, None);
         assert_eq!(result, None);
+        assert_eq!(turns, None);
     }
 
     #[test]
     fn parse_output_handles_invalid_json() {
-        let (cost, session, result) = parse_task_output("not json");
+        let (cost, session, result, turns) = parse_task_output("not json");
         assert_eq!(cost, None);
         assert_eq!(session, None);
         assert_eq!(result, None);
+        assert_eq!(turns, None);
+    }
+
+    #[test]
+    fn build_state_populates_turns_used() {
+        let manifest = Manifest::new(vec![
+            Task::new("task-a", "do a"),
+            Task::new("task-b", "do b"),
+        ]);
+        let result = RunResult {
+            tasks: vec![
+                TaskResult {
+                    name: "task-a".into(),
+                    success: true,
+                    stdout: r#"{"result":"ok","num_turns":4}"#.into(),
+                    stderr: String::new(),
+                    duration: Duration::from_secs(2),
+                    work_dir: PathBuf::from("/tmp"),
+                    cost_usd: None,
+                    files_modified: None,
+                    lines_changed: None,
+                },
+                TaskResult {
+                    name: "task-b".into(),
+                    success: true,
+                    stdout: r#"{"result":"ok","num_turns":8}"#.into(),
+                    stderr: String::new(),
+                    duration: Duration::from_secs(3),
+                    work_dir: PathBuf::from("/tmp"),
+                    cost_usd: None,
+                    files_modified: None,
+                    lines_changed: None,
+                },
+            ],
+        };
+        let state = build_state(&manifest, &result, Utc::now());
+        assert_eq!(state.results[0].turns_used, Some(4));
+        assert_eq!(state.results[1].turns_used, Some(8));
+        assert_eq!(state.summary.avg_turns_used, Some(6.0));
+    }
+
+    #[test]
+    fn build_state_propagates_git_metrics() {
+        let manifest = Manifest::new(vec![Task::new("task-a", "do a")]);
+        let result = RunResult {
+            tasks: vec![TaskResult {
+                name: "task-a".into(),
+                success: true,
+                stdout: "{}".into(),
+                stderr: String::new(),
+                duration: Duration::from_secs(1),
+                work_dir: PathBuf::from("/tmp"),
+                cost_usd: None,
+                files_modified: Some(3),
+                lines_changed: Some(42),
+            }],
+        };
+        let state = build_state(&manifest, &result, Utc::now());
+        assert_eq!(state.results[0].files_modified, Some(3));
+        assert_eq!(state.results[0].lines_changed, Some(42));
     }
 }


### PR DESCRIPTION
## Summary

Extends state file with per-task metrics: turns_used (from result JSON), files_modified and lines_changed (from git diff in worktree).

- turns_used parsed from num_turns in result JSON
- files_modified and lines_changed from git diff --stat
- compute_metrics includes avg_turns_used
- print_metrics shows turn usage stats

## Notes

Task hit max_turns. Had if_same_then_else clippy lint (identical insertion/deletion branches). Fixed manually.

Closes #368

## Test plan

- [x] 121 unit tests pass
- [x] clippy clean