### PR TITLE
feat(claudes): enhance MCP server with titles, descriptions, and instructions

### DIFF
--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -707,9 +707,18 @@ async fn cmd_serve(_args: claudes::cli::ServeArgs) -> ExitCode {
     let router = McpRouter::new()
         .server_info("claudes", env!("CARGO_PKG_VERSION"))
         .instructions(
-            "Manifest-driven execution engine for Claude Code sessions. \
-             Use plan_tasks to generate a manifest, run_manifest to execute it, \
-             task_status and list_runs to inspect results, and clean to remove worktrees.",
+            "Manifest-driven execution engine for running Claude Code sessions in parallel.\n\n\
+             Workflow:\n\
+             1. Use plan_tasks to generate a manifest from task prompts (review before running)\n\
+             2. Use run_manifest to execute the manifest (tasks run in parallel in git worktrees)\n\
+             3. Use task_status to check results, costs, and errors\n\
+             4. Use list_runs to see history of all runs\n\
+             5. Use clean to remove worktrees and state when done\n\n\
+             Each task runs as an isolated headless Claude Code session. Tasks can have \
+             pre_hooks (setup), post_hooks (validation), and finally_hooks (cleanup). \
+             Manifests support a shared block for defaults and named profiles for presets.\n\n\
+             Always plan first, review the manifest, then run. Check task_status after \
+             running to verify results and inspect any failures.",
         )
         .tools(claudes::mcp::tools());
 

--- a/crates/claudes/src/mcp.rs
+++ b/crates/claudes/src/mcp.rs
@@ -50,6 +50,22 @@ struct TaskStatusInput {
 struct ListRunsInput {}
 
 #[derive(Debug, Deserialize, JsonSchema)]
+struct FixInput {
+    /// Run ID to fix (default: latest run).
+    run_id: Option<String>,
+    /// Re-run only these task(s) (default: all failed/timed-out).
+    tasks: Option<Vec<String>>,
+    /// Additional guidance to append to the fix prompt.
+    guidance: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct MetricsInput {
+    /// Limit to the last N runs.
+    last: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 struct CleanInput {
     /// Force remove even with uncommitted changes.
     force: Option<bool>,
@@ -66,13 +82,21 @@ pub fn tools() -> Vec<Tool> {
         run_manifest(),
         task_status(),
         list_runs(),
+        fix_tasks(),
+        metrics(),
         clean_tool(),
     ]
 }
 
 fn plan_tasks() -> Tool {
     ToolBuilder::new("plan_tasks")
-        .description("Generate a claudes manifest from one or more task prompts without executing.")
+        .title("Plan Tasks")
+        .description(
+            "Generate a claudes manifest from one or more task prompts without executing. \
+             Returns a JSON manifest that can be reviewed, edited, and then passed to run_manifest. \
+             Each prompt becomes a separate task. Use this to preview what would run before executing.",
+        )
+        .read_only_safe()
         .handler(|input: PlanInput| async move {
             let opts = crate::planner::PlanOptions {
                 prompts: input.prompts,
@@ -89,7 +113,13 @@ fn plan_tasks() -> Tool {
 
 fn run_manifest() -> Tool {
     ToolBuilder::new("run_manifest")
-        .description("Execute a claudes manifest JSON and return the run result summary.")
+        .title("Run Manifest")
+        .description(
+            "Execute a claudes manifest. Tasks run in parallel in isolated git worktrees. \
+             Returns the full run state including per-task status, cost, duration, and errors. \
+             The manifest JSON should include version, tasks array, and optionally a shared block. \
+             Use plan_tasks first to generate a manifest, then pass it here to execute.",
+        )
         .handler(|input: RunManifestInput| async move {
             let manifest: crate::Manifest = match serde_json::from_str(&input.manifest_json) {
                 Ok(m) => m,
@@ -110,6 +140,9 @@ fn run_manifest() -> Tool {
             match crate::run(&manifest, &options).await {
                 Ok(result) => {
                     let state = crate::state::build_state(&manifest, &result, started_at);
+                    if let Err(e) = crate::state::save(&project_dir, &state) {
+                        tracing::warn!("failed to write state file: {e}");
+                    }
                     Ok(json_result(&state))
                 }
                 Err(e) => Ok(CallToolResult::error(format!("{e}"))),
@@ -120,7 +153,12 @@ fn run_manifest() -> Tool {
 
 fn task_status() -> Tool {
     ToolBuilder::new("task_status")
-        .description("Get the status of the most recent claudes run, or a specific run by ID.")
+        .title("Task Status")
+        .description(
+            "Get the full status of a claudes run, including per-task results, costs, \
+             durations, branches, and errors. Defaults to the most recent run. \
+             Pass a run_id to query a specific historical run.",
+        )
         .read_only_safe()
         .handler(|input: TaskStatusInput| async move {
             let _ = input.json; // always JSON in MCP context
@@ -142,20 +180,204 @@ fn task_status() -> Tool {
 
 fn list_runs() -> Tool {
     ToolBuilder::new("list_runs")
-        .description("List all claudes runs in the current project directory.")
+        .title("List Runs")
+        .description(
+            "List all claudes runs in the current project, sorted newest first. \
+             Returns an array of run summaries with run_id, start time, task count, \
+             success count, wall time, and cost. Use task_status with a specific \
+             run_id to get full details for any run.",
+        )
         .read_only_safe()
         .handler(|_input: ListRunsInput| async move {
             let project_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
             let runs = crate::state::list_runs(&project_dir);
-            Ok(json_result(&runs))
+            let summaries: Vec<serde_json::Value> = runs
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "run_id": r.run_id,
+                        "started_at": r.started_at.to_rfc3339(),
+                        "total_tasks": r.summary.total,
+                        "succeeded": r.summary.succeeded,
+                        "failed": r.summary.failed,
+                        "timed_out": r.summary.timed_out,
+                        "wall_time_secs": r.summary.wall_time_secs,
+                        "total_cost_usd": r.summary.total_cost_usd,
+                    })
+                })
+                .collect();
+            Ok(json_result(&serde_json::json!({ "runs": summaries })))
+        })
+        .build()
+}
+
+fn fix_tasks() -> Tool {
+    ToolBuilder::new("fix_tasks")
+        .title("Fix Failed Tasks")
+        .description(
+            "Re-run failed or timed-out tasks from a previous run. Enters the existing \
+             worktree and spawns a new claude session with the original prompt plus error \
+             context. Optionally provide additional guidance. Re-runs post_hooks to verify \
+             the fix. Defaults to fixing all failed/timed-out tasks from the latest run.",
+        )
+        .handler(|input: FixInput| async move {
+            let project_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+            let state = if let Some(ref run_id) = input.run_id {
+                crate::state::load_run(&project_dir, run_id)
+            } else {
+                crate::state::load(&project_dir)
+            };
+
+            let state = match state {
+                Some(s) => s,
+                None => {
+                    return Ok(CallToolResult::error(
+                        "no run state found (run a manifest first)",
+                    ));
+                }
+            };
+
+            let task_filter = input.tasks.unwrap_or_default();
+            let tasks_to_fix: Vec<&crate::state::TaskState> = state
+                .results
+                .iter()
+                .filter(|t| {
+                    if task_filter.is_empty() {
+                        matches!(
+                            t.status,
+                            crate::state::TaskStatus::Failed | crate::state::TaskStatus::Timeout
+                        )
+                    } else {
+                        task_filter.contains(&t.name)
+                    }
+                })
+                .collect();
+
+            if tasks_to_fix.is_empty() {
+                return Ok(json_result(
+                    &serde_json::json!({"message": "no failed or timed-out tasks to fix"}),
+                ));
+            }
+
+            let mut results: Vec<serde_json::Value> = Vec::new();
+
+            for task_state in tasks_to_fix {
+                let original_task = state
+                    .manifest
+                    .tasks
+                    .iter()
+                    .find(|t| t.name == task_state.name);
+
+                let original_prompt = original_task
+                    .map(|t| t.prompt.as_str())
+                    .unwrap_or("[unknown]");
+
+                let error_context = task_state
+                    .error
+                    .as_deref()
+                    .unwrap_or("task timed out or failed with no error output");
+
+                let mut fix_prompt = format!(
+                    "The previous task failed. Original prompt: {original_prompt}. \
+                     Error: {error_context}. Fix the issue."
+                );
+                if let Some(ref guidance) = input.guidance {
+                    fix_prompt.push_str(&format!(" {guidance}"));
+                }
+
+                let mut fix_task = original_task
+                    .cloned()
+                    .unwrap_or_else(|| crate::Task::new(&task_state.name, ""));
+                fix_task.prompt = fix_prompt;
+                fix_task.isolation = Some(crate::Isolation::None);
+
+                let fix_manifest = crate::Manifest::new(vec![fix_task]);
+
+                let work_dir = PathBuf::from(&task_state.work_dir);
+                if !work_dir.exists() {
+                    results.push(serde_json::json!({
+                        "task": task_state.name,
+                        "status": "error",
+                        "message": format!("work_dir no longer exists: {}", task_state.work_dir),
+                    }));
+                    continue;
+                }
+
+                let options = crate::RunOptions {
+                    project_dir: work_dir,
+                    force: false,
+                    binary: None,
+                    env: vec![],
+                    cleanup: crate::CleanupPolicy::default(),
+                    event_sender: None,
+                };
+
+                let started_at = chrono::Utc::now();
+                match crate::run(&fix_manifest, &options).await {
+                    Ok(result) => {
+                        let fix_state =
+                            crate::state::build_state(&fix_manifest, &result, started_at);
+                        if let Err(e) = crate::state::save(&project_dir, &fix_state) {
+                            tracing::warn!("failed to write fix state: {e}");
+                        }
+                        let succeeded = result.all_succeeded();
+                        results.push(serde_json::json!({
+                            "task": task_state.name,
+                            "status": if succeeded { "fixed" } else { "still_failing" },
+                        }));
+                    }
+                    Err(e) => {
+                        results.push(serde_json::json!({
+                            "task": task_state.name,
+                            "status": "error",
+                            "message": format!("{e}"),
+                        }));
+                    }
+                }
+            }
+
+            Ok(json_result(&serde_json::json!({ "results": results })))
+        })
+        .build()
+}
+
+fn metrics() -> Tool {
+    ToolBuilder::new("metrics")
+        .title("Run Metrics")
+        .description(
+            "Aggregate statistics across historical runs: total tasks, success/failure/timeout \
+             rates, total and average cost, average duration. Optionally limit to the last N runs.",
+        )
+        .read_only_safe()
+        .handler(|input: MetricsInput| async move {
+            let project_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            let mut runs = crate::state::list_runs(&project_dir);
+
+            if let Some(n) = input.last {
+                runs.truncate(n);
+            }
+
+            if runs.is_empty() {
+                return Ok(CallToolResult::error(
+                    "no runs found (run a manifest first)",
+                ));
+            }
+
+            let m = crate::state::compute_metrics(&runs);
+            Ok(json_result(&m))
         })
         .build()
 }
 
 fn clean_tool() -> Tool {
     ToolBuilder::new("clean")
+        .title("Clean")
         .description(
-            "Remove worktrees and optionally run state files and merged claudes/* branches.",
+            "Remove claudes artifacts. By default, removes git worktrees from .worktrees/. \
+             Set runs=true to also remove run state files from .claudes/runs/. \
+             Set branches=true to also delete local claudes/* branches that have been merged into main. \
+             Set force=true to force-remove worktrees even with uncommitted changes.",
         )
         .handler(|input: CleanInput| async move {
             let project_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));


### PR DESCRIPTION
## Summary

Polish the MCP server with better metadata:

- Tool titles (Plan Tasks, Run Manifest, Task Status, List Runs, Clean)
- Expanded descriptions with usage guidance
- `read_only_safe()` on read-only tools
- Fix `list_runs` serialization (returns `{runs: [...]}` object instead of raw array)
- Detailed workflow instructions on McpRouter explaining the plan -> run -> check loop

## Test plan

- [x] 117 unit tests pass
- [x] clippy clean
- [ ] Manual: verify tools show titles in Claude Code