### PR TITLE
chore: update .mcp.json from claude-pool to claudes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,11 +1,8 @@
 {
   "mcpServers": {
-    "claude-pool": {
+    "claudes": {
       "command": "cargo",
-      "args": ["run", "-p", "claude-pool-mcp", "--", "-n", "4", "--model", "claude-haiku-4-5-20251001", "--permission-mode", "auto"],
-      "env": {
-        "RUST_LOG": "claude_pool=debug,claude_pool_mcp=debug"
-      }
+      "args": ["run", "--quiet", "-p", "claudes", "--", "serve"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Replace deprecated `claude-pool-mcp` server with `claudes serve` in project `.mcp.json`.

## Test plan

- [x] `claudes serve` starts MCP server on stdio