### PR TITLE
fix(claudes): auto-inherit branch from dependency in chains

### DIFF
--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -365,6 +365,25 @@ pub async fn run(manifest: &Manifest, options: &RunOptions) -> Result<RunResult>
                     ));
                 }
 
+                // Inherit branch from dependency if this task doesn't specify one.
+                // This ensures chained tasks share a branch and worktree automatically.
+                if task.branch.is_none()
+                    && let Some(deps) = &task.depends_on
+                {
+                    for dep in deps {
+                        if let Some(Some(dep_branch)) = task_branches.get(dep.as_str()) {
+                            info!(
+                                task = task.name,
+                                dep = dep,
+                                branch = dep_branch,
+                                "inheriting branch from dependency"
+                            );
+                            task.branch = Some(dep_branch.clone());
+                            break;
+                        }
+                    }
+                }
+
                 // Check if any dependency used the same branch and has a worktree
                 // we can reuse (avoids git error when branch is already checked out).
                 let reuse_work_dir = if let Some(branch) = &task.branch


### PR DESCRIPTION
## Summary

When a chained task doesn't specify a branch, it now automatically inherits the branch from its first dependency. This makes chained workflows work correctly without requiring explicit branch names on every task.

**Before**: `["impl", "review"]` where only impl has a branch — review gets a new branch and can't see impl's changes.  
**After**: review inherits impl's branch, reuses the worktree, sees all changes.

## Test plan

- [x] `cargo test --lib -p claudes` (152 tests)
- [x] `cargo clippy clean`