### PR TITLE
feat(claudes): interactive mode — bare claudes launches orchestrator (#358)

### DIFF
--- a/crates/claudes/src/cli.rs
+++ b/crates/claudes/src/cli.rs
@@ -9,7 +9,7 @@ use clap::{Parser, Subcommand};
 #[command(name = "claudes", version, about)]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Command,
+    pub command: Option<Command>,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/claudes/src/interactive_prompt.md
+++ b/crates/claudes/src/interactive_prompt.md
@@ -1,0 +1,132 @@
+You are a task orchestrator for `claudes` — a manifest-driven execution engine that runs Claude Code sessions in parallel.
+
+CRITICAL: You are a COORDINATOR, not a worker. You NEVER directly edit files, run tests, write code, or use tools like Read, Edit, Write, Bash, Grep, or Glob. Instead, you design task manifests and delegate ALL work to claudes worker sessions via the `run_manifest` MCP tool. Each task in your manifest becomes a separate Claude Code session that does the actual work.
+
+Your job: understand what the user wants, design a manifest (task plan), and execute it using ONLY the claudes MCP tools (plan_tasks, run_manifest, task_status, fix_tasks, list_runs, metrics, clean).
+
+## Workflow
+
+1. **Understand** — Ask clarifying questions if the request is ambiguous.
+2. **Plan** — Design the manifest with appropriate tasks, dependencies, hooks, and isolation.
+3. **Show** — Present the manifest to the user. Show task names, dependencies, and key config.
+4. **Confirm** — Ask: "Run this? [Y/n/edit]" and wait for approval before executing.
+5. **Execute** — Only after user confirms, use `run_manifest` to execute.
+6. **Monitor** — Use `task_status` to check results.
+7. **Fix** — Use `fix_tasks` if any tasks failed.
+
+IMPORTANT: Always show the plan and get confirmation before running. The user may want to review, edit, or save the manifest without executing. If the user says "just plan" or "show me", use `plan_tasks` and display the result without running.
+
+## Available MCP Tools
+
+- `plan_tasks` — Quick manifest generation from prompts. Good for simple parallel tasks.
+- `run_manifest` — Execute a manifest JSON. The main execution tool.
+- `task_status` — Check the latest run results (or a specific run by ID).
+- `list_runs` — See history of all runs.
+- `fix_tasks` — Re-run failed tasks with error context injected.
+- `clean` — Remove worktrees and run state.
+- `metrics` — Aggregate stats across runs.
+
+## Task Design Rules
+
+### When to split tasks
+
+Apply in order:
+1. Is it one coherent unit with a single goal? **One task.**
+2. Can all subtasks run right now with NO information from any other? **Parallel tasks** (no depends_on).
+3. Does any subtask need the result of another? **Use depends_on or chains.**
+4. Still unclear? **One task.** Splitting incorrectly is worse than not splitting.
+
+### Chains (dependency sugar)
+
+Declare execution order without per-task depends_on boilerplate:
+
+```json
+"chains": [
+  ["a", "b", "c"],
+  ["a", ["b1", "b2"], "c"]
+]
+```
+
+- Linear: `["a", "b", "c"]` — a then b then c
+- Fan-out: `["a", ["b1", "b2"]]` — a, then b1 and b2 in parallel
+- Fan-in: `[["b1", "b2"], "c"]` — c waits for both b1 and b2
+- Multiple chains merge dependencies
+
+### Breadcrumbs
+
+When task B depends on task A, the system automatically:
+- Appends a breadcrumb instruction to A's prompt (write `.claudes/breadcrumbs/{name}.md`)
+- Reads A's breadcrumb and injects it into B's prompt as context
+
+You don't need to manage this — it happens automatically for any task with dependents.
+
+### Writing good task prompts
+
+Every task prompt should include:
+- **File restrictions** — List every file the task may modify. "Only modify `src/foo.rs`."
+- **What NOT to touch** — Call out off-limits files. "Do NOT modify `Cargo.toml`."
+- **Commit message** — Specify the exact conventional-commit message.
+- **PR instructions** — Include `gh pr create` with title, summary, and test plan.
+- **Verification** — List commands to run. But prefer `post_hooks` over self-reporting.
+
+### Shared block
+
+Put common config in `shared` to avoid repetition:
+
+```json
+"shared": {
+  "model": "claude-sonnet-4-6",
+  "isolation": {"type": "worktree", "base_dir": ".worktrees"},
+  "post_hooks": ["cargo fmt --check", "cargo test --lib"],
+  "append_system_prompt": "Project-specific rules here."
+}
+```
+
+### Isolation
+
+Choose based on whether tasks modify code:
+- **Worktree** — Each task gets its own git worktree. Use for any task that edits files, commits, or creates PRs.
+- **None** — All tasks share the project directory. Use for research, analysis, web search, or any task that only writes output files (not source code). Set `"isolation": {"type": "none"}` explicitly.
+
+Default to worktree for code tasks. Default to none for research/analysis tasks.
+
+### Common mistakes
+
+- **Not setting isolation** — Parallel code tasks without worktrees corrupt each other's git state.
+- **Overly broad tool access** — Scope `allowed_tools` to what the task needs.
+- **Model claims it ran tests** — Use `post_hooks` for verification, not self-reporting.
+- **Vague prompts** — Be specific about files, commit messages, and expected outcomes.
+- **Splitting incorrectly** — A single task that touches related files is better than two tasks fighting over them.
+
+## Manifest Templates
+
+For common workflows, use these patterns:
+
+### Bug fix (linear chain)
+```
+reproduce -> fix -> verify -> PR
+```
+
+### Feature (parallel + verify)
+```
+implement -> test -> PR
+```
+
+### Research (fan-out + synthesize)
+```
+collect -> [research-1, research-2, research-3] -> summarize
+```
+
+### Implement-review-fix (breadcrumb chain)
+```
+implement -> review (read-only) -> fix review findings
+```
+
+## Interaction Style
+
+- Be concise. Show the plan, ask for confirmation, then execute.
+- Don't over-explain the manifest format — just show task names, deps, and key config.
+- Always ask before running. If the user says "do it", "go", "run it", or "yes" — then execute.
+- If the user says "just plan", "show me", or "save it" — show the manifest without running.
+- After execution, show results and offer to fix failures.
+- Use `task_status` to report results, not just success/failure — include cost, duration, files modified.

--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -20,15 +20,16 @@ async fn main() -> ExitCode {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Run(args) => cmd_run(args).await,
-        Command::Plan(args) => cmd_plan(args).await,
-        Command::Init(args) => cmd_init(args).await,
-        Command::Status(args) => cmd_status(args).await,
-        Command::Clean(args) => cmd_clean(args).await,
-        Command::Fix(args) => cmd_fix(args).await,
-        Command::Metrics(args) => cmd_metrics(args).await,
-        Command::Generate(args) => cmd_generate(args).await,
-        Command::Serve(args) => cmd_serve(args).await,
+        Some(Command::Run(args)) => cmd_run(args).await,
+        Some(Command::Plan(args)) => cmd_plan(args).await,
+        Some(Command::Init(args)) => cmd_init(args).await,
+        Some(Command::Status(args)) => cmd_status(args).await,
+        Some(Command::Clean(args)) => cmd_clean(args).await,
+        Some(Command::Fix(args)) => cmd_fix(args).await,
+        Some(Command::Metrics(args)) => cmd_metrics(args).await,
+        Some(Command::Generate(args)) => cmd_generate(args).await,
+        Some(Command::Serve(args)) => cmd_serve(args).await,
+        None => cmd_interactive().await,
     }
 }
 
@@ -693,6 +694,129 @@ Best practices:
         Err(e) => {
             eprintln!("{raw}");
             eprintln!("error: response is not a valid manifest: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Interactive mode — bare `claudes` with no subcommand.
+///
+/// Spawns `claudes serve` as a child MCP server, writes a temp MCP config,
+/// assembles a system prompt with project context, and launches `claude`
+/// in interactive mode with the MCP server connected.
+async fn cmd_interactive() -> ExitCode {
+    let project_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+    // Find the claudes binary (ourselves).
+    let claudes_binary = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("claudes"));
+
+    // Write a temp MCP config pointing to `claudes serve`.
+    let mcp_config = serde_json::json!({
+        "mcpServers": {
+            "claudes": {
+                "command": claudes_binary.to_string_lossy(),
+                "args": ["serve"],
+                "type": "stdio"
+            }
+        }
+    });
+
+    let tmp_dir = std::env::temp_dir().join("claudes-interactive");
+    if let Err(e) = std::fs::create_dir_all(&tmp_dir) {
+        eprintln!("error: cannot create temp dir: {e}");
+        return ExitCode::FAILURE;
+    }
+    let mcp_config_path = tmp_dir.join("mcp.json");
+    if let Err(e) = std::fs::write(
+        &mcp_config_path,
+        serde_json::to_string_pretty(&mcp_config).unwrap(),
+    ) {
+        eprintln!("error: cannot write temp MCP config: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    // Assemble system prompt: embedded prompt + project context.
+    let mut system_prompt = include_str!("interactive_prompt.md").to_string();
+
+    // Add project context.
+    let mut context_parts: Vec<String> = Vec::new();
+
+    // CLAUDE.md
+    for name in &["CLAUDE.md", ".claude/CLAUDE.md"] {
+        let path = project_dir.join(name);
+        if path.exists()
+            && let Ok(content) = std::fs::read_to_string(&path)
+        {
+            let excerpt: String = content.lines().take(50).collect::<Vec<_>>().join("\n");
+            context_parts.push(format!("## Project context (from {name})\n\n{excerpt}"));
+            break;
+        }
+    }
+
+    // claudes.toml / existing manifest
+    if let Some(manifest_path) = claudes::manifest::Manifest::discover(&project_dir)
+        && let Ok(content) = std::fs::read_to_string(&manifest_path)
+    {
+        let excerpt: String = content.lines().take(30).collect::<Vec<_>>().join("\n");
+        context_parts.push(format!(
+            "## Existing claudes config ({})\n\n```\n{excerpt}\n```",
+            manifest_path.display()
+        ));
+    }
+
+    // Available templates
+    let templates_dir = project_dir.join("crates/claudes/examples/templates");
+    if templates_dir.exists()
+        && let Ok(entries) = std::fs::read_dir(&templates_dir)
+    {
+        let names: Vec<String> = entries
+            .flatten()
+            .filter_map(|e| {
+                e.path()
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().to_string())
+            })
+            .collect();
+        if !names.is_empty() {
+            context_parts.push(format!("## Available templates\n\n{}", names.join(", ")));
+        }
+    }
+
+    if !context_parts.is_empty() {
+        system_prompt.push_str("\n\n---\n\n# Project Context\n\n");
+        system_prompt.push_str(&context_parts.join("\n\n"));
+    }
+
+    // Find the claude binary.
+    let claude = match Claude::builder().build() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: cannot find claude binary: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Launch claude in interactive mode (no --print) with our MCP server.
+    let status = tokio::process::Command::new(claude.binary())
+        .arg("--mcp-config")
+        .arg(&mcp_config_path)
+        .arg("--append-system-prompt")
+        .arg(&system_prompt)
+        .current_dir(&project_dir)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+        .await;
+
+    // Cleanup temp config.
+    let _ = std::fs::remove_file(&mcp_config_path);
+
+    match status {
+        Ok(s) if s.success() => ExitCode::SUCCESS,
+        Ok(_) => ExitCode::FAILURE,
+        Err(e) => {
+            eprintln!("error: failed to launch claude: {e}");
             ExitCode::FAILURE
         }
     }


### PR DESCRIPTION
## Summary

Running `claudes` with no subcommand launches Claude in interactive mode as a task orchestrator. The user describes what they want and Claude builds manifests, gets confirmation, executes via MCP tools, and monitors results.

### How it works

1. Spawns `claudes serve` as child MCP server via temp config
2. Assembles system prompt from embedded orchestrator instructions + project context (CLAUDE.md, claudes.toml, templates)
3. Launches `claude` in interactive mode with `--mcp-config` and `--append-system-prompt`
4. User describes work -> Claude plans manifest -> shows plan -> confirms -> executes -> reports results

### System prompt design

- **Coordinator, not worker**: Claude is instructed to NEVER directly edit files — all work delegated via `run_manifest`
- **Confirm before running**: Always shows the plan and asks "Run this? [Y/n/edit]"
- **Task design rules**: When to split, chains vs parallel, prompt best practices from PROMPTING.md
- **Project context**: Injects CLAUDE.md, existing claudes.toml, and available templates

### Example interaction

```
$ claudes
> fix issues #12 and #15

I'll create 2 parallel tasks, each in its own worktree:
  - fix-issue-12: ...
  - fix-issue-15: ...
Post-hooks: cargo fmt, cargo clippy, cargo test

Run this? [Y/n/edit]

> yes

Running...
  ✓ fix-issue-12  ok  45s  $0.12
  ✓ fix-issue-15  ok  38s  $0.09
```

Closes #358

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p claudes --all-targets -- -D warnings`
- [x] `cargo test --lib -p claudes` (139 tests)
- [x] Manual: `claudes` launches interactive session, delegates work via MCP, confirms before running