### PR TITLE
feat(claudes): optional indicatif progress display (#381)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "clap",
  "claude-wrapper",
  "crossterm",
+ "indicatif",
  "schemars",
  "serde",
  "serde_json",
@@ -329,6 +330,19 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -421,6 +435,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -739,6 +759,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +953,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -1621,6 +1666,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1813,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/claudes/Cargo.toml
+++ b/crates/claudes/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = { workspace = true }
 tower-mcp = { workspace = true }
 schemars = { workspace = true }
 crossterm = "0.28"
+indicatif = "0.17"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/claudes/src/cli.rs
+++ b/crates/claudes/src/cli.rs
@@ -132,6 +132,10 @@ pub struct RunArgs {
     /// Disable colored output.
     #[arg(long)]
     pub no_color: bool,
+
+    /// Show indicatif progress bars instead of streaming text (falls back to text when not a TTY).
+    #[arg(long)]
+    pub progress: bool,
 }
 
 /// Arguments for `claudes status`.

--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -221,11 +222,12 @@ async fn execute_manifest(
     let stream_handle = if format == OutputFormat::Text {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         options.event_sender = Some(tx);
-        Some(tokio::spawn(output::render_stream(
-            rx,
-            verbosity,
-            args.no_color,
-        )))
+        let use_progress = args.progress && std::io::stderr().is_terminal();
+        Some(if use_progress {
+            tokio::spawn(output::render_progress(rx, args.no_color))
+        } else {
+            tokio::spawn(output::render_stream(rx, verbosity, args.no_color))
+        })
     } else {
         None
     };

--- a/crates/claudes/src/output.rs
+++ b/crates/claudes/src/output.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
 
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
 use crossterm::style::{Color, Stylize};
 use tokio::sync::mpsc;
 
@@ -170,6 +172,77 @@ fn print_json_summary(result: &RunResult) {
     });
 
     println!("{}", serde_json::to_string_pretty(&json).unwrap());
+}
+
+/// Render task progress using indicatif progress bars.
+///
+/// Runs until the channel is closed (all senders dropped).
+/// Each task gets a spinner showing elapsed time and final status.
+pub async fn render_progress(mut rx: mpsc::UnboundedReceiver<TaskEvent>, no_color: bool) {
+    let use_color = !no_color && std::env::var_os("NO_COLOR").is_none();
+
+    let multi = MultiProgress::new();
+    let spinner_style =
+        ProgressStyle::with_template("  {spinner:.cyan} {prefix:<20} {elapsed_precise} {msg}")
+            .unwrap()
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", " "]);
+
+    let mut bars: HashMap<String, ProgressBar> = HashMap::new();
+
+    while let Some(event) = rx.recv().await {
+        let task = event.task_name.clone();
+        let data = &event.event.data;
+        let event_type = event.event.event_type().unwrap_or("");
+
+        match event_type {
+            "claudes_task_start" => {
+                let pb = multi.add(ProgressBar::new_spinner());
+                pb.set_style(spinner_style.clone());
+                pb.set_prefix(task.clone());
+                pb.set_message("starting...");
+                pb.enable_steady_tick(std::time::Duration::from_millis(80));
+                bars.insert(task, pb);
+            }
+            "result" => {
+                let subtype = data
+                    .get("subtype")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("unknown");
+                let cost = data
+                    .get("total_cost_usd")
+                    .or_else(|| data.get("cost_usd"))
+                    .and_then(|c| c.as_f64());
+
+                if let Some(pb) = bars.get(task.as_str()) {
+                    let msg = if subtype == "success" {
+                        let cost_str = cost.map(|c| format!(", ${c:.2}")).unwrap_or_default();
+                        let m = format!("complete{cost_str}");
+                        if use_color {
+                            format!("\x1b[32m{m}\x1b[0m")
+                        } else {
+                            m
+                        }
+                    } else if subtype == "error_max_turns" {
+                        let m = "TIMEOUT".to_string();
+                        if use_color {
+                            format!("\x1b[31m{m}\x1b[0m")
+                        } else {
+                            m
+                        }
+                    } else {
+                        let m = "FAILED".to_string();
+                        if use_color {
+                            format!("\x1b[31m{m}\x1b[0m")
+                        } else {
+                            m
+                        }
+                    };
+                    pb.finish_with_message(msg);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Render streaming events from tasks as they arrive.


### PR DESCRIPTION
## Summary
- Add --progress flag for indicatif-based progress bars
- Per-task spinner with elapsed time and status
- Falls back to text mode when not a TTY
- Shows total cost on completion

Closes #381

## Test plan
- [ ] cargo fmt --check
- [ ] cargo clippy clean
- [ ] cargo test --lib -p claudes
- [ ] Manual: claudes run --progress shows progress bars