### PR TITLE
fix(claude-wrapper)!: remove panicky Transport::from(&str)

### DIFF
--- a/crates/claude-wrapper/README.md
+++ b/crates/claude-wrapper/README.md
@@ -221,7 +221,7 @@ println!("{}", output.stdout);
 
 ```rust
 McpAddCommand::new("sentry", "https://mcp.sentry.dev/mcp")
-    .transport("http")
+    .transport(Transport::Http)
     .execute(&claude)
     .await?;
 ```

--- a/crates/claude-wrapper/src/command/mcp.rs
+++ b/crates/claude-wrapper/src/command/mcp.rs
@@ -72,14 +72,14 @@ impl ClaudeCommand for McpGetCommand {
 /// # Example
 ///
 /// ```no_run
-/// use claude_wrapper::{Claude, ClaudeCommand, McpAddCommand, Scope};
+/// use claude_wrapper::{Claude, ClaudeCommand, McpAddCommand, Scope, Transport};
 ///
 /// # async fn example() -> claude_wrapper::Result<()> {
 /// let claude = Claude::builder().build()?;
 ///
 /// // Add an HTTP MCP server
 /// McpAddCommand::new("sentry", "https://mcp.sentry.dev/mcp")
-///     .transport("http")
+///     .transport(Transport::Http)
 ///     .scope(Scope::User)
 ///     .execute(&claude)
 ///     .await?;
@@ -128,8 +128,8 @@ impl McpAddCommand {
 
     /// Set the transport type.
     #[must_use]
-    pub fn transport(mut self, transport: impl Into<Transport>) -> Self {
-        self.transport = Some(transport.into());
+    pub fn transport(mut self, transport: Transport) -> Self {
+        self.transport = Some(transport);
         self
     }
 
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn test_mcp_add_http() {
         let cmd = McpAddCommand::new("sentry", "https://mcp.sentry.dev/mcp")
-            .transport("http")
+            .transport(Transport::Http)
             .scope(Scope::User);
 
         let args = cmd.args();
@@ -521,7 +521,7 @@ mod tests {
     #[test]
     fn test_mcp_add_oauth_flags() {
         let cmd = McpAddCommand::new("my-server", "https://example.com/mcp")
-            .transport("http")
+            .transport(Transport::Http)
             .callback_port(8080)
             .client_id("my-app-id")
             .client_secret();

--- a/crates/claude-wrapper/src/types.rs
+++ b/crates/claude-wrapper/src/types.rs
@@ -57,15 +57,34 @@ impl FromStr for Transport {
     }
 }
 
-impl From<&str> for Transport {
-    /// Convert a string slice to a `Transport`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the string is not a recognized transport type.
-    /// Valid values are: `"stdio"`, `"http"`, `"sse"`.
-    fn from(s: &str) -> Self {
-        s.parse().unwrap_or_else(|e| panic!("{e}"))
+impl TryFrom<&str> for Transport {
+    type Error = TransportParseError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+#[cfg(test)]
+mod transport_tests {
+    use super::*;
+
+    #[test]
+    fn from_str_accepts_known_variants() {
+        assert_eq!("stdio".parse::<Transport>().unwrap(), Transport::Stdio);
+        assert_eq!("http".parse::<Transport>().unwrap(), Transport::Http);
+        assert_eq!("sse".parse::<Transport>().unwrap(), Transport::Sse);
+    }
+
+    #[test]
+    fn from_str_returns_error_for_unknown() {
+        let err = "websocket".parse::<Transport>().unwrap_err();
+        assert!(err.to_string().contains("websocket"));
+    }
+
+    #[test]
+    fn try_from_str_returns_error_for_unknown() {
+        assert!(Transport::try_from("bogus").is_err());
     }
 }
 


### PR DESCRIPTION
## Summary

- `Transport::from(&str)` called `.parse().unwrap_or_else(|e| panic!("{e}"))`. Panicking in a `From` impl is a footgun, especially when invoked via `.into()`.
- Removes the `From<&str>` impl, adds a `TryFrom<&str>` that delegates to `FromStr`.
- Tightens `McpAddCommand::transport()` to take `Transport` directly instead of `impl Into<Transport>`. Callers that were passing `"http"` now pass `Transport::Http`.
- Callers wanting fallible string input should use `.parse()` or `.try_into()`.

**Breaking:** `.transport("http")` no longer compiles. This is pre-1.0 and the previous behavior would have panicked on any unknown string, so effectively no caller was relying on the `&str` path working safely.

Closes #452

## Test plan

- [x] Added tests for `FromStr` (known + unknown) and `TryFrom<&str>` (unknown)
- [x] `cargo test --lib -p claude-wrapper` (97 passed)
- [x] `cargo test --doc -p claude-wrapper --all-features` (39 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p claude-wrapper --all-targets --all-features -- -D warnings`