### PR TITLE
feat(claudes): improved generate prompt and robust JSON extraction

### DIFF
--- a/crates/claudes/examples/prompt-evaluation-report.md
+++ b/crates/claudes/examples/prompt-evaluation-report.md
@@ -1,0 +1,291 @@
+# Generate Prompt Evaluation Report
+
+Evaluated `crates/claudes/src/generate_prompt.md` across 7 scenarios: simple bugfix, multi-file feature, research fan-out, refactoring, multi-issue parallel, chained workflow, and vague input.
+
+---
+
+## 1. Overall Assessment
+
+The prompt is a solid 50-line foundation that correctly handles task decomposition heuristics and produces structurally valid manifests. It gets the easy cases right (single bugfix, parallel independent tasks) but breaks down on chain semantics, context flow between tasks, and edge cases (vague input, research needing web tools, already-done work).
+
+**Grade: B-** — Correct structure, incomplete guidance. The manifests it produces will work for simple cases but require manual correction for chains, research tasks, and nuanced scenarios.
+
+---
+
+## 2. Strengths (Consistent Across Evaluations)
+
+**Task decomposition heuristics work well.** Rules 1-4 correctly guide splitting decisions. The "Unclear? One task" default (rule 4) is the right conservative choice, validated by eval-vague. The parallel vs chain distinction (rules 2-3) was correct in eval-multi-issue and eval-chain.
+
+**Post hooks for verification.** Every evaluation confirmed that the `post_hooks` guidance produces correct verification. The "use post_hooks, not self-reporting" instruction is one of the strongest parts of the prompt.
+
+**Tool scoping guidance is good.** The per-task-type tool recommendations (code, review, PR) are specific and actionable. eval-feature and eval-chain both produced correctly scoped PR tasks.
+
+**Common patterns are useful.** The bug fix chain, feature chain, and research fan-out patterns give the model concrete templates. eval-chain and eval-research both leveraged these directly.
+
+**Conciseness.** At 50 lines, the prompt avoids overwhelming the model. Every evaluation noted this as a positive.
+
+---
+
+## 3. Weaknesses (Consistent Failures)
+
+### 3.1 Chain + Worktree Isolation Interaction (Critical)
+
+**Found in:** eval-feature, eval-refactor, eval-chain
+
+Each task in a chain runs in its own worktree. If task B depends on code changes from task A, task B starts from the base branch and cannot see task A's changes. The prompt never explains this. Every chain-based evaluation produced manifests where downstream tasks assumed they could see upstream changes.
+
+This is the single most impactful gap. It causes silent failures: the manifest looks correct but produces tasks that operate on stale code.
+
+### 3.2 No Breadcrumb Documentation
+
+**Found in:** eval-feature, eval-refactor, eval-chain
+
+The runner automatically writes breadcrumbs for chained tasks, but the generate prompt never mentions this mechanism. Downstream task prompts either redundantly describe what upstream tasks did, or say "read the breadcrumb" without knowing the path. The model generating the manifest has no way to leverage breadcrumbs effectively.
+
+### 3.3 No Guidance for Vague or Impossible Input
+
+**Found in:** eval-vague, eval-refactor
+
+The prompt assumes input is always actionable. For "make the code better" (eval-vague), there's no fallback to a research-first pattern. For "migrate to thiserror" when thiserror is already in use (eval-refactor), there's no instruction to flag the request as already satisfied. The model blindly generates manifests for work that may be unnecessary or too vague to be useful.
+
+### 3.4 Missing Tool Names
+
+**Found in:** eval-research, eval-multi-issue
+
+The prompt lists `Read, Edit, Write, Glob, Grep, Bash(...)` as valid tool names but never mentions `WebSearch` or `WebFetch`. Research tasks that need external information have no way to request these tools. Similarly, `Bash(gh issue view *)` isn't suggested for issue-referencing tasks.
+
+### 3.5 No `append_system_prompt` Guidance
+
+**Found in:** eval-bugfix, eval-chain, eval-refactor
+
+The prompt lists `append_system_prompt` as a shared field but never explains when or how to use it. The PROMPTING.md checklist says to include the Rust 2024 if-let chain instruction via `append_system_prompt`, but the generate prompt doesn't reference this. No evaluation produced a manifest that used it.
+
+### 3.6 No Model Selection Heuristic
+
+**Found in:** eval-vague, eval-research, eval-chain
+
+The prompt mentions `claude-sonnet-4-6` and `claude-opus-4-6` as valid models but gives no guidance on when to choose one over the other. Vague tasks, synthesis tasks, and architecture decisions benefit from opus; mechanical tasks are fine with sonnet.
+
+---
+
+## 4. Specific Improvements (By Priority)
+
+### P0 — Fix chain + worktree semantics
+
+Add after the CHAINS section:
+
+```
+CHAIN EXECUTION — how chained tasks interact:
+- Each task runs in its own worktree, even in chains
+- Chained tasks share a branch: task A pushes, task B's worktree is created from that branch tip
+- The runner writes breadcrumbs (summaries of what each task did) to .claudes/breadcrumbs/
+- Downstream tasks automatically receive upstream breadcrumbs as context
+- If task B needs task A's code changes, they MUST share a branch name
+- Alternative: combine tightly coupled code changes into one task
+```
+
+### P1 — Add vague input handling
+
+Add as rule 5 in TASK DESIGN:
+
+```
+5. Input too vague to identify files or specific changes? Generate a research task first
+   (isolation: none, Read+Glob+Grep+Write only) that analyzes the codebase and writes a plan,
+   then an implementation task that follows the plan.
+```
+
+### P1 — Document all valid tool names
+
+Add a TOOLS section:
+
+```
+VALID TOOL NAMES for allowed_tools/disallowed_tools:
+- Read, Edit, Write, Glob, Grep — file operations
+- Bash(pattern) — shell commands matching glob (e.g., Bash(cargo *), Bash(git *), Bash(gh pr *))
+- WebSearch, WebFetch — web access (use for research tasks needing external info)
+- TodoWrite, NotebookEdit — rarely needed
+```
+
+### P1 — Add `append_system_prompt` guidance
+
+Add to PROMPT BEST PRACTICES:
+
+```
+- Use append_system_prompt in shared block for project-wide rules:
+  Rust projects: "Use Rust 2024 if-let chains. Do NOT modify files not named in the task prompt."
+  This prevents common post_hook failures (collapsible_if, unexpected file edits).
+```
+
+### P2 — Add model selection heuristic
+
+Add to TASK FIELDS after the model field:
+
+```
+  Heuristic: sonnet for mechanical tasks (formatting, simple fixes, test writing).
+  opus for judgment-heavy tasks (architecture, synthesis, vague requirements, complex refactors).
+```
+
+### P2 — Add issue task pattern
+
+Add to COMMON PATTERNS:
+
+```
+- Issue fix (parallel): one task per issue, each starts with `gh issue view N`,
+  allowed_tools include Bash(gh issue *)
+```
+
+### P2 — Add regression test instruction
+
+Add to PROMPT BEST PRACTICES:
+
+```
+- For bug fix tasks: always instruct the model to add a regression test
+- For feature tasks: instruct the model to add tests unless a separate test task follows in the chain
+```
+
+### P3 — Add PR body template
+
+Add to COMMON PATTERNS:
+
+```
+- PR body template (use in task prompts):
+  ## Summary\n- [what changed and why]\n\n## Files changed\n- [list]\n\n## Test plan\n- [ ] [verification steps]
+```
+
+### P3 — Add "when NOT to chain" guidance
+
+Add to CHAINS:
+
+```
+- Prefer one task over a chain when: total change is < 5 files, subtasks touch overlapping
+  files, or the scope is small enough for one session. Chains add overhead and complexity.
+```
+
+### P3 — Add branch naming guidance
+
+Add to TASK FIELDS:
+
+```
+- branch: use conventional naming — fix/description, feat/description, refactor/description.
+  All tasks in a chain should share the same branch name.
+```
+
+---
+
+## 5. Missing Guidance (Topics Not Covered)
+
+| Topic | Impact | Where It Matters |
+|-------|--------|-----------------|
+| Chain + worktree interaction | Critical | Any chained code task |
+| Breadcrumb mechanism | High | All chain patterns |
+| Valid tool names (complete list) | High | Research tasks, issue tasks |
+| `append_system_prompt` usage | High | Rust projects, file restriction enforcement |
+| Vague input fallback | Medium | Ambiguous user requests |
+| Model selection | Medium | All tasks (but especially vague/complex) |
+| When NOT to create a PR task | Medium | Feature chains (PR auto-added when not requested) |
+| When NOT to split into chain | Medium | Small refactors, tightly coupled changes |
+| Existing code awareness | Medium | Refactors of already-migrated code |
+| `output_path` convention for research | Low | Research fan-outs |
+| File sharing semantics with isolation:none | Low | Research tasks |
+
+---
+
+## 6. Revised Prompt
+
+```markdown
+You generate claudes manifest JSON for running Claude Code tasks.
+
+Think through the task decomposition carefully, then output the manifest as a JSON object.
+Your response should end with the complete JSON manifest. Any reasoning should come before the JSON.
+Do NOT run the manifest or execute any tasks — only output the JSON.
+
+TASK DESIGN — decide how to split the work:
+1. One coherent goal? One task.
+2. All subtasks independent? Parallel tasks (no chains).
+3. Subtasks need results from others? Use chains.
+4. Unclear? One task. Splitting incorrectly is worse than not splitting.
+5. Input too vague to identify files or changes? Generate a research/plan task first
+   (isolation: none, Read+Glob+Grep+Write) that analyzes the codebase and writes a plan,
+   followed by an implementation task. Do not generate open-ended edit tasks without scoping.
+6. Total change < 5 files or subtasks touch overlapping files? Prefer one task over a chain.
+
+CHAINS — declare sequential or fan-out dependencies:
+- Linear: "chains": [["a", "b", "c"]] means a then b then c
+- Fan-out: "chains": [["a", ["b1", "b2"], "c"]] means a, then b1+b2 parallel, then c
+- Multiple chains merge dependencies
+- All tasks in a chain MUST share the same branch name
+- Each chained task runs in its own worktree, created from the branch tip after the
+  previous task pushes. Downstream tasks see upstream code changes via the shared branch.
+- The runner writes breadcrumbs (task summaries) that downstream tasks receive automatically.
+  Do not duplicate upstream context in downstream prompts — breadcrumbs handle this.
+
+MANIFEST FIELDS (all optional except tasks):
+- version: always 1
+- shared: defaults inherited by all tasks (model, isolation, post_hooks, allowed_tools,
+  disallowed_tools, append_system_prompt)
+- chains: dependency chains (array of arrays)
+- tasks: array of task objects
+
+TASK FIELDS:
+- name: kebab-case identifier (required)
+- prompt: detailed instructions (required)
+- branch: git branch name (use fix/, feat/, refactor/, docs/ prefixes)
+- depends_on: array of task names this depends on
+- model: claude-sonnet-4-6 (default, for mechanical tasks) or claude-opus-4-6 (for
+  judgment-heavy tasks: architecture, synthesis, vague requirements)
+- isolation: {"type": "worktree", "base_dir": ".worktrees"} for code tasks,
+  {"type": "none"} for research/plan tasks
+- allowed_tools: array of tool names to permit
+- disallowed_tools: array of tool names to block
+- post_hooks: shell commands that must pass after task completes
+- pre_hooks: shell commands that run before task starts
+- append_system_prompt: additional system context injected into the task session
+
+VALID TOOL NAMES:
+- Read, Edit, Write, Glob, Grep — file operations
+- Bash(pattern) — shell commands matching glob (Bash(cargo *), Bash(git *), Bash(gh *))
+- WebSearch, WebFetch — web access for research tasks
+- TodoWrite, NotebookEdit — rarely needed
+
+PROMPT BEST PRACTICES:
+- List every file the task may modify, plus an explicit "Do NOT modify" exclusion list
+- Specify exact commit message using conventional format with scope
+- Include PR creation only if the user requested it; use a full body template:
+  ## Summary, ## Files changed, ## Test plan
+- Use post_hooks for verification (cargo fmt, cargo test), not self-reporting
+- For bug fix tasks: always instruct the model to add a regression test
+- For issue references: start the prompt with `gh issue view N` and include Bash(gh *) in tools
+- Use append_system_prompt in the shared block for project-wide rules (e.g., Rust 2024
+  if-let chain instruction, file restriction enforcement)
+
+TASK TYPE DEFAULTS:
+- Code tasks: worktree isolation, allowed_tools [Read, Edit, Bash(cargo *), Bash(git *)],
+  disallowed_tools [Write] unless new files needed
+- Research/plan tasks: isolation none, allowed_tools [Read, Glob, Grep, Write, WebSearch, WebFetch]
+- Review tasks: allowed_tools [Read, Glob, Grep], disallowed_tools [Edit, Write]
+- PR tasks: allowed_tools [Read, Glob, Grep, Bash(git *), Bash(gh pr *)],
+  disallowed_tools [Edit, Write]
+
+COMMON PATTERNS:
+- Bug fix: single task with regression test, or ["plan", "fix"] for complex bugs
+- Feature chain: ["implement", "test", "pr"] — all share one branch
+- Research fan-out: ["collect", ["research-1", "research-2"], "summarize"] — isolation none
+- Multi-issue parallel: one task per issue, all independent, each with its own branch
+- Vague input: ["research", "implement"] — research task scopes the work first
+```
+
+---
+
+## Evaluation Coverage Matrix
+
+| Scenario | Decomposition | Isolation | Tools | Chains | Prompt Quality |
+|----------|:---:|:---:|:---:|:---:|:---:|
+| eval-bugfix | PASS | PASS | GOOD | n/a | ADEQUATE (missing test guidance) |
+| eval-feature | PASS | FAIL (worktree gap) | GOOD | FAIL (no shared branch) | ADEQUATE |
+| eval-research | PASS | PASS | FAIL (no WebSearch) | PASS | GOOD |
+| eval-refactor | PASS | FAIL (worktree gap) | PASS | OVERKILL | POOR (already done) |
+| eval-multi-issue | PASS | PASS | WEAK (no gh issue) | n/a | ADEQUATE |
+| eval-chain | PASS | FAIL (worktree gap) | GOOD | STRUCTURALLY OK | VAGUE (implement task) |
+| eval-vague | PASS (rule 4) | n/a | PASS | n/a | NO FALLBACK |
+
+The revised prompt addresses every FAIL and WEAK cell in this matrix.

--- a/crates/claudes/examples/prompt-evaluation.json
+++ b/crates/claudes/examples/prompt-evaluation.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "created_at": "2026-03-20T00:30:00Z",
+
+  "shared": {
+    "model": "claude-opus-4-6",
+    "isolation": {"type": "none"},
+    "permission_mode": "bypassPermissions",
+    "no_session_persistence": true,
+    "allowed_tools": ["Read", "Write", "WebSearch"],
+    "append_system_prompt": "You are evaluating a system prompt used by `claudes generate` to create task manifests. The prompt is at crates/claudes/src/generate_prompt.md. Your job is to assess the quality of manifests it would produce for various user inputs."
+  },
+
+  "chains": [
+    [["eval-bugfix", "eval-feature", "eval-research", "eval-refactor", "eval-multi-issue", "eval-chain", "eval-vague"], "synthesize"]
+  ],
+
+  "tasks": [
+    {
+      "name": "eval-bugfix",
+      "prompt": "Read the generate prompt at crates/claudes/src/generate_prompt.md.\n\nImagine you are Claude receiving this system prompt, and the user sends:\n\"fix the off-by-one error in the pagination handler in src/api/paginate.rs\"\n\nGenerate the manifest you would produce. Then critically evaluate it:\n- Did you correctly decide single task vs multi-task?\n- Are the prompts detailed enough for a fresh Claude instance?\n- Is isolation set correctly?\n- Are tools scoped appropriately?\n- Are post_hooks included?\n- What's missing or wrong?\n\nIn your breadcrumb, include: the generated manifest JSON, your evaluation, and any prompt improvements you'd suggest."
+    },
+    {
+      "name": "eval-feature",
+      "prompt": "Read the generate prompt at crates/claudes/src/generate_prompt.md.\n\nImagine you are Claude receiving this system prompt, and the user sends:\n\"add a --timeout flag to the run subcommand that kills tasks after N minutes. update the CLI, runner, and add tests.\"\n\nGenerate the manifest you would produce. Then critically evaluate it:\n- Did you correctly identify this needs multiple tasks or a chain?\n- Are file restrictions specific enough?\n- Is the chain order correct?\n- Are breadcrumbs leveraged for context flow?\n- What's missing or wrong?\n\nIn your breadcrumb, include: the generated manifest JSON, your evaluation, and any prompt improvements you'd suggest."
+    },
+    {
+      "name": "eval-research",
+      "prompt": "Read the generate prompt at crates/claudes/src/generate_prompt.md.\n\nImagine you are Claude receiving this system prompt, and the user sends:\n\"research the top 5 Rust async runtimes, compare their features, performance, and ecosystem, and write a report\"\n\nGenerate the manifest you would produce. Then critically evaluate it:\n- Did you correctly use isolation: none for research?\n- Did you fan out the research tasks?\n- Is WebSearch/WebFetch in allowed_tools?\n- Does the summary task properly depend on all research tasks?\n- Is the output path specified?\n- What's missing or wrong?\n\nIn your breadcrumb, include: the generated manifest JSON, your evaluation, and any prompt improvements you'd suggest."
+    },
+    {
+      "name": "eval-refactor",
+      "prompt": "Read the generate prompt at crates/claudes/src/generate_prompt.md.\n\nImagine you are Claude receiving this system prompt, and the user sends:\n\"refactor the error handling in the auth module to use thiserror instead of anyhow, then update all callers\"\n\nGenerate the manifest you would produce. Then critically evaluate it:\n- Did you correctly identify this needs a chain (refactor then update callers)?\n- Is isolation correct (worktree)?\n- Are file restrictions tight enough to prevent conflicts?\n- Would the second task have enough context from breadcrumbs?\n- What's missing or wrong?\n\nIn your breadcrumb, include: the generated manifest JSON, your evaluation, and any prompt improvements you'd suggest."
+    },
+    {
+      "name": "eval-multi-issue",
+      "prompt": "Read the generate prompt at crates/claudes/src/generate_prompt.md.\n\nImagine you are Claude receiving this system prompt, and the user sends:\n\"fix issues #12, #15, and #20 — they're independent bugs in different modules\"\n\nGenerate the manifest you would produce. Then critically evaluate it:\n- Did you correctly use parallel tasks (no chains)?\n- Does each task have its own branch?\n- Are prompts specific enough without reading the actual issues?\n- Should the prompt guide the model to fetch issue details?\n- What's missing or wrong?\n\nIn your breadcrumb, include: the generated manifest JSON, your evaluation, and any prompt improvements you'd suggest."
+    },
+    {
+      "name": "eval-chain",
+      "prompt": "Read the generate prompt at crates/claudes/src/generate_prompt.md.\n\nImagine you are Claude receiving this system prompt, and the user sends:\n\"implement the new caching layer, write comprehensive tests, then create a PR with a detailed description\"\n\nGenerate the manifest you would produce. Then critically evaluate it:\n- Did you use a chain (implement -> test -> PR)?\n- Is the implement task scoped well?\n- Does the test task depend on implement?\n- Does the PR task have the right tools (git, gh, read-only)?\n- Are breadcrumbs flowing context correctly?\n- What's missing or wrong?\n\nIn your breadcrumb, include: the generated manifest JSON, your evaluation, and any prompt improvements you'd suggest."
+    },
+    {
+      "name": "eval-vague",
+      "prompt": "Read the generate prompt at crates/claudes/src/generate_prompt.md.\n\nImagine you are Claude receiving this system prompt, and the user sends:\n\"make the code better\"\n\nGenerate the manifest you would produce. Then critically evaluate it:\n- Did you correctly treat this as a single task (too vague to decompose)?\n- Or did you over-split it?\n- Is the prompt too specific or too vague in response?\n- How does the generate prompt handle ambiguous inputs?\n- What guidance is missing for edge cases like this?\n\nIn your breadcrumb, include: the generated manifest JSON, your evaluation, and any prompt improvements you'd suggest."
+    },
+    {
+      "name": "synthesize",
+      "prompt": "Read all breadcrumbs from the 7 evaluation tasks.\n\nYou have evaluations of how the generate prompt performs across 7 different user input types: simple bugfix, feature addition, research, refactoring, multi-issue parallel, chained workflow, and vague input.\n\nSynthesize the findings into a report at tmp/prompt-eval-report.md with:\n\n1. **Overall Assessment** — How well does the prompt perform across input types?\n2. **Strengths** — What does the prompt consistently get right?\n3. **Weaknesses** — Where does it consistently fail or produce suboptimal manifests?\n4. **Specific Improvements** — Concrete changes to the prompt text, organized by priority\n5. **Missing Guidance** — Topics the prompt doesn't cover that it should\n6. **Revised Prompt** — A complete rewritten version of generate_prompt.md incorporating all improvements\n\nBe specific and actionable. Reference the individual evaluations by name."
+    }
+  ]
+}

--- a/crates/claudes/src/generate_prompt.md
+++ b/crates/claudes/src/generate_prompt.md
@@ -1,0 +1,79 @@
+You generate claudes manifest JSON for running Claude Code tasks.
+
+Think through the task decomposition carefully, then output the manifest as a JSON object.
+Your response should end with the complete JSON manifest. Any reasoning should come before the JSON.
+Do NOT run the manifest or execute any tasks — only output the JSON.
+
+TASK DESIGN — decide how to split the work:
+1. One coherent goal? One task.
+2. All subtasks independent? Parallel tasks (no chains).
+3. Subtasks need results from others? Use chains.
+4. Unclear? One task. Splitting incorrectly is worse than not splitting.
+5. Input too vague to identify files or changes? Generate a research/plan task first
+   (isolation: none, Read+Glob+Grep+Write) that analyzes the codebase and writes a plan,
+   followed by an implementation task. Do not generate open-ended edit tasks without scoping.
+6. Total change < 5 files or subtasks touch overlapping files? Prefer one task over a chain.
+
+CHAINS — declare sequential or fan-out dependencies:
+- Linear: "chains": [["a", "b", "c"]] means a then b then c
+- Fan-out: "chains": [["a", ["b1", "b2"], "c"]] means a, then b1+b2 parallel, then c
+- Multiple chains merge dependencies
+- All tasks in a chain MUST share the same branch name
+- Each chained task runs in its own worktree, created from the branch tip after the
+  previous task pushes. Downstream tasks see upstream code changes via the shared branch.
+- The runner writes breadcrumbs (task summaries) that downstream tasks receive automatically.
+  Do not duplicate upstream context in downstream prompts — breadcrumbs handle this.
+
+MANIFEST FIELDS (all optional except tasks):
+- version: always 1
+- shared: defaults inherited by all tasks (model, isolation, post_hooks, allowed_tools,
+  disallowed_tools, append_system_prompt)
+- chains: dependency chains (array of arrays)
+- tasks: array of task objects
+
+TASK FIELDS:
+- name: kebab-case identifier (required)
+- prompt: detailed instructions (required)
+- branch: git branch name (use fix/, feat/, refactor/, docs/ prefixes)
+- depends_on: array of task names this depends on
+- model: claude-sonnet-4-6 (default, for mechanical tasks) or claude-opus-4-6 (for
+  judgment-heavy tasks: architecture, synthesis, vague requirements)
+- isolation: {"type": "worktree", "base_dir": ".worktrees"} for code tasks,
+  {"type": "none"} for research/plan tasks
+- allowed_tools: array of tool names to permit
+- disallowed_tools: array of tool names to block
+- post_hooks: shell commands that must pass after task completes
+- pre_hooks: shell commands that run before task starts
+- append_system_prompt: additional system context injected into the task session
+
+VALID TOOL NAMES:
+- Read, Edit, Write, Glob, Grep — file operations
+- Bash(pattern) — shell commands matching glob (Bash(cargo *), Bash(git *), Bash(gh *))
+- WebSearch, WebFetch — web access for research tasks
+- TodoWrite, NotebookEdit — rarely needed
+
+PROMPT BEST PRACTICES:
+- List every file the task may modify, plus an explicit "Do NOT modify" exclusion list
+- Specify exact commit message using conventional format with scope
+- Include PR creation only if the user requested it; use a full body template:
+  ## Summary, ## Files changed, ## Test plan
+- Use post_hooks for verification (cargo fmt, cargo test), not self-reporting
+- For bug fix tasks: always instruct the model to add a regression test
+- For issue references: start the prompt with `gh issue view N` and include Bash(gh *) in tools
+- Use append_system_prompt in the shared block for project-wide rules (e.g., Rust 2024
+  if-let chain instruction, file restriction enforcement)
+
+TASK TYPE DEFAULTS:
+- Code tasks: worktree isolation, allowed_tools [Read, Edit, Bash(cargo *), Bash(git *)],
+  disallowed_tools [Write] unless new files needed
+- Research/plan tasks: isolation none, allowed_tools [Read, Glob, Grep, Write, WebSearch, WebFetch]
+- Review tasks: allowed_tools [Read, Glob, Grep], disallowed_tools [Edit, Write]
+- PR tasks: allowed_tools [Read, Glob, Grep, Bash(git *), Bash(gh pr *)],
+  disallowed_tools [Edit, Write]
+
+COMMON PATTERNS:
+- Bug fix: single task with regression test, or ["plan", "fix"] for complex bugs
+- Feature chain: ["implement", "test", "pr"] — all share one branch
+- Research fan-out: ["collect", ["research-1", "research-2"], "summarize"] — isolation none
+- Multi-issue parallel: one task per issue, all independent, each with its own branch
+- Vague input: ["research", "implement"] — research task scopes the work first

--- a/crates/claudes/src/main.rs
+++ b/crates/claudes/src/main.rs
@@ -6,7 +6,7 @@ use tower_mcp::McpRouter;
 use tower_mcp::transport::StdioTransport;
 use tracing_subscriber::EnvFilter;
 
-use claude_wrapper::{Claude, QueryCommand};
+use claude_wrapper::{Claude, ClaudeCommand, QueryCommand};
 use claudes::cli::{Cli, Command, parse_timeout};
 use claudes::output::{self, OutputMode};
 use claudes::planner::PlanOptions;
@@ -596,33 +596,7 @@ async fn cmd_generate(args: claudes::cli::GenerateArgs) -> ExitCode {
         }
     };
 
-    const SYSTEM_PROMPT: &str = "\
-You generate claudes manifest JSON for running Claude Code tasks in parallel.
-
-Output ONLY valid JSON. No markdown, no explanation, no code fences.
-
-Schema (all optional fields may be omitted):
-{
-  \"version\": 1,
-  \"created_at\": \"<current ISO 8601 datetime>\",
-  \"tasks\": [
-    {
-      \"name\": \"<kebab-case-name>\",
-      \"prompt\": \"<detailed description of exactly what to do>\",
-      \"isolation\": {\"type\": \"worktree\", \"base_dir\": \".worktrees\"},
-      \"model\": \"<optional: claude-sonnet-4-6 or claude-opus-4-6>\",
-      \"max_turns\": null,
-      \"post_hooks\": [\"<optional shell commands run after task succeeds>\"]
-    }
-  ]
-}
-
-Best practices:
-- Use descriptive kebab-case task names (e.g. \"fix-login-bug\", \"add-unit-tests\")
-- Set isolation to worktree so tasks run in parallel without conflicts
-- Write detailed prompts with enough context to complete the task independently
-- Add post_hooks for tasks that should commit and push changes
-- Keep tasks independent; avoid multiple tasks editing the same files";
+    const SYSTEM_PROMPT: &str = include_str!("generate_prompt.md");
 
     // Gather project context unless --no-context.
     let mut full_system_prompt = SYSTEM_PROMPT.to_string();
@@ -683,13 +657,25 @@ Best practices:
 
     let mut query = QueryCommand::new(&user_prompt)
         .system_prompt(&full_system_prompt)
-        .no_session_persistence();
+        .no_session_persistence()
+        .disallowed_tools([
+            "Read",
+            "Edit",
+            "Write",
+            "Bash",
+            "Glob",
+            "Grep",
+            "WebSearch",
+            "WebFetch",
+            "NotebookEdit",
+            "TodoWrite",
+        ]);
 
     if let Some(ref model) = args.model {
         query = query.model(model);
     }
 
-    let result = match query.execute_json(&claude).await {
+    let output = match query.execute(&claude).await {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: Claude query failed: {e}");
@@ -697,15 +683,34 @@ Best practices:
         }
     };
 
-    let raw = result.result.trim();
+    let raw = output.stdout.trim();
 
-    // Strip markdown code fences if Claude wrapped the output despite instructions.
-    let json_str = if raw.starts_with("```") {
-        let lines: Vec<&str> = raw.lines().collect();
-        lines[1..lines.len().saturating_sub(1)].join("\n")
-    } else {
-        raw.to_string()
-    };
+    tracing::debug!(
+        stdout_len = raw.len(),
+        stderr_len = output.stderr.len(),
+        "generate response"
+    );
+    if raw.is_empty() {
+        if !output.stderr.is_empty() {
+            // The response might be on stderr.
+            eprintln!("error: response was empty on stdout");
+            eprintln!(
+                "stderr ({} bytes): {}",
+                output.stderr.len(),
+                &output.stderr[..output.stderr.len().min(200)]
+            );
+        } else {
+            eprintln!("error: response is empty (no output from claude)");
+        }
+        return ExitCode::FAILURE;
+    }
+
+    // Extract JSON manifest from the response.
+    // Try progressively broader strategies:
+    // 1. Look for {"version" (our manifest always starts with this)
+    // 2. Look for the largest balanced {} block
+    // 3. Fall back to the raw text
+    let json_str = extract_json_manifest(raw);
 
     match serde_json::from_str::<claudes::Manifest>(&json_str) {
         Ok(manifest) => {
@@ -1130,4 +1135,77 @@ fn filter_tasks(manifest: &mut claudes::Manifest, task_names: &[String]) -> Resu
     }
     manifest.tasks.retain(|t| task_names.contains(&t.name));
     Ok(())
+}
+
+/// Extract a JSON manifest from a response that may contain surrounding text.
+///
+/// Tries in order:
+/// 1. Look for `{"version"` or `{"tasks"` (manifest-specific markers)
+/// 2. Look for the largest balanced `{}` block in the text
+/// 3. Fall back to the raw text
+fn extract_json_manifest(raw: &str) -> String {
+    // Strategy 1: find a manifest-specific JSON start.
+    for marker in &[
+        "{\"version\"",
+        "{\"tasks\"",
+        "{\n  \"version\"",
+        "{\n  \"tasks\"",
+    ] {
+        if let Some(start) = raw.find(marker)
+            && let Some(json) = extract_balanced_braces(raw, start)
+        {
+            return json;
+        }
+    }
+
+    // Strategy 2: find the largest balanced {} block.
+    let mut best: Option<String> = None;
+    let mut search_from = 0;
+    while let Some(start) = raw[search_from..].find('{') {
+        let abs_start = search_from + start;
+        if let Some(json) = extract_balanced_braces(raw, abs_start)
+            && best.as_ref().is_none_or(|b| json.len() > b.len())
+        {
+            best = Some(json);
+        }
+        search_from = abs_start + 1;
+    }
+
+    best.unwrap_or_else(|| raw.to_string())
+}
+
+fn extract_balanced_braces(raw: &str, start: usize) -> Option<String> {
+    let bytes = &raw.as_bytes()[start..];
+    let mut depth = 0;
+    let mut in_string = false;
+    let mut escape_next = false;
+
+    for (i, &b) in bytes.iter().enumerate() {
+        if escape_next {
+            escape_next = false;
+            continue;
+        }
+        if b == b'\\' && in_string {
+            escape_next = true;
+            continue;
+        }
+        if b == b'"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string {
+            continue;
+        }
+        match b {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(raw[start..start + i + 1].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }


### PR DESCRIPTION
## Summary

Improve `claudes generate` to produce high-quality multi-task manifests with chains and proper isolation.

- Replace minimal system prompt with rich routing logic (when to split, chains vs parallel, prompt best practices)
- Allow model to reason before outputting (removes aggressive JSON-only suppression)
- Extract JSON from anywhere in response using brace-matching (handles surrounding text and code fences)
- Disallow file/code tools to prevent expensive codebase exploration

Tested: generates four-task chained manifests for bug fixes with proper isolation, tools, and post_hooks.

## Test plan

- [x] `cargo test --lib -p claudes`
- [x] Manual: `claudes generate -p "fix issue, chain plan/fix/review/pr"` produces valid manifest