### PR TITLE
fix(ci): add checks:write permission for security audit

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,5 +1,9 @@
 name: Dependencies
 
+permissions:
+  checks: write
+  contents: read
+
 on:
   schedule:
     - cron: "0 3 * * 1"


### PR DESCRIPTION
## Summary

The `rustsec/audit-check` action needs `checks: write` permission to create check runs. Without it, PRs from automation-created branches fail with `Resource not accessible by integration`.

## Test plan

- [ ] CI passes on this PR