### PR TITLE
feat(claudes): in-place indicatif spinners for progress mode

### DIFF
--- a/crates/claudes/Cargo.toml
+++ b/crates/claudes/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = { workspace = true }
 tower-mcp = { workspace = true }
 schemars = { workspace = true }
 crossterm = "0.28"
+indicatif = "0.17"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -213,18 +213,17 @@ async fn execute_manifest(
     // Opening bookend: what we're about to do.
     output::print_run_start(manifest, mode, args.no_color);
 
-    // Set up streaming renderer.
+    // Always create event sender so streaming/tracing works in all modes.
     let mut options = options.clone();
-    let stream_handle = if mode != OutputMode::Quiet {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        options.event_sender = Some(tx);
-        Some(match mode {
-            OutputMode::Progress => tokio::spawn(output::render_progress(rx, args.no_color)),
-            OutputMode::Ndjson => tokio::spawn(output::render_ndjson(rx)),
-            OutputMode::Quiet => unreachable!(),
-        })
-    } else {
-        None
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    options.event_sender = Some(tx);
+    let stream_handle = match mode {
+        OutputMode::Progress => tokio::spawn(output::render_progress(rx, args.no_color)),
+        OutputMode::Ndjson => tokio::spawn(output::render_ndjson(rx)),
+        OutputMode::Quiet => tokio::spawn(async move {
+            let mut rx = rx;
+            while rx.recv().await.is_some() {}
+        }),
     };
 
     let result = match claudes::run(manifest, &options).await {
@@ -237,9 +236,7 @@ async fn execute_manifest(
 
     // Drop the sender so the renderer finishes.
     options.event_sender = None;
-    if let Some(handle) = stream_handle {
-        let _ = handle.await;
-    }
+    let _ = stream_handle.await;
 
     // Write state file.
     let state = claudes::state::build_state(manifest, &result, started_at);

--- a/crates/claudes/src/output.rs
+++ b/crates/claudes/src/output.rs
@@ -301,82 +301,137 @@ fn print_run_complete_ndjson(result: &RunResult) {
 // Streaming renderers
 // ============================================================================
 
-/// Render streaming events as indicatif progress display.
+/// Render streaming events as in-place indicatif progress bars.
 ///
-/// Shows per-task status lines that update in place. Each task gets a colored
-/// prefix and shows its current activity (latest tool call).
+/// Each task gets a spinner that updates in place showing elapsed time and
+/// current activity (latest tool call). On completion the spinner is replaced
+/// with a final status line. No scrolling — everything updates in place.
 pub async fn render_progress(mut rx: mpsc::UnboundedReceiver<TaskEvent>, no_color: bool) {
+    use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
     let stderr = std::io::stderr();
     let use_color = !no_color && std::env::var_os("NO_COLOR").is_none() && stderr.is_terminal();
 
-    let mut color_map: HashMap<String, Color> = HashMap::new();
+    let mp = MultiProgress::new();
+    let mut bars: HashMap<String, ProgressBar> = HashMap::new();
     let mut color_index: usize = 0;
-    let mut start_times: HashMap<String, std::time::Instant> = HashMap::new();
+    let mut color_map: HashMap<String, Color> = HashMap::new();
+    let mut total_tasks: usize = 0;
+    let mut completed_tasks: usize = 0;
+    let mut total_cost: f64 = 0.0;
+
+    let spinner_style =
+        ProgressStyle::with_template("  {spinner:.cyan} {prefix:<22} {elapsed:>5}  {msg}")
+            .unwrap()
+            .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
+
+    // Gap between task spinners and footer.
+    let gap = mp.add(ProgressBar::new_spinner());
+    gap.set_style(ProgressStyle::with_template(" ").unwrap());
+    gap.finish();
+
+    // Footer bar — shows aggregate progress.
+    let footer = mp.add(ProgressBar::new_spinner());
+
+    // Spacer bar — just a blank line below the footer for breathing room.
+    let spacer = mp.add(ProgressBar::new_spinner());
+    spacer.set_style(ProgressStyle::with_template(" ").unwrap());
+    spacer.finish();
+    footer.enable_steady_tick(std::time::Duration::from_millis(500));
 
     while let Some(event) = rx.recv().await {
         let task = &event.task_name;
         let data = &event.event.data;
         let event_type = event.event.event_type().unwrap_or("");
 
-        let color_opt = if use_color {
-            if !color_map.contains_key(task.as_str()) {
-                let c = COLOR_PALETTE[color_index % COLOR_PALETTE.len()];
-                color_map.insert(task.clone(), c);
-                color_index += 1;
-            }
-            color_map.get(task.as_str()).copied()
-        } else {
-            None
-        };
+        // Assign a color for this task.
+        if use_color && !color_map.contains_key(task.as_str()) {
+            let c = COLOR_PALETTE[color_index % COLOR_PALETTE.len()];
+            color_map.insert(task.clone(), c);
+            color_index += 1;
+        }
 
-        let prefix = {
-            let name = truncate_name(task, 20);
-            let padded = format!("{name:<20}");
-            match color_opt {
-                Some(color) => format!("{}", padded.with(color)),
-                None => padded,
-            }
-        };
+        let task_prefix = truncate_name(task, 20);
 
         match event_type {
             "claudes_task_start" => {
-                start_times.insert(task.clone(), std::time::Instant::now());
-                let mut out = stderr.lock();
-                let _ = writeln!(out, "  | {prefix} | starting");
+                total_tasks += 1;
+                let pb = mp.insert_before(&gap, ProgressBar::new_spinner());
+                pb.set_style(spinner_style.clone());
+                pb.set_prefix(task_prefix);
+                pb.set_message("starting");
+                pb.enable_steady_tick(std::time::Duration::from_millis(100));
+                bars.insert(task.clone(), pb);
+                footer.set_message(format!("{completed_tasks}/{total_tasks} complete"));
             }
             "result" => {
                 let subtype = data
                     .get("subtype")
                     .and_then(|s| s.as_str())
                     .unwrap_or("unknown");
-                let elapsed = start_times
-                    .get(task.as_str())
-                    .map(|t| t.elapsed().as_secs())
-                    .unwrap_or(0);
                 let cost = data
                     .get("total_cost_usd")
                     .or_else(|| data.get("cost_usd"))
                     .and_then(|c| c.as_f64());
 
-                let status_msg = if subtype == "success" {
-                    let cost_str = cost.map(|c| format!(", ${c:.2}")).unwrap_or_default();
-                    format!("complete ({elapsed}s{cost_str})")
-                } else if subtype == "error_max_turns" {
-                    format!("TIMEOUT ({elapsed}s)")
-                } else {
-                    format!("FAILED ({elapsed}s)")
-                };
+                if let Some(pb) = bars.get(task.as_str()) {
+                    let elapsed = format!("{:.0}s", pb.elapsed().as_secs_f64());
+                    let cost_str = cost.map(|c| format!("  ${c:.2}")).unwrap_or_default();
 
-                let mut out = stderr.lock();
-                if use_color {
-                    let color = if subtype == "success" {
-                        Color::Green
+                    if subtype == "success" {
+                        let msg = format!("ok  {elapsed}{cost_str}");
+                        let finish = if use_color {
+                            format!(
+                                "  {}  {:<22} {}",
+                                "✓".with(Color::Green),
+                                task_prefix
+                                    .with(*color_map.get(task.as_str()).unwrap_or(&Color::White)),
+                                msg.with(Color::Green)
+                            )
+                        } else {
+                            format!("  ✓  {task_prefix:<22} {msg}")
+                        };
+                        pb.finish_with_message("");
+                        pb.set_style(ProgressStyle::with_template("{msg}").unwrap());
+                        pb.finish_with_message(finish);
                     } else {
-                        Color::Red
-                    };
-                    let _ = writeln!(out, "  | {prefix} | {}", status_msg.with(color));
+                        let status = if subtype == "error_max_turns" {
+                            "TIMEOUT"
+                        } else {
+                            "FAILED"
+                        };
+                        let msg = format!("{status}  {elapsed}");
+                        let finish = if use_color {
+                            format!(
+                                "  {}  {:<22} {}",
+                                "✗".with(Color::Red),
+                                task_prefix
+                                    .with(*color_map.get(task.as_str()).unwrap_or(&Color::White)),
+                                msg.with(Color::Red)
+                            )
+                        } else {
+                            format!("  ✗  {task_prefix:<22} {msg}")
+                        };
+                        pb.finish_with_message("");
+                        pb.set_style(ProgressStyle::with_template("{msg}").unwrap());
+                        pb.finish_with_message(finish);
+                    }
+                }
+
+                completed_tasks += 1;
+                if let Some(c) = cost {
+                    total_cost += c;
+                }
+                let cost_msg = if total_cost > 0.0 {
+                    format!("  ${total_cost:.2}")
                 } else {
-                    let _ = writeln!(out, "  | {prefix} | {status_msg}");
+                    String::new()
+                };
+                footer.set_message(format!(
+                    "{completed_tasks}/{total_tasks} complete{cost_msg}"
+                ));
+                if completed_tasks == total_tasks {
+                    footer.finish_with_message("");
                 }
             }
             "assistant" => {
@@ -392,11 +447,13 @@ pub async fn render_progress(mut rx: mpsc::UnboundedReceiver<TaskEvent>, no_colo
                                 .and_then(|n| n.as_str())
                                 .unwrap_or("unknown");
                             let first_arg = extract_tool_arg(block);
-                            let mut out = stderr.lock();
-                            if first_arg.is_empty() {
-                                let _ = writeln!(out, "  | {prefix} | {tool}");
+                            let msg = if first_arg.is_empty() {
+                                tool.to_string()
                             } else {
-                                let _ = writeln!(out, "  | {prefix} | {tool}({first_arg})");
+                                format!("{tool}({first_arg})")
+                            };
+                            if let Some(pb) = bars.get(task.as_str()) {
+                                pb.set_message(msg);
                             }
                         }
                     }

--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -185,7 +185,20 @@ pub async fn run(manifest: &Manifest, options: &RunOptions) -> Result<RunResult>
         warn!("failed to write running indicator: {e}");
     }
 
-    info!(tasks = manifest.tasks.len(), "executing manifest");
+    let task_names: Vec<&str> = manifest.tasks.iter().map(|t| t.name.as_str()).collect();
+    let model = manifest
+        .shared
+        .as_ref()
+        .and_then(|s| s.model.as_deref())
+        .or_else(|| manifest.tasks.first().and_then(|t| t.model.as_deref()))
+        .unwrap_or("default");
+    info!(
+        tasks = manifest.tasks.len(),
+        model = model,
+        task_names = ?task_names,
+        project_dir = %options.project_dir.display(),
+        "executing manifest"
+    );
 
     let mut join_set = JoinSet::new();
 
@@ -235,7 +248,26 @@ pub async fn run(manifest: &Manifest, options: &RunOptions) -> Result<RunResult>
         }
     }
 
-    Ok(RunResult { tasks: results })
+    let result = RunResult { tasks: results };
+
+    let wall_time = result
+        .tasks
+        .iter()
+        .map(|t| t.duration.as_secs_f64())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap_or(0.0);
+    let total_cost: f64 = result.tasks.iter().filter_map(|t| t.cost_usd).sum();
+
+    info!(
+        total = result.tasks.len(),
+        succeeded = result.success_count(),
+        failed = result.tasks.len() - result.success_count(),
+        wall_time_secs = format!("{wall_time:.1}"),
+        total_cost_usd = format!("{total_cost:.4}"),
+        "run complete"
+    );
+
+    Ok(result)
 }
 
 /// Execute a single task.
@@ -286,12 +318,30 @@ async fn run_task_impl(task: &Task, options: &RunOptions) -> TaskResult {
             // Get file stats from git diff in the worktree.
             let (files_modified, lines_changed) = parse_git_diff_stat(&env.work_dir).await;
 
+            let duration = start.elapsed();
+            let success = output.success;
+            if success {
+                info!(
+                    task = task_name,
+                    duration_secs = format!("{:.1}", duration.as_secs_f64()),
+                    cost_usd = cost_usd.unwrap_or(0.0),
+                    files_modified = files_modified.unwrap_or(0),
+                    "task complete"
+                );
+            } else {
+                error!(
+                    task = task_name,
+                    duration_secs = format!("{:.1}", duration.as_secs_f64()),
+                    "task failed"
+                );
+            }
+
             TaskResult {
                 name: task_name,
-                success: output.success,
+                success,
                 stdout: output.stdout,
                 stderr: output.stderr,
-                duration: start.elapsed(),
+                duration,
                 work_dir: env.work_dir,
                 cost_usd,
                 files_modified,
@@ -474,6 +524,46 @@ async fn run_task_inner(
                 }
             }
 
+            // Log stream events at DEBUG level.
+            match event.event_type() {
+                Some("assistant") => {
+                    if let Some(content) = event
+                        .data
+                        .get("message")
+                        .and_then(|m| m.get("content"))
+                        .and_then(|c| c.as_array())
+                    {
+                        for block in content {
+                            if block.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
+                                let tool = block
+                                    .get("name")
+                                    .and_then(|n| n.as_str())
+                                    .unwrap_or("unknown");
+                                tracing::debug!(task = task_name, tool = tool, "tool call");
+                            }
+                        }
+                    }
+                }
+                Some("rate_limit_event") => {
+                    tracing::debug!(task = task_name, "rate limited");
+                }
+                Some("result") => {
+                    let cost = event.cost_usd();
+                    let subtype = event
+                        .data
+                        .get("subtype")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("unknown");
+                    tracing::debug!(
+                        task = task_name,
+                        subtype = subtype,
+                        cost_usd = cost,
+                        "session result"
+                    );
+                }
+                _ => {}
+            }
+
             // Accumulate cost from stream events.
             if let Some(cost) = event.cost_usd() {
                 stream_cost = Some(cost);
@@ -574,6 +664,7 @@ async fn run_hook(
     kind: &str,
 ) -> Result<()> {
     info!(task = task_name, hook = hook, "running {kind} hook");
+    let start = std::time::Instant::now();
     let output = tokio::process::Command::new("sh")
         .arg("-c")
         .arg(hook)
@@ -584,13 +675,31 @@ async fn run_hook(
             name: task_name.to_owned(),
             message: format!("{kind} hook '{hook}' failed to spawn: {e}"),
         })?;
+    let exit_code = output.status.code().unwrap_or(-1);
+    let duration_ms = start.elapsed().as_millis();
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        error!(
+            task = task_name,
+            hook = hook,
+            kind = kind,
+            exit_code = exit_code,
+            duration_ms = duration_ms,
+            "{kind} hook failed"
+        );
         return Err(Error::TaskFailed {
             name: task_name.to_owned(),
             message: format!("{kind} hook '{hook}' exited non-zero: {stderr}"),
         });
     }
+    tracing::debug!(
+        task = task_name,
+        hook = hook,
+        kind = kind,
+        exit_code = exit_code,
+        duration_ms = duration_ms,
+        "{kind} hook succeeded"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #418. Replace scrolling text output in progress mode with indicatif `MultiProgress`:

- Each task gets a spinner that updates in place with elapsed time and current tool call
- On completion, spinner snaps to checkmark (green) or cross (red) with final status
- No scrolling during execution — everything updates in place
- Adds `indicatif = "0.17"` dependency

## Test plan

- [x] `cargo clippy -p claudes --all-targets -- -D warnings`
- [x] `cargo test --lib -p claudes` (123 tests)
- [x] Manual: progress mode shows in-place spinners