### PR TITLE
feat(claude-runner): lease system via GitHub labels

### DIFF
--- a/crates/claude-runner/src/github.rs
+++ b/crates/claude-runner/src/github.rs
@@ -218,6 +218,51 @@ pub async fn create_pull_request(
     })
 }
 
+/// Add a label to an issue.
+pub async fn add_label(repo: &str, number: u64, label: &str) -> Result<()> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "edit",
+            "--repo",
+            repo,
+            &number.to_string(),
+            "--add-label",
+            label,
+        ])
+        .output()
+        .await
+        .map_err(|e| Error::GitHub(format!("gh issue edit failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::GitHub(format!("add label failed: {stderr}")));
+    }
+    Ok(())
+}
+
+/// Remove a label from an issue.
+pub async fn remove_label(repo: &str, number: u64, label: &str) -> Result<()> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "edit",
+            "--repo",
+            repo,
+            &number.to_string(),
+            "--remove-label",
+            label,
+        ])
+        .output()
+        .await
+        .map_err(|e| Error::GitHub(format!("gh issue edit failed: {e}")))?;
+
+    if !output.status.success() {
+        tracing::debug!(label = label, "remove label failed (non-fatal)");
+    }
+    Ok(())
+}
+
 /// Post a comment on an issue.
 pub async fn comment_on_issue(repo: &str, number: u64, body: &str) -> Result<()> {
     let output = tokio::process::Command::new("gh")

--- a/crates/claude-runner/src/orchestrator.rs
+++ b/crates/claude-runner/src/orchestrator.rs
@@ -35,7 +35,11 @@ pub async fn process_issue(
         "fetched issue"
     );
 
-    // 2. Triage.
+    // 2. Acquire lease (add runner:in-progress, remove runner:ready).
+    let _ = github::add_label(repo, number, "runner:in-progress").await;
+    let _ = github::remove_label(repo, number, "runner:ready").await;
+
+    // 3. Triage.
     let decision = triage::triage(&issue, policy);
     let needs_clarification = match &decision {
         TriageDecision::Ready => {
@@ -250,7 +254,15 @@ pub async fn process_issue(
         "run complete"
     );
 
-    // 9. Cleanup on success.
+    // 9. Update lease labels.
+    let _ = github::remove_label(repo, number, "runner:in-progress").await;
+    if all_succeeded {
+        let _ = github::add_label(repo, number, "runner:complete").await;
+    } else {
+        let _ = github::add_label(repo, number, "runner:failed").await;
+    }
+
+    // 10. Cleanup on success.
     if all_succeeded {
         if let Err(e) = isolation::remove_worktree(repo_dir, &worktree_dir, false).await {
             warn!(error = %e, "failed to clean worktree (non-fatal)");

--- a/runner.toml
+++ b/runner.toml
@@ -1,6 +1,6 @@
 repo = "joshrotenberg/claude-wrapper"
-eligible_labels = ["bug", "enhancement"]
-exclude_labels = ["blocked", "needs-design"]
+eligible_labels = ["runner:ready"]
+exclude_labels = ["blocked", "needs-design", "runner:in-progress", "runner:complete"]
 branch_pattern = "automation/{issue}-{slug}"
 max_concurrency = 3
 auto_merge = false


### PR DESCRIPTION
## Summary

Add GitHub label-based lease system for watch mode:
- `runner:ready` → `runner:in-progress` → `runner:complete` / `runner:failed`
- Policy uses `runner:ready` as eligible label (explicit opt-in)
- Prevents duplicate work across multiple runner instances

## Test plan
- [x] cargo clippy clean
- [x] Labels created on repo