### PR TITLE
feat(claudes): default isolation to worktree (#413)

### DIFF
--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -241,9 +241,9 @@ pub async fn run(manifest: &Manifest, options: &RunOptions) -> Result<RunResult>
 /// Execute a single task.
 async fn run_task(task: &Task, options: &RunOptions) -> TaskResult {
     let isolation_type = match &task.isolation {
-        None | Some(crate::manifest::Isolation::None) => "none",
+        None | Some(crate::manifest::Isolation::Worktree { .. }) => "worktree",
+        Some(crate::manifest::Isolation::None) => "none",
         Some(crate::manifest::Isolation::Clone { .. }) => "clone",
-        Some(crate::manifest::Isolation::Worktree { .. }) => "worktree",
     };
     let span = tracing::info_span!(
         "task",
@@ -327,6 +327,14 @@ async fn run_task_inner(
     let project_dir = &options.project_dir;
     let force = options.force;
 
+    // Default to worktree isolation when none is specified.
+    let effective_isolation =
+        task.isolation
+            .clone()
+            .unwrap_or(crate::manifest::Isolation::Worktree {
+                base_dir: ".worktrees".into(),
+            });
+
     // Set up isolation.
     let env = if force {
         // If force, try to clean up existing worktree first.
@@ -334,15 +342,15 @@ async fn run_task_inner(
             project_dir,
             &task.name,
             task.branch.as_deref(),
-            task.isolation.as_ref(),
+            Some(&effective_isolation),
         )
         .await
         {
             Ok(env) => env,
             Err(Error::Worktree(msg)) if msg.contains("already exists") => {
                 // Force remove and retry.
-                let worktree_dir = match &task.isolation {
-                    Some(crate::manifest::Isolation::Worktree { base_dir }) => {
+                let worktree_dir = match &effective_isolation {
+                    crate::manifest::Isolation::Worktree { base_dir } => {
                         project_dir.join(base_dir).join(&task.name)
                     }
                     _ => project_dir.join(".worktrees").join(&task.name),
@@ -356,7 +364,7 @@ async fn run_task_inner(
                     project_dir,
                     &task.name,
                     task.branch.as_deref(),
-                    task.isolation.as_ref(),
+                    Some(&effective_isolation),
                 )
                 .await?
             }
@@ -367,7 +375,7 @@ async fn run_task_inner(
             project_dir,
             &task.name,
             task.branch.as_deref(),
-            task.isolation.as_ref(),
+            Some(&effective_isolation),
         )
         .await?
     };

--- a/crates/claudes/tests/fake_claude.rs
+++ b/crates/claudes/tests/fake_claude.rs
@@ -1057,6 +1057,66 @@ async fn event_sender_receives_events() {
 }
 
 // ============================================================================
+// Default isolation
+// ============================================================================
+
+/// Task with no isolation field set defaults to worktree isolation.
+#[tokio::test]
+#[ignore]
+async fn default_isolation_creates_worktree() {
+    let dir = temp_git_repo();
+    let options = run_options(dir.path().to_path_buf());
+
+    // No isolation field set — should default to worktree.
+    let manifest = Manifest::new(vec![Task::new("default-iso", "do something")]);
+
+    let result = claudes::run(&manifest, &options).await.unwrap();
+    assert!(result.all_succeeded());
+
+    // Worktree should have been created at the default location.
+    let wt_dir = dir.path().join(".worktrees").join("default-iso");
+    assert!(
+        wt_dir.exists(),
+        "worktree directory should exist with default isolation"
+    );
+    assert_eq!(result.tasks[0].work_dir, wt_dir);
+
+    // Clean up.
+    let _ = Command::new("git")
+        .args(["worktree", "remove", "--force"])
+        .arg(&wt_dir)
+        .current_dir(dir.path())
+        .status();
+}
+
+/// Explicit isolation: none still works as an opt-out.
+#[tokio::test]
+#[ignore]
+async fn explicit_none_isolation_runs_in_place() {
+    let dir = temp_git_repo();
+    let options = run_options(dir.path().to_path_buf());
+
+    let manifest = Manifest::new(vec![{
+        let mut t = Task::new("explicit-none", "do something");
+        t.isolation = Some(Isolation::None);
+        t
+    }]);
+
+    let result = claudes::run(&manifest, &options).await.unwrap();
+    assert!(result.all_succeeded());
+
+    // No worktree should be created.
+    let wt_dir = dir.path().join(".worktrees").join("explicit-none");
+    assert!(
+        !wt_dir.exists(),
+        "no worktree should exist with explicit isolation: none"
+    );
+
+    // Task ran in the project dir.
+    assert_eq!(result.tasks[0].work_dir, dir.path());
+}
+
+// ============================================================================
 // Error cases
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Tasks without explicit isolation now default to worktree instead of none
- Parallel tasks no longer share git state by accident
- Explicit `isolation: "none"` still works as opt-out
- Added integration tests for default and explicit isolation behavior

Closes #413

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy clean
- [x] cargo test --lib -p claudes
- [x] cargo test --test fake_claude -p claudes -- --ignored (new tests: default_isolation_creates_worktree, explicit_none_isolation_runs_in_place)