### PR TITLE
feat(claudes): three distinct output modes (#415)

### DIFF
--- a/crates/claudes/src/cli.rs
+++ b/crates/claudes/src/cli.rs
@@ -113,8 +113,8 @@ pub struct RunArgs {
     #[arg(long)]
     pub quiet: bool,
 
-    /// Output format (text|json).
-    #[arg(long, default_value = "text")]
+    /// Output mode (progress|json|quiet). Default: progress when TTY, json when piped.
+    #[arg(long, default_value = "auto")]
     pub output: String,
 
     /// Overwrite existing worktrees.
@@ -124,10 +124,6 @@ pub struct RunArgs {
     /// Auto-cleanup worktrees after run (none|on-success|always; default: none).
     #[arg(long, default_value = "none")]
     pub cleanup: String,
-
-    /// Increase output verbosity (repeat for more detail: -v, -vv).
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count)]
-    pub verbose: u8,
 
     /// Disable colored output.
     #[arg(long)]

--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::EnvFilter;
 
 use claude_wrapper::{Claude, QueryCommand};
 use claudes::cli::{Cli, Command, parse_timeout};
-use claudes::output::{self, OutputFormat, Verbosity};
+use claudes::output::{self, OutputMode};
 use claudes::planner::PlanOptions;
 
 #[tokio::main]
@@ -207,25 +207,22 @@ async fn execute_manifest(
     options: &claudes::RunOptions,
     args: &claudes::cli::RunArgs,
 ) -> ExitCode {
-    let format = match args.output.as_str() {
-        "json" => OutputFormat::Json,
-        _ if args.quiet => OutputFormat::Quiet,
-        _ => OutputFormat::Text,
-    };
-
-    let verbosity = Verbosity::from(args.verbose);
+    let mode = OutputMode::detect(&args.output, args.quiet);
     let started_at = chrono::Utc::now();
 
-    // Set up streaming if we're in text mode.
+    // Opening bookend: what we're about to do.
+    output::print_run_start(manifest, mode, args.no_color);
+
+    // Set up streaming renderer.
     let mut options = options.clone();
-    let stream_handle = if format == OutputFormat::Text {
+    let stream_handle = if mode != OutputMode::Quiet {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         options.event_sender = Some(tx);
-        Some(tokio::spawn(output::render_stream(
-            rx,
-            verbosity,
-            args.no_color,
-        )))
+        Some(match mode {
+            OutputMode::Progress => tokio::spawn(output::render_progress(rx, args.no_color)),
+            OutputMode::Ndjson => tokio::spawn(output::render_ndjson(rx)),
+            OutputMode::Quiet => unreachable!(),
+        })
     } else {
         None
     };
@@ -250,7 +247,9 @@ async fn execute_manifest(
         tracing::warn!("failed to write state file: {e}");
     }
 
-    output::print_summary(&result, format);
+    // Closing bookend: what we did.
+    output::print_run_complete(&result, mode, args.no_color);
+
     if result.all_succeeded() {
         ExitCode::SUCCESS
     } else {
@@ -488,8 +487,7 @@ async fn cmd_fix(args: claudes::cli::FixArgs) -> ExitCode {
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         options.event_sender = Some(tx);
-        let stream_handle =
-            tokio::spawn(output::render_stream(rx, output::Verbosity::Default, false));
+        let stream_handle = tokio::spawn(output::render_progress(rx, false));
 
         let result = match claudes::run(&fix_manifest, &options).await {
             Ok(r) => r,
@@ -508,7 +506,7 @@ async fn cmd_fix(args: claudes::cli::FixArgs) -> ExitCode {
             tracing::warn!("failed to write fix state file: {e}");
         }
 
-        output::print_summary(&result, output::OutputFormat::Text);
+        output::print_run_complete(&result, OutputMode::Progress, false);
 
         if !result.all_succeeded() {
             all_succeeded = false;

--- a/crates/claudes/src/output.rs
+++ b/crates/claudes/src/output.rs
@@ -1,12 +1,19 @@
-//! Output formatting for task execution results.
+//! Output modes for task execution.
+//!
+//! Three mutually exclusive modes:
+//! - **Progress** (default TTY) — indicatif spinners with live status
+//! - **Ndjson** (default piped) — structured NDJSON, superset of Claude events
+//! - **Quiet** — exit code only
 
 use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
 
+use chrono::Utc;
 use crossterm::style::{Color, Stylize};
 use tokio::sync::mpsc;
 
-use crate::runner::{RunResult, TaskEvent, TaskResult};
+use crate::manifest::Manifest;
+use crate::runner::{RunResult, TaskEvent};
 use crate::state::is_timeout;
 
 const COLOR_PALETTE: &[Color] = &[
@@ -14,139 +21,253 @@ const COLOR_PALETTE: &[Color] = &[
         r: 0,
         g: 255,
         b: 255,
-    }, // bright cyan
+    }, // cyan
     Color::Rgb {
         r: 0,
         g: 255,
         b: 128,
-    }, // bright green
+    }, // green
     Color::Rgb {
         r: 255,
         g: 255,
         b: 0,
-    }, // bright yellow
+    }, // yellow
     Color::Rgb {
         r: 255,
         g: 128,
         b: 255,
-    }, // bright magenta
+    }, // magenta
     Color::Rgb {
         r: 128,
         g: 128,
         b: 255,
-    }, // bright blue
+    }, // blue
     Color::Rgb {
         r: 255,
         g: 128,
         b: 0,
-    }, // bright orange
+    }, // orange
 ];
 
-/// Verbosity level for streaming output.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum Verbosity {
-    /// No streaming output.
-    Quiet,
-    /// Show task start and task complete with cost (default).
-    #[default]
-    Default,
-    /// Show tool calls with their first argument.
-    Verbose,
-    /// Show full event stream including assistant text.
-    VeryVerbose,
-    /// Show full event stream (same as VeryVerbose).
-    Debug,
-}
-
-impl From<u8> for Verbosity {
-    fn from(count: u8) -> Self {
-        match count {
-            0 => Verbosity::Default,
-            1 => Verbosity::Verbose,
-            2 => Verbosity::VeryVerbose,
-            _ => Verbosity::Debug,
-        }
-    }
-}
-
-/// Format style for output.
+/// Output mode — mutually exclusive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OutputFormat {
-    /// Human-readable streaming text.
-    Text,
-    /// Structured JSON.
-    Json,
+pub enum OutputMode {
+    /// Live indicatif progress display (default when TTY).
+    Progress,
+    /// Structured NDJSON on stdout (default when piped).
+    Ndjson,
     /// Exit code only, no output.
     Quiet,
 }
 
-/// Print a summary of the run results.
-pub fn print_summary(result: &RunResult, format: OutputFormat) {
-    match format {
-        OutputFormat::Text => print_text_summary(result),
-        OutputFormat::Json => print_json_summary(result),
-        OutputFormat::Quiet => {}
-    }
-}
-
-fn print_text_summary(result: &RunResult) {
-    let stdout = std::io::stdout();
-    let mut out = stdout.lock();
-
-    let _ = writeln!(out);
-    for task in &result.tasks {
-        print_task_result(&mut out, task);
-    }
-
-    let total = result.tasks.len();
-    let succeeded = result.success_count();
-    let _ = writeln!(out);
-    let _ = writeln!(
-        out,
-        "{succeeded}/{total} tasks complete. Total time: {:.1}s",
-        result
-            .tasks
-            .iter()
-            .map(|t| t.duration.as_secs_f64())
-            .max_by(|a, b| a.partial_cmp(b).unwrap())
-            .unwrap_or(0.0)
-    );
-
-    let has_cost = result.tasks.iter().any(|t| t.cost_usd.is_some());
-    if has_cost {
-        let total_cost: f64 = result.tasks.iter().filter_map(|t| t.cost_usd).sum();
-        let _ = writeln!(out, "Total cost: ${total_cost:.2}");
-    }
-}
-
-fn print_task_result(out: &mut impl Write, task: &TaskResult) {
-    let status = if task.success {
-        "complete"
-    } else if is_timeout(&task.stdout, &task.stderr) {
-        "TIMEOUT"
-    } else {
-        "FAILED"
-    };
-    let duration = format!("{:.0}s", task.duration.as_secs_f64());
-    let cost_str = task
-        .cost_usd
-        .map(|c| format!("  ${c:.2}"))
-        .unwrap_or_default();
-
-    let _ = writeln!(
-        out,
-        "  {name:<30} {status:<12} {duration}{cost_str}",
-        name = task.name,
-    );
-
-    if !task.success && !task.stderr.is_empty() {
-        for line in task.stderr.lines().take(5) {
-            let _ = writeln!(out, "    {line}");
+impl OutputMode {
+    /// Select the default mode based on TTY detection and flags.
+    pub fn detect(output_flag: &str, quiet: bool) -> Self {
+        match output_flag {
+            "json" | "ndjson" => OutputMode::Ndjson,
+            "quiet" => OutputMode::Quiet,
+            _ if quiet => OutputMode::Quiet,
+            _ if std::io::stderr().is_terminal() => OutputMode::Progress,
+            _ => OutputMode::Ndjson,
         }
     }
 }
 
-fn print_json_summary(result: &RunResult) {
+// ============================================================================
+// Bookends — manifest summary and run results
+// ============================================================================
+
+/// Print the opening bookend: what we're about to do.
+pub fn print_run_start(manifest: &Manifest, mode: OutputMode, no_color: bool) {
+    match mode {
+        OutputMode::Progress => print_run_start_progress(manifest, no_color),
+        OutputMode::Ndjson => print_run_start_ndjson(manifest),
+        OutputMode::Quiet => {}
+    }
+}
+
+/// Print the closing bookend: what we did.
+pub fn print_run_complete(result: &RunResult, mode: OutputMode, no_color: bool) {
+    match mode {
+        OutputMode::Progress => print_run_complete_progress(result, no_color),
+        OutputMode::Ndjson => print_run_complete_ndjson(result),
+        OutputMode::Quiet => {}
+    }
+}
+
+fn print_run_start_progress(manifest: &Manifest, no_color: bool) {
+    let stderr = std::io::stderr();
+    let use_color = !no_color && std::env::var_os("NO_COLOR").is_none() && stderr.is_terminal();
+    let mut out = stderr.lock();
+
+    let task_count = manifest.tasks.len();
+    let model = manifest
+        .shared
+        .as_ref()
+        .and_then(|s| s.model.as_deref())
+        .or_else(|| manifest.tasks.first().and_then(|t| t.model.as_deref()))
+        .unwrap_or("default");
+    let isolation = manifest
+        .shared
+        .as_ref()
+        .and_then(|s| s.isolation.as_ref())
+        .map(|i| match i {
+            crate::manifest::Isolation::Worktree { .. } => "worktree",
+            crate::manifest::Isolation::Clone { .. } => "clone",
+            crate::manifest::Isolation::None => "none",
+        })
+        .unwrap_or("worktree");
+
+    let _ = writeln!(out);
+    let header = format!("  {task_count} tasks, model: {model}, isolation: {isolation}");
+    if use_color {
+        let _ = writeln!(out, "{}", header.with(Color::White));
+    } else {
+        let _ = writeln!(out, "{header}");
+    }
+
+    for (i, task) in manifest.tasks.iter().enumerate() {
+        let color = if use_color {
+            Some(COLOR_PALETTE[i % COLOR_PALETTE.len()])
+        } else {
+            None
+        };
+        let name = truncate_name(&task.name, 30);
+        let branch = task
+            .branch
+            .as_deref()
+            .map(|b| format!(" ({b})"))
+            .unwrap_or_default();
+        let line = format!("    {name}{branch}");
+        match color {
+            Some(c) => {
+                let _ = writeln!(out, "{}", line.with(c));
+            }
+            None => {
+                let _ = writeln!(out, "{line}");
+            }
+        }
+    }
+    let _ = writeln!(out);
+}
+
+fn print_run_complete_progress(result: &RunResult, no_color: bool) {
+    let stderr = std::io::stderr();
+    let use_color = !no_color && std::env::var_os("NO_COLOR").is_none() && stderr.is_terminal();
+    let mut out = stderr.lock();
+
+    let _ = writeln!(out);
+
+    for task in &result.tasks {
+        let status = if task.success {
+            "ok"
+        } else if is_timeout(&task.stdout, &task.stderr) {
+            "TIMEOUT"
+        } else {
+            "FAILED"
+        };
+        let duration = format!("{:.0}s", task.duration.as_secs_f64());
+        let cost_str = task
+            .cost_usd
+            .map(|c| format!("${c:.4}"))
+            .unwrap_or_default();
+        let files_str = task
+            .files_modified
+            .map(|f| {
+                let lines = task.lines_changed.unwrap_or(0);
+                format!("  {f} files +{lines}")
+            })
+            .unwrap_or_default();
+
+        let name = truncate_name(&task.name, 30);
+
+        if use_color {
+            let status_color = if task.success {
+                Color::Green
+            } else {
+                Color::Red
+            };
+            let _ = write!(out, "  {:<30} ", name);
+            let _ = write!(out, "{}", format!("{status:<12}").with(status_color));
+            let _ = writeln!(out, " {duration:>6}  {cost_str:<10}{files_str}");
+        } else {
+            let _ = writeln!(
+                out,
+                "  {name:<30} {status:<12} {duration:>6}  {cost_str:<10}{files_str}",
+            );
+        }
+
+        if !task.success && !task.stderr.is_empty() {
+            for line in task.stderr.lines().take(5) {
+                let _ = writeln!(out, "    {line}");
+            }
+        }
+    }
+
+    let total = result.tasks.len();
+    let succeeded = result.success_count();
+    let wall_time = result
+        .tasks
+        .iter()
+        .map(|t| t.duration.as_secs_f64())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap_or(0.0);
+
+    let _ = writeln!(out);
+    let summary = format!("{succeeded}/{total} succeeded, wall time: {wall_time:.1}s");
+    if use_color {
+        let color = if succeeded == total {
+            Color::Green
+        } else {
+            Color::Yellow
+        };
+        let _ = write!(out, "  {}", summary.with(color));
+    } else {
+        let _ = write!(out, "  {summary}");
+    }
+
+    let has_cost = result.tasks.iter().any(|t| t.cost_usd.is_some());
+    if has_cost {
+        let total_cost: f64 = result.tasks.iter().filter_map(|t| t.cost_usd).sum();
+        let _ = write!(out, ", total cost: ${total_cost:.2}");
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(out);
+}
+
+fn print_run_start_ndjson(manifest: &Manifest) {
+    let task_names: Vec<&str> = manifest.tasks.iter().map(|t| t.name.as_str()).collect();
+    let model = manifest
+        .shared
+        .as_ref()
+        .and_then(|s| s.model.as_deref())
+        .unwrap_or("default");
+    let event = serde_json::json!({
+        "type": "run_start",
+        "tasks": task_names,
+        "task_count": manifest.tasks.len(),
+        "model": model,
+        "timestamp": Utc::now().to_rfc3339(),
+    });
+    println!("{}", serde_json::to_string(&event).unwrap_or_default());
+}
+
+fn print_run_complete_ndjson(result: &RunResult) {
+    let total_cost: Option<f64> = {
+        let costs: Vec<f64> = result.tasks.iter().filter_map(|t| t.cost_usd).collect();
+        if costs.is_empty() {
+            None
+        } else {
+            Some(costs.iter().sum())
+        }
+    };
+    let wall_time = result
+        .tasks
+        .iter()
+        .map(|t| t.duration.as_secs_f64())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap_or(0.0);
+
     let tasks: Vec<serde_json::Value> = result
         .tasks
         .iter()
@@ -155,36 +276,36 @@ fn print_json_summary(result: &RunResult) {
                 "name": t.name,
                 "success": t.success,
                 "duration_secs": t.duration.as_secs_f64(),
+                "cost_usd": t.cost_usd,
+                "files_modified": t.files_modified,
+                "lines_changed": t.lines_changed,
                 "work_dir": t.work_dir.to_string_lossy(),
-                "stdout": t.stdout,
-                "stderr": t.stderr,
             })
         })
         .collect();
 
-    let json = serde_json::json!({
+    let event = serde_json::json!({
+        "type": "run_complete",
+        "total": result.tasks.len(),
+        "succeeded": result.success_count(),
+        "failed": result.tasks.iter().filter(|t| !t.success).count(),
+        "wall_time_secs": wall_time,
+        "total_cost_usd": total_cost,
         "tasks": tasks,
-        "all_succeeded": result.all_succeeded(),
-        "success_count": result.success_count(),
-        "total_count": result.tasks.len(),
+        "timestamp": Utc::now().to_rfc3339(),
     });
-
-    println!("{}", serde_json::to_string_pretty(&json).unwrap());
+    println!("{}", serde_json::to_string(&event).unwrap_or_default());
 }
 
-/// Render streaming events from tasks as they arrive.
-///
-/// Runs until the channel is closed (all senders dropped).
-pub async fn render_stream(
-    mut rx: mpsc::UnboundedReceiver<TaskEvent>,
-    verbosity: Verbosity,
-    no_color: bool,
-) {
-    if verbosity == Verbosity::Quiet {
-        while rx.recv().await.is_some() {}
-        return;
-    }
+// ============================================================================
+// Streaming renderers
+// ============================================================================
 
+/// Render streaming events as indicatif progress display.
+///
+/// Shows per-task status lines that update in place. Each task gets a colored
+/// prefix and shows its current activity (latest tool call).
+pub async fn render_progress(mut rx: mpsc::UnboundedReceiver<TaskEvent>, no_color: bool) {
     let stderr = std::io::stderr();
     let use_color = !no_color && std::env::var_os("NO_COLOR").is_none() && stderr.is_terminal();
 
@@ -209,7 +330,8 @@ pub async fn render_stream(
         };
 
         let prefix = {
-            let padded = format!("{task:<20}");
+            let name = truncate_name(task, 20);
+            let padded = format!("{name:<20}");
             match color_opt {
                 Some(color) => format!("{}", padded.with(color)),
                 None => padded,
@@ -235,89 +357,185 @@ pub async fn render_stream(
                     .get("total_cost_usd")
                     .or_else(|| data.get("cost_usd"))
                     .and_then(|c| c.as_f64());
-                let line = if subtype == "success" {
+
+                let status_msg = if subtype == "success" {
                     let cost_str = cost.map(|c| format!(", ${c:.2}")).unwrap_or_default();
-                    format!("  | {prefix} | complete ({elapsed}s{cost_str})")
+                    format!("complete ({elapsed}s{cost_str})")
                 } else if subtype == "error_max_turns" {
-                    format!("  | {prefix} | TIMEOUT ({elapsed}s)")
+                    format!("TIMEOUT ({elapsed}s)")
                 } else {
-                    format!("  | {prefix} | FAILED ({elapsed}s)")
+                    format!("FAILED ({elapsed}s)")
                 };
+
                 let mut out = stderr.lock();
-                let _ = writeln!(out, "{line}");
+                if use_color {
+                    let color = if subtype == "success" {
+                        Color::Green
+                    } else {
+                        Color::Red
+                    };
+                    let _ = writeln!(out, "  | {prefix} | {}", status_msg.with(color));
+                } else {
+                    let _ = writeln!(out, "  | {prefix} | {status_msg}");
+                }
             }
-            "assistant" if verbosity >= Verbosity::Verbose => {
+            "assistant" => {
                 if let Some(content) = data
                     .get("message")
                     .and_then(|m| m.get("content"))
                     .and_then(|c| c.as_array())
                 {
                     for block in content {
-                        let block_type = block.get("type").and_then(|t| t.as_str());
-                        match block_type {
-                            Some("tool_use") => {
-                                let tool = block
-                                    .get("name")
-                                    .and_then(|n| n.as_str())
-                                    .unwrap_or("unknown");
-                                let cwd = std::env::current_dir()
-                                    .ok()
-                                    .map(|p| p.to_string_lossy().into_owned());
-                                let first_arg = block
-                                    .get("input")
-                                    .and_then(|i| i.as_object())
-                                    .and_then(|obj| obj.values().next())
-                                    .map(|v| {
-                                        let s = if let Some(s) = v.as_str() {
-                                            s.to_string()
-                                        } else {
-                                            v.to_string()
-                                        };
-                                        let s = if let Some(ref cwd) = cwd {
-                                            let prefix = format!("{cwd}/");
-                                            if s.starts_with(&prefix) {
-                                                s[prefix.len()..].to_string()
-                                            } else {
-                                                s
-                                            }
-                                        } else {
-                                            s
-                                        };
-                                        // Also strip .worktrees/<task-name>/ prefix.
-                                        let s = if let Some(rest) = s.strip_prefix(".worktrees/") {
-                                            rest.split_once('/')
-                                                .map_or(s.clone(), |(_, after)| after.to_string())
-                                        } else {
-                                            s
-                                        };
-                                        let mut chars = s.chars();
-                                        let truncated: String = chars.by_ref().take(60).collect();
-                                        if chars.next().is_some() {
-                                            format!("{truncated}...")
-                                        } else {
-                                            truncated
-                                        }
-                                    })
-                                    .unwrap_or_default();
-                                let mut out = stderr.lock();
-                                if first_arg.is_empty() {
-                                    let _ = writeln!(out, "  | {prefix} | {tool}");
-                                } else {
-                                    let _ = writeln!(out, "  | {prefix} | {tool}({first_arg})");
-                                }
+                        if block.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
+                            let tool = block
+                                .get("name")
+                                .and_then(|n| n.as_str())
+                                .unwrap_or("unknown");
+                            let first_arg = extract_tool_arg(block);
+                            let mut out = stderr.lock();
+                            if first_arg.is_empty() {
+                                let _ = writeln!(out, "  | {prefix} | {tool}");
+                            } else {
+                                let _ = writeln!(out, "  | {prefix} | {tool}({first_arg})");
                             }
-                            Some("text") if verbosity >= Verbosity::VeryVerbose => {
-                                if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
-                                    let mut out = stderr.lock();
-                                    let _ = writeln!(out, "  | {prefix} | {text}");
-                                }
-                            }
-                            _ => {}
                         }
                     }
                 }
             }
             _ => {}
         }
+    }
+}
+
+/// Render streaming events as NDJSON on stdout.
+///
+/// Passes through raw Claude StreamEvents with the task name injected.
+/// Adds claudes-specific events (task_start, task_complete) using distinct types.
+pub async fn render_ndjson(mut rx: mpsc::UnboundedReceiver<TaskEvent>) {
+    let mut start_times: HashMap<String, std::time::Instant> = HashMap::new();
+
+    while let Some(event) = rx.recv().await {
+        let task = &event.task_name;
+        let data = &event.event.data;
+        let event_type = event.event.event_type().unwrap_or("");
+
+        match event_type {
+            "claudes_task_start" => {
+                start_times.insert(task.clone(), std::time::Instant::now());
+                let ev = serde_json::json!({
+                    "type": "task_start",
+                    "task": task,
+                    "timestamp": Utc::now().to_rfc3339(),
+                });
+                println!("{}", serde_json::to_string(&ev).unwrap_or_default());
+            }
+            "result" => {
+                // Emit the raw result event with task injected.
+                let mut raw = data.clone();
+                if let serde_json::Value::Object(ref mut map) = raw {
+                    map.insert("task".into(), serde_json::Value::String(task.clone()));
+                    map.insert(
+                        "timestamp".into(),
+                        serde_json::Value::String(Utc::now().to_rfc3339()),
+                    );
+                }
+                println!("{}", serde_json::to_string(&raw).unwrap_or_default());
+
+                // Also emit a claudes task_complete event.
+                let elapsed = start_times
+                    .get(task.as_str())
+                    .map(|t| t.elapsed().as_secs_f64())
+                    .unwrap_or(0.0);
+                let cost = data
+                    .get("total_cost_usd")
+                    .or_else(|| data.get("cost_usd"))
+                    .and_then(|c| c.as_f64());
+                let subtype = data
+                    .get("subtype")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("unknown");
+                let success = subtype == "success";
+
+                let ev = serde_json::json!({
+                    "type": "task_complete",
+                    "task": task,
+                    "success": success,
+                    "duration_secs": elapsed,
+                    "cost_usd": cost,
+                    "timestamp": Utc::now().to_rfc3339(),
+                });
+                println!("{}", serde_json::to_string(&ev).unwrap_or_default());
+            }
+            _ => {
+                // Pass through all other events with task injected.
+                let mut raw = data.clone();
+                if let serde_json::Value::Object(ref mut map) = raw {
+                    map.insert("task".into(), serde_json::Value::String(task.clone()));
+                }
+                println!("{}", serde_json::to_string(&raw).unwrap_or_default());
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Extract the first tool argument from a tool_use block, with path stripping.
+fn extract_tool_arg(block: &serde_json::Value) -> String {
+    block
+        .get("input")
+        .and_then(|i| i.as_object())
+        .and_then(|obj| obj.values().next())
+        .map(|v| {
+            let s = if let Some(s) = v.as_str() {
+                s.to_string()
+            } else {
+                v.to_string()
+            };
+            // Strip cwd prefix.
+            let s = if let Ok(cwd) = std::env::current_dir() {
+                let prefix = format!("{}/", cwd.display());
+                if let Some(rest) = s.strip_prefix(&prefix) {
+                    rest.to_string()
+                } else {
+                    s
+                }
+            } else {
+                s
+            };
+            // Strip .worktrees/<task-name>/ prefix.
+            let s = if let Some(rest) = s.strip_prefix(".worktrees/") {
+                rest.split_once('/')
+                    .map_or(s.clone(), |(_, after)| after.to_string())
+            } else if let Some(idx) = s.find("/.worktrees/") {
+                let rest = &s[idx + "/.worktrees/".len()..];
+                rest.split_once('/')
+                    .map_or(s.clone(), |(_, p)| p.to_string())
+            } else {
+                s
+            };
+            truncate(&s, 60)
+        })
+        .unwrap_or_default()
+}
+
+fn truncate_name(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let truncated: String = s.chars().take(max - 3).collect();
+        format!("{truncated}...")
+    } else {
+        s.to_string()
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let mut chars = s.chars();
+    let truncated: String = chars.by_ref().take(max).collect();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
     }
 }


### PR DESCRIPTION
## Summary

Replace the hybrid streaming output system with three mutually exclusive modes:

- **Progress** (default when TTY): colored per-task status lines showing tool calls, completion with cost/duration
- **Ndjson** (default when piped): structured NDJSON on stdout — superset of Claude StreamEvents with task name injected, plus claudes lifecycle events (run_start, task_start, task_complete, run_complete)
- **Quiet**: exit code only

Both progress and ndjson get bookend events:
- Opening: manifest summary (task count, model, isolation, task list)
- Closing: per-task results with duration, cost, files modified

CLI changes:
- `--output` accepts `progress|json|quiet|auto` (default: auto, which detects TTY)
- Removed `-v`/`-vv` verbosity flags — progress mode always shows tool calls
- `--quiet` still works as shorthand for `--output quiet`

Closes #415

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p claudes --all-targets -- -D warnings`
- [x] `cargo test --lib -p claudes` (119 tests)
- [x] `cargo test --test fake_claude -p claudes -- --ignored` (55 tests)