### PR TITLE
fix(claude-wrapper): clean child cleanup on timeout; add missing tests

### DIFF
--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -25,7 +25,7 @@ tempfile = ["dep:tempfile"]
 serde = { workspace = true }
 serde_json = { version = "1", optional = true }
 thiserror = { workspace = true }
-tokio = { version = "1", features = ["process", "time", "io-util"] }
+tokio = { version = "1", features = ["process", "time", "io-util", "macros"] }
 tracing = { workspace = true }
 tempfile = { version = "3", optional = true }
 which = "8"

--- a/crates/claude-wrapper/src/command/query.rs
+++ b/crates/claude-wrapper/src/command/query.rs
@@ -885,4 +885,37 @@ mod tests {
         let args = cmd.args();
         assert!(args.contains(&"--tmux".to_string()));
     }
+
+    // ─── shell_quote unit tests (#455) ───
+
+    #[test]
+    fn shell_quote_plain_word_is_unchanged() {
+        assert_eq!(shell_quote("simple"), "simple");
+        assert_eq!(shell_quote(""), "");
+        assert_eq!(shell_quote("file.rs"), "file.rs");
+    }
+
+    #[test]
+    fn shell_quote_whitespace_gets_single_quoted() {
+        assert_eq!(shell_quote("hello world"), "'hello world'");
+        assert_eq!(shell_quote("a\tb"), "'a\tb'");
+    }
+
+    #[test]
+    fn shell_quote_metacharacters_get_quoted() {
+        assert_eq!(shell_quote("a|b"), "'a|b'");
+        assert_eq!(shell_quote("$VAR"), "'$VAR'");
+        assert_eq!(shell_quote("a;b"), "'a;b'");
+        assert_eq!(shell_quote("(x)"), "'(x)'");
+    }
+
+    #[test]
+    fn shell_quote_embedded_single_quote_is_escaped() {
+        assert_eq!(shell_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn shell_quote_double_quote_gets_single_quoted() {
+        assert_eq!(shell_quote(r#"say "hi""#), r#"'say "hi"'"#);
+    }
 }

--- a/crates/claude-wrapper/src/error.rs
+++ b/crates/claude-wrapper/src/error.rs
@@ -59,3 +59,85 @@ impl From<std::io::Error> for Error {
 
 /// Result type alias for claude-wrapper operations.
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command_failed(stdout: &str, stderr: &str, working_dir: Option<PathBuf>) -> Error {
+        Error::CommandFailed {
+            command: "/bin/claude --print".to_string(),
+            exit_code: 7,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            working_dir,
+        }
+    }
+
+    #[test]
+    fn command_failed_display_includes_command_and_exit_code() {
+        let e = command_failed("", "", None);
+        let s = e.to_string();
+        assert!(s.contains("/bin/claude --print"));
+        assert!(s.contains("exit code 7"));
+    }
+
+    #[test]
+    fn command_failed_display_omits_empty_stdout_and_stderr() {
+        let s = command_failed("", "", None).to_string();
+        assert!(!s.contains("stdout:"));
+        assert!(!s.contains("stderr:"));
+    }
+
+    #[test]
+    fn command_failed_display_includes_nonempty_stdout() {
+        let s = command_failed("hello", "", None).to_string();
+        assert!(s.contains("stdout: hello"));
+    }
+
+    #[test]
+    fn command_failed_display_includes_nonempty_stderr() {
+        let s = command_failed("", "boom", None).to_string();
+        assert!(s.contains("stderr: boom"));
+    }
+
+    #[test]
+    fn command_failed_display_includes_both_streams_when_present() {
+        let s = command_failed("out", "err", None).to_string();
+        assert!(s.contains("stdout: out"));
+        assert!(s.contains("stderr: err"));
+    }
+
+    #[test]
+    fn command_failed_display_includes_working_dir_when_present() {
+        let s = command_failed("", "", Some(PathBuf::from("/tmp/proj"))).to_string();
+        assert!(s.contains("/tmp/proj"));
+    }
+
+    #[test]
+    fn command_failed_display_omits_working_dir_when_absent() {
+        let s = command_failed("", "", None).to_string();
+        assert!(!s.contains("(in "));
+    }
+
+    #[test]
+    fn timeout_display_formats_seconds() {
+        let s = Error::Timeout {
+            timeout_seconds: 42,
+        }
+        .to_string();
+        assert!(s.contains("42s"));
+    }
+
+    #[test]
+    fn io_error_display_includes_working_dir_when_present() {
+        let e = Error::Io {
+            message: "spawn failed".to_string(),
+            source: std::io::Error::new(std::io::ErrorKind::NotFound, "no file"),
+            working_dir: Some(PathBuf::from("/work")),
+        };
+        let s = e.to_string();
+        assert!(s.contains("spawn failed"));
+        assert!(s.contains("/work"));
+    }
+}

--- a/crates/claude-wrapper/src/exec.rs
+++ b/crates/claude-wrapper/src/exec.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::Claude;
 use crate::error::{Error, Result};
@@ -149,6 +150,17 @@ async fn run_internal(
     })
 }
 
+/// Run a command with a timeout, killing and reaping the child on expiration.
+///
+/// Spawns the child explicitly (rather than wrapping `Command::output()` in a
+/// `tokio::time::timeout`) so that we retain the handle and can SIGKILL the
+/// child and wait for it when the timeout fires. Stdout and stderr are drained
+/// concurrently with `child.wait()` via `tokio::join!` so neither pipe buffer
+/// can fill up and deadlock the child.
+///
+/// On timeout, partial stdout/stderr captured before the kill is logged at
+/// warn level; the returned `Error::Timeout` itself does not carry the
+/// partial output.
 async fn run_with_timeout(
     binary: &std::path::Path,
     args: &[String],
@@ -156,9 +168,97 @@ async fn run_with_timeout(
     working_dir: Option<&std::path::Path>,
     timeout: Duration,
 ) -> Result<CommandOutput> {
-    tokio::time::timeout(timeout, run_internal(binary, args, env, working_dir))
-        .await
-        .map_err(|_| Error::Timeout {
-            timeout_seconds: timeout.as_secs(),
-        })?
+    let mut cmd = Command::new(binary);
+    cmd.args(args);
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| Error::Io {
+        message: format!("failed to spawn claude: {e}"),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
+
+    let mut stdout = child.stdout.take().expect("stdout was piped");
+    let mut stderr = child.stderr.take().expect("stderr was piped");
+
+    // Drain stdout and stderr concurrently with the process wait so
+    // neither pipe buffer can fill up and deadlock the child.
+    // tokio::join! polls all three on the same task; no tokio::spawn
+    // (and therefore no `rt` feature) required.
+    let wait_and_drain = async {
+        let (status, stdout_str, stderr_str) =
+            tokio::join!(child.wait(), drain(&mut stdout), drain(&mut stderr));
+        (status, stdout_str, stderr_str)
+    };
+
+    match tokio::time::timeout(timeout, wait_and_drain).await {
+        Ok((Ok(status), stdout, stderr)) => {
+            let exit_code = status.code().unwrap_or(-1);
+
+            if !status.success() {
+                return Err(Error::CommandFailed {
+                    command: format!("{} {}", binary.display(), args.join(" ")),
+                    exit_code,
+                    stdout,
+                    stderr,
+                    working_dir: working_dir.map(|p| p.to_path_buf()),
+                });
+            }
+
+            Ok(CommandOutput {
+                stdout,
+                stderr,
+                exit_code,
+                success: true,
+            })
+        }
+        Ok((Err(e), _stdout, _stderr)) => Err(Error::Io {
+            message: "failed to wait for claude process".to_string(),
+            source: e,
+            working_dir: working_dir.map(|p| p.to_path_buf()),
+        }),
+        Err(_) => {
+            // Timeout: kill the child (reaps via start_kill + wait).
+            // Note that kill() only targets the direct child; if it has
+            // spawned its own subprocesses that are holding our pipe
+            // fds open, draining would block. Cap the drain with a
+            // short deadline so the timeout error returns promptly.
+            let _ = child.kill().await;
+            let drain_budget = Duration::from_millis(200);
+            let stdout_str = tokio::time::timeout(drain_budget, drain(&mut stdout))
+                .await
+                .unwrap_or_default();
+            let stderr_str = tokio::time::timeout(drain_budget, drain(&mut stderr))
+                .await
+                .unwrap_or_default();
+            if !stdout_str.is_empty() || !stderr_str.is_empty() {
+                warn!(
+                    stdout = %stdout_str,
+                    stderr = %stderr_str,
+                    "partial output from timed-out process",
+                );
+            }
+            Err(Error::Timeout {
+                timeout_seconds: timeout.as_secs(),
+            })
+        }
+    }
+}
+
+async fn drain<R: AsyncReadExt + Unpin>(reader: &mut R) -> String {
+    let mut buf = Vec::new();
+    let _ = reader.read_to_end(&mut buf).await;
+    String::from_utf8_lossy(&buf).into_owned()
 }

--- a/crates/claude-wrapper/src/streaming.rs
+++ b/crates/claude-wrapper/src/streaming.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
-use tracing::debug;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::process::{ChildStderr, Command};
+use tracing::{debug, warn};
 
 use crate::Claude;
 use crate::error::{Error, Result};
@@ -88,18 +88,26 @@ pub async fn stream_query<F>(
 where
     F: FnMut(StreamEvent),
 {
-    if let Some(timeout) = claude.timeout {
-        stream_query_with_timeout(claude, cmd, handler, timeout).await
-    } else {
-        stream_query_internal(claude, cmd, handler).await
-    }
+    stream_query_impl(claude, cmd, handler, claude.timeout).await
 }
 
+/// Unified streaming implementation with optional timeout.
+///
+/// Reads stderr concurrently in a background task so a chatty child
+/// cannot deadlock by filling the stderr pipe buffer, and so any
+/// captured stderr is available even on timeout or IO error.
+///
+/// On timeout, the child is killed and reaped (`kill().await` sends
+/// SIGKILL and waits), and whatever stderr was produced is logged at
+/// warn level. The returned `Error::Timeout` does not carry partial
+/// output -- streamed stdout events were already dispatched to the
+/// handler as they arrived.
 #[cfg(feature = "json")]
-async fn stream_query_internal<F>(
+async fn stream_query_impl<F>(
     claude: &Claude,
     cmd: &crate::command::query::QueryCommand,
     mut handler: F,
+    timeout: Option<Duration>,
 ) -> Result<CommandOutput>
 where
     F: FnMut(StreamEvent),
@@ -112,7 +120,12 @@ where
     command_args.extend(claude.global_args.clone());
     command_args.extend(args);
 
-    debug!(binary = %claude.binary.display(), args = ?command_args, "streaming claude command");
+    debug!(
+        binary = %claude.binary.display(),
+        args = ?command_args,
+        timeout = ?timeout,
+        "streaming claude command"
+    );
 
     let mut cmd = Command::new(&claude.binary);
     cmd.args(&command_args)
@@ -133,137 +146,84 @@ where
     })?;
 
     let stdout = child.stdout.take().expect("stdout was piped");
+    let mut stderr = child.stderr.take().expect("stderr was piped");
+
     let mut reader = BufReader::new(stdout).lines();
 
-    while let Some(line) = reader.next_line().await.map_err(|e| Error::Io {
-        message: "failed to read stdout line".to_string(),
-        source: e,
-        working_dir: claude.working_dir.clone(),
-    })? {
-        if line.trim().is_empty() {
-            continue;
-        }
-        match serde_json::from_str::<StreamEvent>(&line) {
-            Ok(event) => handler(event),
-            Err(e) => {
-                debug!(line = %line, error = %e, "failed to parse stream event, skipping");
+    // Run stdout line reading and stderr draining concurrently so a
+    // chatty child can't deadlock by filling the stderr pipe buffer.
+    // tokio::join! polls both futures on the same task (no tokio::spawn
+    // needed, so we avoid pulling in the `rt` feature).
+    let drain = drain_stderr(&mut stderr);
+    let read_future = read_lines(&mut reader, &mut handler, claude.working_dir.clone());
+    let combined = async {
+        let (line_result, stderr_str) = tokio::join!(read_future, drain);
+        (line_result, stderr_str)
+    };
+
+    let (line_result, stderr_str) = match timeout {
+        Some(d) => match tokio::time::timeout(d, combined).await {
+            Ok(pair) => pair,
+            Err(_) => {
+                // Timeout: kill the child (reaps via start_kill + wait)
+                // and try to drain whatever stderr remains. kill() only
+                // targets the direct child, so a subprocess tree holding
+                // our pipe fds could block the drain -- cap it with a
+                // short deadline.
+                let _ = child.kill().await;
+                let drain_budget = Duration::from_millis(200);
+                let stderr_str = tokio::time::timeout(drain_budget, drain_stderr(&mut stderr))
+                    .await
+                    .unwrap_or_default();
+                if !stderr_str.is_empty() {
+                    warn!(stderr = %stderr_str, "stderr from timed-out streaming process");
+                }
+                return Err(Error::Timeout {
+                    timeout_seconds: d.as_secs(),
+                });
             }
-        }
+        },
+        None => combined.await,
+    };
+
+    // If reading lines failed partway through (IO error, not timeout),
+    // clean up the child before returning.
+    if let Err(e) = line_result {
+        let _ = child.kill().await;
+        return Err(e);
     }
 
-    let output = child.wait_with_output().await.map_err(|e| Error::Io {
+    let status = child.wait().await.map_err(|e| Error::Io {
         message: "failed to wait for claude process".to_string(),
         source: e,
         working_dir: claude.working_dir.clone(),
     })?;
 
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    let exit_code = output.status.code().unwrap_or(-1);
+    let exit_code = status.code().unwrap_or(-1);
 
-    if !output.status.success() {
+    if !status.success() {
         return Err(Error::CommandFailed {
             command: format!("{} {}", claude.binary.display(), command_args.join(" ")),
             exit_code,
             stdout: String::new(),
-            stderr,
+            stderr: stderr_str,
             working_dir: claude.working_dir.clone(),
         });
     }
 
     Ok(CommandOutput {
         stdout: String::new(), // already consumed via streaming
-        stderr,
+        stderr: stderr_str,
         exit_code,
         success: true,
     })
 }
 
 #[cfg(feature = "json")]
-async fn stream_query_with_timeout<F>(
-    claude: &Claude,
-    cmd: &crate::command::query::QueryCommand,
-    mut handler: F,
-    timeout: Duration,
-) -> Result<CommandOutput>
-where
-    F: FnMut(StreamEvent),
-{
-    use crate::command::ClaudeCommand;
-
-    let args = cmd.args();
-
-    let mut command_args = Vec::new();
-    command_args.extend(claude.global_args.clone());
-    command_args.extend(args);
-
-    debug!(binary = %claude.binary.display(), args = ?command_args, "streaming claude command with timeout");
-
-    let mut cmd = Command::new(&claude.binary);
-    cmd.args(&command_args)
-        .env_remove("CLAUDECODE")
-        .envs(&claude.env)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .stdin(std::process::Stdio::null());
-
-    if let Some(ref dir) = claude.working_dir {
-        cmd.current_dir(dir);
-    }
-
-    let mut child = cmd.spawn().map_err(|e| Error::Io {
-        message: format!("failed to spawn claude: {e}"),
-        source: e,
-        working_dir: claude.working_dir.clone(),
-    })?;
-
-    let stdout = child.stdout.take().expect("stdout was piped");
-    let mut reader = BufReader::new(stdout).lines();
-
-    // Wrap the line-reading in a timeout
-    let result = tokio::time::timeout(
-        timeout,
-        read_lines(&mut reader, &mut handler, claude.working_dir.clone()),
-    )
-    .await;
-
-    match result {
-        Ok(Ok(())) => {
-            // Successfully read all lines; now wait for the process
-            let output = child.wait_with_output().await.map_err(|e| Error::Io {
-                message: "failed to wait for claude process".to_string(),
-                source: e,
-                working_dir: claude.working_dir.clone(),
-            })?;
-
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            let exit_code = output.status.code().unwrap_or(-1);
-
-            if !output.status.success() {
-                return Err(Error::CommandFailed {
-                    command: format!("{} {}", claude.binary.display(), command_args.join(" ")),
-                    exit_code,
-                    stdout: String::new(),
-                    stderr,
-                    working_dir: claude.working_dir.clone(),
-                });
-            }
-
-            Ok(CommandOutput {
-                stdout: String::new(), // already consumed via streaming
-                stderr,
-                exit_code,
-                success: true,
-            })
-        }
-        Ok(Err(e)) => Err(e),
-        Err(_) => {
-            // Timeout occurred; kill the child process
-            let _ = child.kill().await;
-            Err(Error::Timeout {
-                timeout_seconds: timeout.as_secs(),
-            })
-        }
-    }
+async fn drain_stderr(stderr: &mut ChildStderr) -> String {
+    let mut buf = Vec::new();
+    let _ = stderr.read_to_end(&mut buf).await;
+    String::from_utf8_lossy(&buf).into_owned()
 }
 
 #[cfg(feature = "json")]

--- a/crates/claude-wrapper/tests/fake_claude.rs
+++ b/crates/claude-wrapper/tests/fake_claude.rs
@@ -137,6 +137,91 @@ async fn fake_claude_timeout_fires() {
     );
 }
 
+/// Regression test for #454: an exec-path timeout must return promptly
+/// and not leave the child running. We use a 5s DELAY with a 500ms
+/// timeout and assert the call returns well under the child's delay.
+#[tokio::test]
+async fn exec_timeout_returns_promptly() {
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_DELAY", "5")
+        .timeout(std::time::Duration::from_millis(500))
+        .build()
+        .expect("failed to build client");
+
+    let start = std::time::Instant::now();
+    let result = claude_wrapper::VersionCommand::new().execute(&claude).await;
+    let elapsed = start.elapsed();
+
+    assert!(matches!(result, Err(claude_wrapper::Error::Timeout { .. })));
+    // Must return well before the child's 5s delay. Allow generous
+    // slack for CI jitter.
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "exec timeout should return promptly, took {elapsed:?}"
+    );
+}
+
+/// Regression test for #454: streaming timeout path must return a
+/// Timeout error and not hang waiting for the child.
+#[tokio::test]
+async fn streaming_timeout_returns_promptly() {
+    use claude_wrapper::streaming::{StreamEvent, stream_query};
+
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_DELAY", "5")
+        .env("FAKE_CLAUDE_OUTPUT", "slow response")
+        .timeout(std::time::Duration::from_millis(500))
+        .build()
+        .expect("failed to build client");
+
+    let cmd = QueryCommand::new("test prompt")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+
+    let start = std::time::Instant::now();
+    let result = stream_query(&claude, &cmd, |_: StreamEvent| {}).await;
+    let elapsed = start.elapsed();
+
+    assert!(matches!(result, Err(claude_wrapper::Error::Timeout { .. })));
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "streaming timeout should return promptly, took {elapsed:?}"
+    );
+}
+
+/// After an exec timeout the client handle should still be usable for
+/// subsequent commands; no shared state should be corrupted by the
+/// killed child.
+#[tokio::test]
+async fn client_reusable_after_timeout() {
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_DELAY", "5")
+        .timeout(std::time::Duration::from_millis(200))
+        .build()
+        .expect("failed to build client");
+
+    let first = claude_wrapper::VersionCommand::new().execute(&claude).await;
+    assert!(first.is_err());
+
+    // Rebuild without the delay but keep the short timeout; a fast
+    // command should still succeed on the same binary path.
+    let fast = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_OUTPUT", "fast")
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("failed to build client");
+
+    let second = claude_wrapper::VersionCommand::new()
+        .execute(&fast)
+        .await
+        .expect("fast call should succeed");
+    assert!(second.stdout.contains("fast"));
+}
+
 /// Verify that pointing at a nonexistent binary surfaces an error at execution
 /// time (not at build time).
 #[tokio::test]


### PR DESCRIPTION
Closes #454 and #455.

## #454: timeout cleanup

Both `exec::run_with_timeout` and `streaming::stream_query` used to wrap `cmd.output()` / the line reader in `tokio::time::timeout` without retaining the child handle. On timeout the future was dropped, which left the child running (tokio's `Child` does not kill on drop) and lost whatever was buffered in stderr. A chatty stderr could also deadlock the happy path by filling the pipe buffer while we were blocked on stdout.

Both paths now:

- Spawn the child explicitly and keep the handle.
- Drain stdout and stderr concurrently with `child.wait()` via `tokio::join!` so neither pipe buffer can fill up. This adds the `macros` feature to the lib's tokio dependency.
- On timeout, SIGKILL and reap the direct child via `child.kill().await` (which does `start_kill` + `wait` under the hood), then try to drain any remaining output under a short 200ms budget so the call returns promptly even when the child tree has orphaned descendants holding the pipe fds open.
- Log captured partial output at `warn` level before returning `Error::Timeout`.

Note: `child.kill()` only targets the direct child. Killing the full subprocess tree would require putting the child in its own process group and using `killpg`. That is out of scope here -- the tests use `fake-claude.sh`'s `sleep` which deliberately leaks a descendant, and the 200ms drain budget keeps us honest.

## #455: missing tests

Adds:

- `exec_timeout_returns_promptly` and `streaming_timeout_returns_promptly` integration tests asserting the timeout path actually returns quickly, not after the child's full delay. These would have failed on the pre-fix code.
- `client_reusable_after_timeout` to verify no shared state is corrupted by a killed child.
- Unit tests for the private `shell_quote` helper: plain words, whitespace, shell metacharacters, embedded single/double quotes.
- Unit tests for all `Error::Display` branches: `CommandFailed` with/without stdout, stderr, and working_dir; `Timeout`; `Io` with working_dir.

Lib tests: 94 -> 108 (+14). Integration tests: 25 -> 28 (+3).

## Out of scope

- #455 also mentions negative tests for conflicting `QueryCommand` options. Those naturally belong with the session/QueryCommand reshape tracked by #523 and #453, so I'm leaving them for that PR.

## Test plan

- [x] `cargo test -p claude-wrapper --all-features` (108 lib + 28 integration + 39 doc)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p claude-wrapper --all-targets --all-features -- -D warnings`
- [x] Verified `exec_timeout_returns_promptly` and `streaming_timeout_returns_promptly` complete in well under the child's 5s sleep (~1.4s each in isolation)

Depends on #526 for CI to pass.