### PR TITLE
feat(claudes): conditional task execution with condition field (#444)

### DIFF
--- a/crates/claudes/src/manifest.rs
+++ b/crates/claudes/src/manifest.rs
@@ -313,6 +313,7 @@ impl Manifest {
                         task.finally_hooks.as_ref(),
                     ),
                     depends_on: task.depends_on.clone(),
+                    condition: task.condition.clone(),
                     skills: merge_hooks(
                         shared.and_then(|s| s.skills.as_ref()),
                         profile.and_then(|p| p.skills.as_ref()),
@@ -1127,6 +1128,15 @@ pub struct Task {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub depends_on: Option<Vec<String>>,
 
+    /// Optional shell condition command.
+    ///
+    /// If set, this command is executed in the project root before isolation setup.
+    /// Exit code 0 means the task should be **skipped** (condition is met, no work needed).
+    /// Any non-zero exit code (or a spawn failure) means the task runs normally.
+    /// Condition-skipped tasks do not block downstream dependents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+
     /// Skill files (markdown/text) whose contents are appended to the system prompt.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub skills: Option<Vec<String>>,
@@ -1172,6 +1182,7 @@ impl Task {
             post_hooks: None,
             finally_hooks: None,
             depends_on: None,
+            condition: None,
             skills: None,
             settings: None,
             setting_sources: None,
@@ -1421,6 +1432,15 @@ impl TaskBuilder {
     /// Set the Claude CLI setting sources.
     pub fn setting_sources(mut self, setting_sources: impl Into<String>) -> Self {
         self.task.setting_sources = Some(setting_sources.into());
+        self
+    }
+
+    /// Set a shell condition for this task.
+    ///
+    /// The command runs in the project root before isolation setup.
+    /// Exit 0 = skip the task; non-zero (or spawn failure) = run the task.
+    pub fn condition(mut self, condition: impl Into<String>) -> Self {
+        self.task.condition = Some(condition.into());
         self
     }
 
@@ -2886,5 +2906,48 @@ prompt = "do it"
         let c_deps = manifest.tasks[3].depends_on.as_ref().unwrap();
         assert!(c_deps.contains(&"b1".to_string()));
         assert!(c_deps.contains(&"b2".to_string()));
+    }
+
+    #[test]
+    fn task_condition_field_json() {
+        let json = r#"{
+            "name": "check-task",
+            "prompt": "do the work",
+            "condition": "test -f marker.txt"
+        }"#;
+        let task: Task = serde_json::from_str(json).unwrap();
+        assert_eq!(task.condition.as_deref(), Some("test -f marker.txt"));
+    }
+
+    #[test]
+    fn task_condition_field_toml() {
+        let toml_str = r#"
+            name = "check-task"
+            prompt = "do the work"
+            condition = "test -f marker.txt"
+        "#;
+        let task: Task = toml::from_str(toml_str).unwrap();
+        assert_eq!(task.condition.as_deref(), Some("test -f marker.txt"));
+    }
+
+    #[test]
+    fn task_condition_field_absent_defaults_to_none() {
+        let json = r#"{"name": "t", "prompt": "p"}"#;
+        let task: Task = serde_json::from_str(json).unwrap();
+        assert!(task.condition.is_none());
+    }
+
+    #[test]
+    fn task_condition_not_inherited_from_shared() {
+        // condition is task-only: it must not appear on the Shared struct.
+        // Verify that resolving a manifest preserves the task's condition.
+        let json = r#"{
+            "tasks": [
+                {"name": "t", "prompt": "p", "condition": "exit 1"}
+            ]
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+        let resolved = manifest.resolve();
+        assert_eq!(resolved.tasks[0].condition.as_deref(), Some("exit 1"));
     }
 }

--- a/crates/claudes/src/output.rs
+++ b/crates/claudes/src/output.rs
@@ -159,10 +159,12 @@ fn print_run_complete_progress(result: &RunResult, no_color: bool) {
     let _ = writeln!(out);
 
     for task in &result.tasks {
-        let is_skipped = !task.success && task.stderr.contains("skipped: dependency failed");
+        let is_dep_skipped = !task.success && task.stderr.contains("skipped: dependency failed");
         let status = if task.success {
             "ok"
-        } else if is_skipped {
+        } else if task.condition_skipped {
+            "SKIPPED (cond)"
+        } else if is_dep_skipped {
             "SKIPPED"
         } else if is_timeout(&task.stdout, &task.stderr) {
             "TIMEOUT"
@@ -187,7 +189,13 @@ fn print_run_complete_progress(result: &RunResult, no_color: bool) {
         if use_color {
             let status_color = if task.success {
                 Color::Green
-            } else if is_skipped {
+            } else if task.condition_skipped {
+                Color::Rgb {
+                    r: 128,
+                    g: 200,
+                    b: 128,
+                }
+            } else if is_dep_skipped {
                 Color::DarkGrey
             } else {
                 Color::Red
@@ -202,7 +210,7 @@ fn print_run_complete_progress(result: &RunResult, no_color: bool) {
             );
         }
 
-        if !task.success && !is_skipped && !task.stderr.is_empty() {
+        if !task.success && !is_dep_skipped && !task.condition_skipped && !task.stderr.is_empty() {
             for line in task.stderr.lines().take(5) {
                 let _ = writeln!(out, "    {line}");
             }
@@ -494,6 +502,47 @@ pub async fn render_progress(mut rx: mpsc::UnboundedReceiver<TaskEvent>, no_colo
                 if let Some(c) = cost {
                     total_cost += c;
                 }
+                let cost_msg = if total_cost > 0.0 {
+                    format!("  ${total_cost:.2}")
+                } else {
+                    String::new()
+                };
+                footer.set_message(format!(
+                    "{completed_tasks}/{total_tasks} complete{cost_msg}"
+                ));
+                if completed_tasks == total_tasks {
+                    footer.finish_with_message("");
+                }
+            }
+            "claudes_task_condition_skipped" => {
+                if let Some(pb) = bars.get(task.as_str()) {
+                    let finish = if use_color {
+                        format!(
+                            "  {}  {:<22} {}",
+                            "⊘".with(Color::Rgb {
+                                r: 128,
+                                g: 200,
+                                b: 128
+                            }),
+                            task_prefix.with(Color::Rgb {
+                                r: 128,
+                                g: 200,
+                                b: 128
+                            }),
+                            "skipped (condition)".with(Color::Rgb {
+                                r: 128,
+                                g: 200,
+                                b: 128
+                            })
+                        )
+                    } else {
+                        format!("  ⊘  {task_prefix:<22} skipped (condition)")
+                    };
+                    pb.finish_with_message("");
+                    pb.set_style(ProgressStyle::with_template("{msg}").unwrap());
+                    pb.finish_with_message(finish);
+                }
+                completed_tasks += 1;
                 let cost_msg = if total_cost > 0.0 {
                     format!("  ${total_cost:.2}")
                 } else {

--- a/crates/claudes/src/planner.rs
+++ b/crates/claudes/src/planner.rs
@@ -283,6 +283,7 @@ pub fn plan(options: &PlanOptions) -> Manifest {
                 post_hooks: None,
                 finally_hooks: None,
                 depends_on: None,
+                condition: None,
                 skills: None,
                 settings: None,
                 setting_sources: None,

--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -24,6 +24,10 @@ pub struct TaskResult {
     pub name: String,
     /// Whether the task succeeded.
     pub success: bool,
+    /// Whether this task was skipped because its `condition` command exited 0.
+    ///
+    /// When true, downstream dependents are not blocked.
+    pub condition_skipped: bool,
     /// Stdout from the claude process.
     pub stdout: String,
     /// Stderr from the claude process.
@@ -293,6 +297,7 @@ pub async fn run(manifest: &Manifest, options: &RunOptions) -> Result<RunResult>
                     results.push(TaskResult {
                         name: task.name.clone(),
                         success: false,
+                        condition_skipped: false,
                         stdout: String::new(),
                         stderr: "skipped: dependency failed".to_string(),
                         duration: std::time::Duration::ZERO,
@@ -359,7 +364,8 @@ pub async fn run(manifest: &Manifest, options: &RunOptions) -> Result<RunResult>
             while let Some(result) = join_set.join_next().await {
                 match result {
                     Ok(task_result) => {
-                        if !task_result.success {
+                        // Condition-skipped tasks do not block dependents.
+                        if !task_result.success && !task_result.condition_skipped {
                             failed_tasks.insert(task_result.name.clone());
                         }
                         task_work_dirs
@@ -459,10 +465,74 @@ async fn run_task(task: &Task, options: &RunOptions) -> TaskResult {
     run_task_impl(task, options).instrument(span).await
 }
 
+/// Evaluate the task condition command.
+///
+/// Returns `true` if the task should be skipped (condition command exited 0).
+/// Returns `false` if the command exited non-zero or failed to spawn (fail-safe: run the task).
+async fn evaluate_condition(condition: &str, project_dir: &std::path::Path) -> bool {
+    match tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(condition)
+        .current_dir(project_dir)
+        .output()
+        .await
+    {
+        Ok(output) => output.status.success(),
+        Err(e) => {
+            warn!(
+                condition = condition,
+                error = %e,
+                "condition spawn failed — treating as non-zero (task will run)"
+            );
+            false
+        }
+    }
+}
+
 /// Inner task execution body.
 async fn run_task_impl(task: &Task, options: &RunOptions) -> TaskResult {
     let start = std::time::Instant::now();
     let task_name = task.name.clone();
+
+    // Evaluate condition before isolation setup, pre_hooks, and finally_hooks.
+    if let Some(condition) = &task.condition {
+        let should_skip = evaluate_condition(condition, &options.project_dir).await;
+        if should_skip {
+            info!(
+                task = task_name,
+                condition = condition,
+                "condition met (exit 0) — skipping task"
+            );
+            if let Some(ref sender) = options.event_sender {
+                let _ = sender.send(TaskEvent {
+                    task_name: task_name.clone(),
+                    event: StreamEvent {
+                        data: serde_json::json!({
+                            "type": "claudes_task_condition_skipped",
+                            "task_name": task_name,
+                        }),
+                    },
+                });
+            }
+            return TaskResult {
+                name: task_name,
+                success: false,
+                condition_skipped: true,
+                stdout: String::new(),
+                stderr: "skipped: condition met".to_string(),
+                duration: start.elapsed(),
+                work_dir: options.project_dir.to_path_buf(),
+                cost_usd: None,
+                files_modified: None,
+                lines_changed: None,
+            };
+        }
+        info!(
+            task = task_name,
+            condition = condition,
+            "condition not met (non-zero) — running task"
+        );
+    }
 
     let result = run_task_inner(task, options).await;
 
@@ -512,6 +582,7 @@ async fn run_task_impl(task: &Task, options: &RunOptions) -> TaskResult {
             TaskResult {
                 name: task_name,
                 success,
+                condition_skipped: false,
                 stdout: output.stdout,
                 stderr: output.stderr,
                 duration,
@@ -526,6 +597,7 @@ async fn run_task_impl(task: &Task, options: &RunOptions) -> TaskResult {
             TaskResult {
                 name: task_name,
                 success: false,
+                condition_skipped: false,
                 stdout: String::new(),
                 stderr: e.to_string(),
                 duration: start.elapsed(),
@@ -1244,5 +1316,38 @@ mod tests {
             .cleanup(CleanupPolicy::OnSuccess)
             .build();
         assert_eq!(opts.cleanup, CleanupPolicy::OnSuccess);
+    }
+
+    #[tokio::test]
+    async fn condition_exit_zero_returns_true() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(evaluate_condition("exit 0", dir.path()).await);
+    }
+
+    #[tokio::test]
+    async fn condition_exit_nonzero_returns_false() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!evaluate_condition("exit 1", dir.path()).await);
+    }
+
+    #[tokio::test]
+    async fn condition_spawn_failure_returns_false() {
+        let _dir = tempfile::tempdir().unwrap();
+        // Passing a non-existent binary through sh -c will still work (sh handles it).
+        // Test spawn failure by using a non-existent working directory.
+        let bad_dir = std::path::Path::new("/nonexistent/path/that/does/not/exist");
+        // sh -c "exit 0" with a bad cwd — sh may still succeed on some platforms,
+        // but the intent of the fail-safe is covered by evaluate_condition returning false on Err.
+        // Instead verify directly with a command that will fail to spawn due to bad cwd.
+        let result = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg("exit 0")
+            .current_dir(bad_dir)
+            .output()
+            .await;
+        // If spawn fails (bad cwd), evaluate_condition should return false.
+        if result.is_err() {
+            assert!(!evaluate_condition("exit 0", bad_dir).await);
+        }
     }
 }

--- a/crates/claudes/src/state.rs
+++ b/crates/claudes/src/state.rs
@@ -118,6 +118,12 @@ pub enum TaskStatus {
     Timeout,
     /// Task was skipped because a dependency failed.
     Skipped,
+    /// Task was skipped because its `condition` command exited with status 0.
+    ///
+    /// Unlike `Skipped`, this is a success-like outcome: downstream dependents
+    /// are not blocked and the task is not counted as a failure.
+    #[serde(rename = "condition_skipped")]
+    ConditionSkipped,
 }
 
 /// Summary statistics for the entire run.
@@ -340,7 +346,9 @@ pub fn build_state(manifest: &Manifest, result: &RunResult, started_at: DateTime
             };
             let log_path = Some(log_path.to_string_lossy().to_string());
 
-            let status = if t.success {
+            let status = if t.condition_skipped {
+                TaskStatus::ConditionSkipped
+            } else if t.success {
                 TaskStatus::Success
             } else if is_timeout(&t.stdout, &t.stderr) {
                 TaskStatus::Timeout
@@ -624,6 +632,7 @@ pub fn print_status(state: &RunState) {
             TaskStatus::Failed => "FAILED",
             TaskStatus::Timeout => "TIMEOUT",
             TaskStatus::Skipped => "SKIPPED",
+            TaskStatus::ConditionSkipped => "SKIPPED (cond)",
         };
         let status_display = if use_color {
             match task.status {
@@ -663,6 +672,16 @@ pub fn print_status(state: &RunState) {
                         .with(Color::Rgb {
                             r: 128,
                             g: 128,
+                            b: 128
+                        })
+                        .to_string()
+                ),
+                TaskStatus::ConditionSkipped => format!(
+                    "{:<10}",
+                    status_str
+                        .with(Color::Rgb {
+                            r: 128,
+                            g: 200,
                             b: 128
                         })
                         .to_string()
@@ -718,6 +737,7 @@ mod tests {
         TaskResult {
             name: name.into(),
             success,
+            condition_skipped: false,
             stdout: if success { "{}".into() } else { String::new() },
             stderr: if success {
                 String::new()
@@ -752,6 +772,7 @@ mod tests {
             tasks: vec![TaskResult {
                 name: "t".into(),
                 success: true,
+                condition_skipped: false,
                 stdout: r#"{"total_cost_usd":0.10}"#.into(),
                 stderr: String::new(),
                 duration: Duration::from_secs(5),
@@ -780,6 +801,7 @@ mod tests {
                 TaskResult {
                     name: "ok".into(),
                     success: true,
+                    condition_skipped: false,
                     stdout: "{}".into(),
                     stderr: String::new(),
                     duration: Duration::from_secs(4),
@@ -791,6 +813,7 @@ mod tests {
                 TaskResult {
                     name: "bad".into(),
                     success: false,
+                    condition_skipped: false,
                     stdout: String::new(),
                     stderr: "oops".into(),
                     duration: Duration::from_secs(2),
@@ -825,6 +848,7 @@ mod tests {
             tasks: vec![TaskResult {
                 name: "test-task".into(),
                 success: true,
+                condition_skipped: false,
                 stdout: r#"{"result":"done","session_id":"sess-123","total_cost_usd":0.05}"#.into(),
                 stderr: String::new(),
                 duration: Duration::from_secs(5),
@@ -865,6 +889,7 @@ mod tests {
                 TaskResult {
                     name: "ok-task".into(),
                     success: true,
+                    condition_skipped: false,
                     stdout: "{}".into(),
                     stderr: String::new(),
                     duration: Duration::from_secs(3),
@@ -876,6 +901,7 @@ mod tests {
                 TaskResult {
                     name: "bad-task".into(),
                     success: false,
+                    condition_skipped: false,
                     stdout: String::new(),
                     stderr: "something went wrong".into(),
                     duration: Duration::from_secs(1),
@@ -905,6 +931,7 @@ mod tests {
             tasks: vec![TaskResult {
                 name: "t".into(),
                 success: true,
+                condition_skipped: false,
                 stdout: "{}".into(),
                 stderr: String::new(),
                 duration: Duration::from_secs(2),
@@ -1035,6 +1062,7 @@ mod tests {
             tasks: vec![TaskResult {
                 name: "timeout-task".into(),
                 success: false,
+                condition_skipped: false,
                 stdout: String::new(),
                 stderr: "reached max_turns limit".into(),
                 duration: Duration::from_secs(60),
@@ -1054,6 +1082,7 @@ mod tests {
             tasks: vec![TaskResult {
                 name: "timeout-task".into(),
                 success: false,
+                condition_skipped: false,
                 stdout: r#"{"subtype":"error_max_turns","result":""}"#.into(),
                 stderr: String::new(),
                 duration: Duration::from_secs(60),
@@ -1102,6 +1131,7 @@ mod tests {
                 TaskResult {
                     name: "a".into(),
                     success: true,
+                    condition_skipped: false,
                     stdout: r#"{"total_cost_usd":1.39,"num_turns":15}"#.into(),
                     stderr: String::new(),
                     duration: Duration::from_secs(5),
@@ -1113,6 +1143,7 @@ mod tests {
                 TaskResult {
                     name: "b".into(),
                     success: true,
+                    condition_skipped: false,
                     stdout: r#"{"total_cost_usd":0.79,"num_turns":21}"#.into(),
                     stderr: String::new(),
                     duration: Duration::from_secs(4),
@@ -1166,6 +1197,7 @@ mod tests {
                 TaskResult {
                     name: "a".into(),
                     success: true,
+                    condition_skipped: false,
                     stdout: r#"{"num_turns":10}"#.into(),
                     stderr: String::new(),
                     duration: Duration::from_secs(2),
@@ -1177,6 +1209,7 @@ mod tests {
                 TaskResult {
                     name: "b".into(),
                     success: true,
+                    condition_skipped: false,
                     stdout: r#"{"num_turns":20}"#.into(),
                     stderr: String::new(),
                     duration: Duration::from_secs(3),
@@ -1197,6 +1230,7 @@ mod tests {
             tasks: vec![TaskResult {
                 name: "t".into(),
                 success: true,
+                condition_skipped: false,
                 stdout: "{}".into(),
                 stderr: String::new(),
                 duration: Duration::from_secs(1),
@@ -1209,5 +1243,38 @@ mod tests {
         let state2 = build_state(&manifest2, &result2, Utc::now());
         let m2 = compute_metrics(&[state2]);
         assert_eq!(m2.avg_turns_used, None);
+    }
+
+    #[test]
+    fn task_status_condition_skipped_serialization() {
+        let status = TaskStatus::ConditionSkipped;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, r#""condition_skipped""#);
+        let parsed: TaskStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, TaskStatus::ConditionSkipped);
+    }
+
+    #[test]
+    fn build_state_condition_skipped() {
+        let manifest = Manifest::new(vec![Task::new("cond-task", "do work")]);
+        let result = RunResult {
+            tasks: vec![TaskResult {
+                name: "cond-task".into(),
+                success: false,
+                condition_skipped: true,
+                stdout: String::new(),
+                stderr: "skipped: condition met".to_string(),
+                duration: Duration::from_millis(5),
+                work_dir: PathBuf::from("/tmp"),
+                cost_usd: None,
+                files_modified: None,
+                lines_changed: None,
+            }],
+        };
+        let state = build_state(&manifest, &result, Utc::now());
+        assert_eq!(state.results[0].status, TaskStatus::ConditionSkipped);
+        // Condition-skipped tasks are not counted as failed.
+        assert_eq!(state.summary.failed, 0);
+        assert_eq!(state.summary.timed_out, 0);
     }
 }


### PR DESCRIPTION
## Summary

Add `condition` field to Task for skipping tasks based on a shell command exit code. When set, the command runs before the Claude session is spawned — zero cost if skipped.

Generated by a claudes pipeline (plan -> implement chain). Review and PR tasks failed due to #448 (shared branch worktree conflict).

Closes #444

## Test plan

- [ ] cargo test --lib -p claudes
- [ ] Manual verification needed — review task was skipped