### PR TITLE
feat(claudes): output formatting polish (#379)

### DIFF
--- a/crates/claudes/src/output.rs
+++ b/crates/claudes/src/output.rs
@@ -133,11 +133,14 @@ fn print_task_result(out: &mut impl Write, task: &TaskResult) {
         .map(|c| format!("  ${c:.2}"))
         .unwrap_or_default();
 
-    let _ = writeln!(
-        out,
-        "  {name:<30} {status:<12} {duration}{cost_str}",
-        name = task.name,
-    );
+    let name: String = if task.name.chars().count() > 30 {
+        let truncated: String = task.name.chars().take(27).collect();
+        format!("{truncated}...")
+    } else {
+        task.name.clone()
+    };
+
+    let _ = writeln!(out, "  {name:<30} {status:<12} {duration}{cost_str}",);
 
     if !task.success && !task.stderr.is_empty() {
         for line in task.stderr.lines().take(5) {
@@ -209,7 +212,13 @@ pub async fn render_stream(
         };
 
         let prefix = {
-            let padded = format!("{task:<20}");
+            let task_display: String = if task.chars().count() > 20 {
+                let truncated: String = task.chars().take(17).collect();
+                format!("{truncated}...")
+            } else {
+                task.clone()
+            };
+            let padded = format!("{task_display:<20}");
             match color_opt {
                 Some(color) => format!("{}", padded.with(color)),
                 None => padded,
@@ -283,10 +292,14 @@ pub async fn render_stream(
                                         } else {
                                             s
                                         };
-                                        // Also strip .worktrees/<task-name>/ prefix.
+                                        // Strip .worktrees/<task-name>/ prefix (relative or absolute).
                                         let s = if let Some(rest) = s.strip_prefix(".worktrees/") {
                                             rest.split_once('/')
                                                 .map_or(s.clone(), |(_, after)| after.to_string())
+                                        } else if let Some(idx) = s.find("/.worktrees/") {
+                                            let rest = &s[idx + "/.worktrees/".len()..];
+                                            rest.split_once('/')
+                                                .map_or(s.clone(), |(_, p)| p.to_string())
                                         } else {
                                             s
                                         };

--- a/crates/claudes/src/state.rs
+++ b/crates/claudes/src/state.rs
@@ -665,8 +665,52 @@ pub fn print_status(state: &RunState) {
         let branch = task.branch.as_deref().unwrap_or("-");
         let time = format!("{:.1}s", task.duration_secs);
 
-        let name = &task.name;
-        println!("  {name:<30} {status_display} {time:>8}  {cost:>8}  {branch}");
+        let name_raw: String = if task.name.chars().count() > 30 {
+            let truncated: String = task.name.chars().take(27).collect();
+            format!("{truncated}...")
+        } else {
+            task.name.clone()
+        };
+        let name_display = if use_color {
+            match task.status {
+                TaskStatus::Success => format!(
+                    "{:<30}",
+                    name_raw
+                        .as_str()
+                        .with(Color::Rgb {
+                            r: 0,
+                            g: 255,
+                            b: 128
+                        })
+                        .to_string()
+                ),
+                TaskStatus::Failed => format!(
+                    "{:<30}",
+                    name_raw
+                        .as_str()
+                        .with(Color::Rgb {
+                            r: 255,
+                            g: 80,
+                            b: 80
+                        })
+                        .to_string()
+                ),
+                TaskStatus::Timeout => format!(
+                    "{:<30}",
+                    name_raw
+                        .as_str()
+                        .with(Color::Rgb {
+                            r: 255,
+                            g: 255,
+                            b: 0
+                        })
+                        .to_string()
+                ),
+            }
+        } else {
+            format!("{name_raw:<30}")
+        };
+        println!("  {name_display} {status_display} {time:>8}  {cost:>8}  {branch}");
 
         if let Some(err) = &task.error
             && let Some(first_line) = err.lines().next()


### PR DESCRIPTION
## Summary
- Relative paths in verbose streaming output
- Elapsed time and cost on task completion lines
- Colored task names in status output (green/red/yellow)
- Fixed-width task name column (30 char max)

Closes #379

## Test plan
- [ ] cargo fmt --check
- [ ] cargo clippy clean
- [ ] cargo test --lib -p claudes
