### PR TITLE
fix(claudes): desugar chains before checking file overlaps

### DIFF
--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -78,6 +78,7 @@ async fn cmd_run(args: claudes::cli::RunArgs) -> ExitCode {
             return ExitCode::FAILURE;
         }
 
+        manifest.desugar_chains();
         for warning in manifest.check_file_overlaps() {
             eprintln!("warning: {warning}");
         }
@@ -154,6 +155,7 @@ async fn cmd_run(args: claudes::cli::RunArgs) -> ExitCode {
                 return ExitCode::FAILURE;
             }
 
+            manifest.desugar_chains();
             for warning in manifest.check_file_overlaps() {
                 eprintln!("warning: {warning}");
             }
@@ -212,6 +214,7 @@ async fn cmd_run(args: claudes::cli::RunArgs) -> ExitCode {
             .extend(args.skill.iter().cloned());
     }
 
+    manifest.desugar_chains();
     for warning in manifest.check_file_overlaps() {
         eprintln!("warning: {warning}");
     }

--- a/crates/claudes/src/manifest.rs
+++ b/crates/claudes/src/manifest.rs
@@ -2503,6 +2503,28 @@ prompt = "do it"
     }
 
     #[test]
+    fn check_file_overlaps_suppressed_when_chain_declares_dependency() {
+        // tasks a and b both touch src/lib.rs, but are sequenced via chains.
+        // Without desugar_chains first, check_file_overlaps would emit a warning.
+        let mut manifest = Manifest::new(vec![
+            Task::new("task-a", "Fix the bug in src/lib.rs"),
+            Task::new("task-b", "Add tests in src/lib.rs"),
+        ]);
+        manifest.chains = Some(vec![vec![
+            ChainStep::Single("task-a".into()),
+            ChainStep::Single("task-b".into()),
+        ]]);
+
+        // Desugar first — this is the ordering fix from issue #442.
+        manifest.desugar_chains();
+        let warnings = manifest.check_file_overlaps();
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings for chain-sequenced tasks, got: {warnings:?}"
+        );
+    }
+
+    #[test]
     fn deserialize_json_without_created_at_uses_default() {
         let json = r#"{
             "version": 1,


### PR DESCRIPTION
## Summary

- Calls `desugar_chains()` before `check_file_overlaps()` at all three call sites in `main.rs`
- Fixes false-positive overlap warnings for tasks sequenced via `chains` (not explicit `depends_on`)
- Adds a test verifying chain-declared dependencies suppress overlap warnings

Closes #442

## Files changed

- `crates/claudes/src/main.rs` — insert `manifest.desugar_chains()` before each overlap check
- `crates/claudes/src/manifest.rs` — add `check_file_overlaps_suppressed_after_desugar_chains` test

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p claudes` passes
- [x] `cargo test --lib -p claudes` passes (including new test)
