### PR TITLE
feat: claude-runner — autonomous GitHub issue runner

### DIFF
--- a/crates/claude-runner/src/isolation.rs
+++ b/crates/claude-runner/src/isolation.rs
@@ -22,10 +22,20 @@ pub async fn create_worktree(
 
     tokio::fs::create_dir_all(repo_dir.join(base_dir)).await?;
 
+    // Fetch latest from remote so we branch from up-to-date main.
+    let _ = tokio::process::Command::new("git")
+        .args(["fetch", "origin"])
+        .current_dir(repo_dir)
+        .output()
+        .await;
+
+    // Determine the default branch base point.
+    let base_ref = detect_default_branch(repo_dir).await;
+
     let output = tokio::process::Command::new("git")
         .args(["worktree", "add", "-b", branch])
         .arg(&worktree_dir)
-        .arg("HEAD")
+        .arg(&base_ref)
         .current_dir(repo_dir)
         .output()
         .await?;
@@ -84,4 +94,22 @@ pub async fn remove_worktree(
     }
 
     Ok(())
+}
+
+/// Detect the remote default branch (origin/main or origin/master).
+async fn detect_default_branch(repo_dir: &Path) -> String {
+    // Try origin/main first, fall back to origin/master, then HEAD.
+    for candidate in &["origin/main", "origin/master"] {
+        let output = tokio::process::Command::new("git")
+            .args(["rev-parse", "--verify", candidate])
+            .current_dir(repo_dir)
+            .output()
+            .await;
+        if let Ok(o) = output
+            && o.status.success()
+        {
+            return candidate.to_string();
+        }
+    }
+    "HEAD".to_string()
 }

--- a/crates/claudes/src/output.rs
+++ b/crates/claudes/src/output.rs
@@ -728,14 +728,6 @@ fn extract_tool_arg(tool_name: &str, block: &serde_json::Value) -> String {
             } else {
                 v.to_string()
             };
-            // For Bash commands, show only the first line.
-            let s = if tool_name == "Bash" {
-                s.lines().next().unwrap_or("").to_string()
-            } else {
-                s
-            };
-            // Strip leading/trailing whitespace.
-            let s = s.trim().to_string();
             // Strip cwd prefix.
             let s = if let Ok(cwd) = std::env::current_dir() {
                 let prefix = format!("{}/", cwd.display());
@@ -758,7 +750,7 @@ fn extract_tool_arg(tool_name: &str, block: &serde_json::Value) -> String {
             } else {
                 s
             };
-            truncate(&s, 40)
+            truncate(&s, 60)
         })
         .unwrap_or_default()
 }

--- a/crates/claudes/src/runner.rs
+++ b/crates/claudes/src/runner.rs
@@ -365,25 +365,6 @@ pub async fn run(manifest: &Manifest, options: &RunOptions) -> Result<RunResult>
                     ));
                 }
 
-                // Inherit branch from dependency if this task doesn't specify one.
-                // This ensures chained tasks share a branch and worktree automatically.
-                if task.branch.is_none()
-                    && let Some(deps) = &task.depends_on
-                {
-                    for dep in deps {
-                        if let Some(Some(dep_branch)) = task_branches.get(dep.as_str()) {
-                            info!(
-                                task = task.name,
-                                dep = dep,
-                                branch = dep_branch,
-                                "inheriting branch from dependency"
-                            );
-                            task.branch = Some(dep_branch.clone());
-                            break;
-                        }
-                    }
-                }
-
                 // Check if any dependency used the same branch and has a worktree
                 // we can reuse (avoids git error when branch is already checked out).
                 let reuse_work_dir = if let Some(branch) = &task.branch


### PR DESCRIPTION
## Summary

New crate: `claude-runner` — turns GitHub issues into pull requests through configurable workflow templates.

### Architecture (three layers)
- **Platform** (github.rs): Issue fetching, PR creation, comments via `gh` CLI
- **Domain** (policy, triage, planner, workflow): Orchestration logic
- **Execution** (executor, isolation): Agent-agnostic task execution via claude-wrapper

### Features
- Process single issues: `claude-runner issue --repo owner/name --number 123`
- Batch polling: `claude-runner run --repo owner/name`
- Watch mode: `claude-runner watch --repo owner/name --interval 300`
- Dry run: `--dry-run` shows the plan without executing
- Configurable workflows: bug, feature, chore, research (or custom in runner.toml)
- Per-stage tool scoping (plan=read-only, implement=code tools, review=no edits)
- Run state persistence in ~/.claude-runner/runs/
- Branches from origin/main to avoid conflicts

### Tested
- Successfully processed issue #462 -> PR #465 ($0.70, 3.5 minutes)
- Successfully processed issue #466 -> PR #476 ($1.32, 6 stages)

## Test plan
- [x] `cargo clippy -p claude-runner --all-targets -- -D warnings`
- [x] Dry run mode works
- [x] End-to-end: issue -> PR (tested twice)