### PR TITLE
feat(claude-wrapper)!: reshape Session around Arc<Claude>; add streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "claude-wrapper"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/claude-wrapper"
 
 [workspace.dependencies]
-claude-wrapper = { path = "crates/claude-wrapper", version = "0.4" }
+claude-wrapper = { path = "crates/claude-wrapper", version = "0.5" }
 claude-pool = { path = "crates/claude-pool", version = "0.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/claude-wrapper/README.md
+++ b/crates/claude-wrapper/README.md
@@ -169,25 +169,43 @@ let output = QueryCommand::new("what did we find?")
     .await?;
 ```
 
-Session management (type-safe):
+Session management (multi-turn, auto-resume):
 
 ```rust
-use claude_wrapper::Session;
+use std::sync::Arc;
+use claude_wrapper::{Claude, QueryCommand};
+use claude_wrapper::session::Session;
 
-// Create from a previous query result
-let mut session = Session::from_result(&claude, &result);
+let claude = Arc::new(Claude::builder().build()?);
 
-// Auto-resumes the session
-let next = session.query("what did we find?").execute().await?;
+// Fresh session
+let mut session = Session::new(Arc::clone(&claude));
 
-// Fork to branch the conversation
-let mut forked = session.fork();
-let alt = forked.query("try a different approach").execute().await?;
+// Plain prompt: session_id is captured from the first turn
+let first = session.send("what's 2 + 2?").await?;
 
-// Track cumulative cost and turns
-println!("Total cost: ${}", session.cumulative_cost_usd());
-println!("Total turns: {}", session.cumulative_turns());
+// Full control: pass a configured QueryCommand. Any session-related
+// flags on `cmd` are overridden with this session's current id so
+// they can't conflict.
+let second = session
+    .execute(QueryCommand::new("explain").model("opus"))
+    .await?;
+
+// Reattach to an existing session id
+let mut resumed = Session::resume(claude, "sess-abc123");
+let next = resumed.send("pick up where we left off").await?;
+
+// Cumulative state
+println!("cost: ${:.4}", session.total_cost_usd());
+println!("turns: {}", session.total_turns());
+println!("history: {} turns", session.history().len());
 ```
+
+`Session` is `Send + Sync` and holds an `Arc<Claude>`, so it can be
+moved between tasks or stored in long-lived actor state. Streaming
+turns use `Session::stream` / `Session::stream_execute`, which capture
+the session id from the first event that carries one — and persist
+it even if the stream errors partway through.
 
 ## Streaming NDJSON Events
 

--- a/crates/claude-wrapper/src/command/query.rs
+++ b/crates/claude-wrapper/src/command/query.rs
@@ -234,6 +234,21 @@ impl QueryCommand {
         self
     }
 
+    /// Clear every session-related flag and set `--resume` to the given id.
+    ///
+    /// Used by `Session::execute` to override whatever session flags the
+    /// caller may have set on their command (including a stale `--resume`,
+    /// `--continue`, `--session-id`, or `--fork-session`). Keeping the
+    /// override logic in one place prevents conflicting flags from reaching
+    /// the CLI.
+    pub(crate) fn replace_session(mut self, id: impl Into<String>) -> Self {
+        self.continue_session = false;
+        self.resume = Some(id.into());
+        self.session_id = None;
+        self.fork_session = false;
+        self
+    }
+
     /// Set a fallback model for when the primary model is overloaded.
     #[must_use]
     pub fn fallback_model(mut self, model: impl Into<String>) -> Self {

--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -207,7 +207,7 @@ pub use mcp_config::TempMcpConfig;
 pub use mcp_config::{McpConfigBuilder, McpServerConfig};
 pub use retry::{BackoffStrategy, RetryPolicy};
 #[cfg(feature = "json")]
-pub use session::{Session, SessionQuery};
+pub use session::Session;
 pub use types::*;
 pub use version::{CliVersion, VersionParseError};
 

--- a/crates/claude-wrapper/src/session.rs
+++ b/crates/claude-wrapper/src/session.rs
@@ -1,534 +1,343 @@
-//! Type-safe session management for multi-turn conversations.
+//! Multi-turn session management.
 //!
-//! The [`Session`] struct consolidates session control into a single abstraction
-//! that prevents conflicting session flags at the type level. Instead of
-//! independently calling `.continue_session()`, `.resume()`, `.session_id()`,
-//! or `.fork_session()` on a [`QueryCommand`] (which can
-//! be combined incorrectly), a `Session` encodes the session mode in its
-//! construction and provides `.query()` with automatic resume behavior.
+//! A [`Session`] threads Claude's `session_id` across turns automatically,
+//! so callers never need to scrape it out of a result event or pass
+//! `--resume` by hand.
+//!
+//! # Ownership
+//!
+//! [`Session`] holds an `Arc<Claude>`. Wrapping the client in an `Arc`
+//! means a session can outlive the original client binding, be moved
+//! between tasks, and sit inside long-lived actor state -- which is the
+//! usage shape that callers like centralino-rs need. One `Arc::clone`
+//! per session is a negligible cost in exchange.
+//!
+//! # Two entry points
+//!
+//! - [`Session::send`] takes a plain prompt. Use this for straightforward
+//!   multi-turn chat.
+//! - [`Session::execute`] takes a fully-configured [`QueryCommand`]. Use
+//!   this when you want per-turn options like `model`, `max_turns`,
+//!   `permission_mode`, etc. The session automatically overrides any
+//!   session-related flags on the command (`--resume`, `--continue`,
+//!   `--session-id`, `--fork-session`) so they can't conflict.
+//!
+//! Streaming follows the same split: [`Session::stream`] and
+//! [`Session::stream_execute`].
 //!
 //! # Example
 //!
 //! ```no_run
+//! use std::sync::Arc;
 //! use claude_wrapper::{Claude, QueryCommand};
 //! use claude_wrapper::session::Session;
 //!
 //! # async fn example() -> claude_wrapper::Result<()> {
-//! let claude = Claude::builder().build()?;
+//! let claude = Arc::new(Claude::builder().build()?);
 //!
-//! // Start a session with an initial query
-//! let first = QueryCommand::new("explain quicksort")
-//!     .execute_json(&claude)
-//!     .await?;
+//! let mut session = Session::new(Arc::clone(&claude));
 //!
-//! // Wrap it in a Session for automatic resume
-//! let mut session = Session::from_result(&claude, &first);
+//! // Simple path
+//! let first = session.send("explain quicksort").await?;
 //!
-//! // Follow-up queries auto-resume the session
-//! let second = session.query("now explain mergesort")
-//!     .model("sonnet")
-//!     .execute()
+//! // Full control: custom model, effort, permission mode, etc.
+//! let second = session
+//!     .execute(QueryCommand::new("now mergesort").model("opus"))
 //!     .await?;
 //!
 //! println!("total cost: ${:.4}", session.total_cost_usd());
-//! println!("total turns: {}", session.total_turns());
+//! println!("turns: {}", session.total_turns());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Resuming an existing session
+//!
+//! ```no_run
+//! # use std::sync::Arc;
+//! # use claude_wrapper::{Claude};
+//! # use claude_wrapper::session::Session;
+//! # async fn example() -> claude_wrapper::Result<()> {
+//! # let claude = Arc::new(Claude::builder().build()?);
+//! // Reattach to a session you stored earlier
+//! let mut session = Session::resume(claude, "sess-abc123");
+//! let result = session.send("pick up where we left off").await?;
 //! # Ok(())
 //! # }
 //! ```
 
+use std::sync::Arc;
+
 use crate::Claude;
 use crate::command::query::QueryCommand;
 use crate::error::Result;
-use crate::types::{Effort, InputFormat, OutputFormat, PermissionMode, QueryResult};
+use crate::types::QueryResult;
 
-/// A type-safe session handle for multi-turn conversations.
+#[cfg(feature = "json")]
+use crate::streaming::{StreamEvent, stream_query};
+
+/// A multi-turn conversation handle.
 ///
-/// `Session` wraps a [`Claude`] client reference and a session ID, providing
-/// `.query()` that automatically resumes the session. It tracks cumulative
-/// cost and turn count across all queries in the session.
-///
-/// Conflicting session flags are impossible because the session mode is
-/// encoded in construction rather than as independent builder methods.
-#[derive(Debug)]
-pub struct Session<'a> {
-    claude: &'a Claude,
-    session_id: String,
+/// Owns an `Arc<Claude>` so it can be moved between tasks and live
+/// inside long-running actors. Tracks `session_id`, cumulative cost,
+/// turn count, and per-turn result history.
+#[derive(Debug, Clone)]
+pub struct Session {
+    claude: Arc<Claude>,
+    session_id: Option<String>,
+    history: Vec<QueryResult>,
     cumulative_cost_usd: f64,
     cumulative_turns: u32,
 }
 
-impl<'a> Session<'a> {
-    /// Create a session from a completed query result.
-    ///
-    /// This is the most common way to start a session: run an initial
-    /// [`QueryCommand::execute_json()`] and then wrap the result.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use claude_wrapper::{Claude, QueryCommand};
-    /// use claude_wrapper::session::Session;
-    ///
-    /// # async fn example() -> claude_wrapper::Result<()> {
-    /// let claude = Claude::builder().build()?;
-    /// let result = QueryCommand::new("hello")
-    ///     .execute_json(&claude).await?;
-    ///
-    /// let mut session = Session::from_result(&claude, &result);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn from_result(claude: &'a Claude, result: &QueryResult) -> Self {
+impl Session {
+    /// Start a fresh session. The first turn will discover a session id
+    /// from its result; subsequent turns reuse it via `--resume`.
+    pub fn new(claude: Arc<Claude>) -> Self {
         Self {
             claude,
-            session_id: result.session_id.clone(),
-            cumulative_cost_usd: result.cost_usd.unwrap_or(0.0),
-            cumulative_turns: result.num_turns.unwrap_or(0),
-        }
-    }
-
-    /// Attach to an existing session by ID.
-    ///
-    /// Cost and turn counters start at zero since we have no history.
-    pub fn from_id(claude: &'a Claude, session_id: impl Into<String>) -> Self {
-        Self {
-            claude,
-            session_id: session_id.into(),
+            session_id: None,
+            history: Vec::new(),
             cumulative_cost_usd: 0.0,
             cumulative_turns: 0,
         }
     }
 
-    /// Continue the most recent session.
-    ///
-    /// Runs the first query with `--continue` to discover the session ID,
-    /// then returns a `Session` that uses `--resume` for subsequent queries.
-    pub async fn continue_recent(
-        claude: &'a Claude,
-        prompt: impl Into<String>,
-    ) -> Result<(Self, QueryResult)> {
-        let result = QueryCommand::new(prompt)
-            .continue_session()
-            .execute_json(claude)
-            .await?;
-
-        let session = Self {
+    /// Reattach to an existing session by id. The next turn immediately
+    /// passes `--resume <id>`. Cost and turn counters start at zero
+    /// since no history is available.
+    pub fn resume(claude: Arc<Claude>, session_id: impl Into<String>) -> Self {
+        Self {
             claude,
-            session_id: result.session_id.clone(),
-            cumulative_cost_usd: result.cost_usd.unwrap_or(0.0),
-            cumulative_turns: result.num_turns.unwrap_or(0),
+            session_id: Some(session_id.into()),
+            history: Vec::new(),
+            cumulative_cost_usd: 0.0,
+            cumulative_turns: 0,
+        }
+    }
+
+    /// Send a plain-prompt turn. Equivalent to
+    /// `execute(QueryCommand::new(prompt))`.
+    #[cfg(feature = "json")]
+    pub async fn send(&mut self, prompt: impl Into<String>) -> Result<QueryResult> {
+        self.execute(QueryCommand::new(prompt)).await
+    }
+
+    /// Send a turn with a fully-configured [`QueryCommand`].
+    ///
+    /// Any session-related flags on `cmd` (`--resume`, `--continue`,
+    /// `--session-id`, `--fork-session`) are overridden with this
+    /// session's current id, so they can't conflict.
+    #[cfg(feature = "json")]
+    pub async fn execute(&mut self, cmd: QueryCommand) -> Result<QueryResult> {
+        let cmd = match &self.session_id {
+            Some(id) => cmd.replace_session(id),
+            None => cmd,
         };
-        Ok((session, result))
+
+        let result = cmd.execute_json(&self.claude).await?;
+        self.record(&result);
+        Ok(result)
     }
 
-    /// Send a follow-up query in this session.
-    ///
-    /// Returns a [`SessionQuery`] builder with `--resume` pre-set.
-    /// Configure additional options (model, effort, etc.) on the builder,
-    /// then call `.execute()`.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use claude_wrapper::{Claude, QueryCommand};
-    /// # use claude_wrapper::session::Session;
-    /// # async fn example() -> claude_wrapper::Result<()> {
-    /// # let claude = Claude::builder().build()?;
-    /// # let result = QueryCommand::new("hello").execute_json(&claude).await?;
-    /// let mut session = Session::from_result(&claude, &result);
-    ///
-    /// let follow_up = session.query("what about the edge cases?")
-    ///     .model("opus")
-    ///     .max_turns(5)
-    ///     .execute()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn query(&mut self, prompt: impl Into<String>) -> SessionQuery<'_, 'a> {
-        SessionQuery::new(self, prompt)
+    /// Stream a plain-prompt turn, dispatching each NDJSON event to
+    /// `handler`. The session's id is captured from the first event
+    /// that carries one, so subsequent turns can resume, and the id
+    /// persists even if the stream errors partway through.
+    #[cfg(feature = "json")]
+    pub async fn stream<F>(&mut self, prompt: impl Into<String>, handler: F) -> Result<()>
+    where
+        F: FnMut(StreamEvent),
+    {
+        self.stream_execute(QueryCommand::new(prompt), handler)
+            .await
     }
 
-    /// Fork this session into a new one.
+    /// Stream a turn with a fully-configured [`QueryCommand`], with the
+    /// same session-id capture semantics as [`Session::stream`].
     ///
-    /// Sends a query with `--resume` and `--fork-session`, creating a new
-    /// session branched from this one. Returns the new `Session` and the
-    /// query result. The original session is not modified.
-    pub async fn fork(&self, prompt: impl Into<String>) -> Result<(Session<'a>, QueryResult)> {
-        let result = QueryCommand::new(prompt)
-            .resume(&self.session_id)
-            .fork_session()
-            .execute_json(self.claude)
-            .await?;
+    /// The command's output format is forced to `stream-json` and any
+    /// session-related flags are overridden as in [`Session::execute`].
+    #[cfg(feature = "json")]
+    pub async fn stream_execute<F>(&mut self, cmd: QueryCommand, mut handler: F) -> Result<()>
+    where
+        F: FnMut(StreamEvent),
+    {
+        use crate::types::OutputFormat;
 
-        let forked = Session {
-            claude: self.claude,
-            session_id: result.session_id.clone(),
-            cumulative_cost_usd: self.cumulative_cost_usd + result.cost_usd.unwrap_or(0.0),
-            cumulative_turns: self.cumulative_turns + result.num_turns.unwrap_or(0),
+        let cmd = match &self.session_id {
+            Some(id) => cmd.replace_session(id),
+            None => cmd,
+        }
+        .output_format(OutputFormat::StreamJson);
+
+        // Capture session_id and result state from events inside a
+        // wrapper closure. The captures happen before the caller's
+        // handler runs, and self is updated after the stream completes
+        // (even on error) so id persists across partial failures.
+        let mut captured_session_id: Option<String> = None;
+        let mut captured_result: Option<QueryResult> = None;
+
+        let outcome = {
+            let wrap = |event: StreamEvent| {
+                if captured_session_id.is_none()
+                    && let Some(sid) = event.session_id()
+                {
+                    captured_session_id = Some(sid.to_string());
+                }
+                if event.is_result()
+                    && captured_result.is_none()
+                    && let Ok(qr) = serde_json::from_value::<QueryResult>(event.data.clone())
+                {
+                    captured_result = Some(qr);
+                }
+                handler(event);
+            };
+            stream_query(&self.claude, &cmd, wrap).await
         };
-        Ok((forked, result))
+
+        if let Some(sid) = captured_session_id {
+            self.session_id = Some(sid);
+        }
+        if let Some(qr) = captured_result {
+            self.record(&qr);
+        }
+
+        outcome.map(|_| ())
     }
 
-    /// Get the current session ID.
-    pub fn id(&self) -> &str {
-        &self.session_id
+    /// Current session id, if one has been established.
+    pub fn id(&self) -> Option<&str> {
+        self.session_id.as_deref()
     }
 
-    /// Get cumulative cost in USD across all queries in this session.
+    /// Cumulative cost in USD across all turns in this session.
     pub fn total_cost_usd(&self) -> f64 {
         self.cumulative_cost_usd
     }
 
-    /// Get cumulative turn count across all queries in this session.
+    /// Cumulative turn count across all turns in this session.
     pub fn total_turns(&self) -> u32 {
         self.cumulative_turns
     }
-}
 
-/// Builder for a follow-up query within a session.
-///
-/// This wraps a [`QueryCommand`] with `--resume` pre-set. Session-related
-/// methods (`.continue_session()`, `.session_id()`, `.fork_session()`,
-/// `.resume()`) are intentionally not exposed, preventing conflicting flags
-/// at the type level.
-///
-/// All other `QueryCommand` options are available via delegation.
-#[derive(Debug)]
-pub struct SessionQuery<'s, 'a> {
-    session: &'s mut Session<'a>,
-    command: QueryCommand,
-}
-
-impl<'s, 'a> SessionQuery<'s, 'a> {
-    fn new(session: &'s mut Session<'a>, prompt: impl Into<String>) -> Self {
-        let command = QueryCommand::new(prompt).resume(&session.session_id);
-        Self { session, command }
+    /// Full per-turn result history.
+    pub fn history(&self) -> &[QueryResult] {
+        &self.history
     }
 
-    /// Set the model to use.
-    #[must_use]
-    pub fn model(mut self, model: impl Into<String>) -> Self {
-        self.command = self.command.model(model);
-        self
+    /// Result of the most recent turn, if any.
+    pub fn last_result(&self) -> Option<&QueryResult> {
+        self.history.last()
     }
 
-    /// Set a custom system prompt.
-    #[must_use]
-    pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
-        self.command = self.command.system_prompt(prompt);
-        self
-    }
-
-    /// Append to the default system prompt.
-    #[must_use]
-    pub fn append_system_prompt(mut self, prompt: impl Into<String>) -> Self {
-        self.command = self.command.append_system_prompt(prompt);
-        self
-    }
-
-    /// Set the output format.
-    #[must_use]
-    pub fn output_format(mut self, format: OutputFormat) -> Self {
-        self.command = self.command.output_format(format);
-        self
-    }
-
-    /// Set the maximum budget in USD.
-    #[must_use]
-    pub fn max_budget_usd(mut self, budget: f64) -> Self {
-        self.command = self.command.max_budget_usd(budget);
-        self
-    }
-
-    /// Set the permission mode.
-    #[must_use]
-    pub fn permission_mode(mut self, mode: PermissionMode) -> Self {
-        self.command = self.command.permission_mode(mode);
-        self
-    }
-
-    /// Add allowed tools.
-    #[must_use]
-    pub fn allowed_tools(mut self, tools: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        self.command = self.command.allowed_tools(tools);
-        self
-    }
-
-    /// Add a single allowed tool.
-    #[must_use]
-    pub fn allowed_tool(mut self, tool: impl Into<String>) -> Self {
-        self.command = self.command.allowed_tool(tool);
-        self
-    }
-
-    /// Add disallowed tools.
-    #[must_use]
-    pub fn disallowed_tools(mut self, tools: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        self.command = self.command.disallowed_tools(tools);
-        self
-    }
-
-    /// Add an MCP config file path.
-    #[must_use]
-    pub fn mcp_config(mut self, path: impl Into<String>) -> Self {
-        self.command = self.command.mcp_config(path);
-        self
-    }
-
-    /// Add an additional directory for tool access.
-    #[must_use]
-    pub fn add_dir(mut self, dir: impl Into<String>) -> Self {
-        self.command = self.command.add_dir(dir);
-        self
-    }
-
-    /// Set the effort level.
-    #[must_use]
-    pub fn effort(mut self, effort: Effort) -> Self {
-        self.command = self.command.effort(effort);
-        self
-    }
-
-    /// Set the maximum number of turns.
-    #[must_use]
-    pub fn max_turns(mut self, turns: u32) -> Self {
-        self.command = self.command.max_turns(turns);
-        self
-    }
-
-    /// Set a JSON schema for structured output validation.
-    #[must_use]
-    pub fn json_schema(mut self, schema: impl Into<String>) -> Self {
-        self.command = self.command.json_schema(schema);
-        self
-    }
-
-    /// Set a fallback model.
-    #[must_use]
-    pub fn fallback_model(mut self, model: impl Into<String>) -> Self {
-        self.command = self.command.fallback_model(model);
-        self
-    }
-
-    /// Disable session persistence.
-    #[must_use]
-    pub fn no_session_persistence(mut self) -> Self {
-        self.command = self.command.no_session_persistence();
-        self
-    }
-
-    /// Bypass all permission checks.
-    #[must_use]
-    pub fn dangerously_skip_permissions(mut self) -> Self {
-        self.command = self.command.dangerously_skip_permissions();
-        self
-    }
-
-    /// Set the agent for the session.
-    #[must_use]
-    pub fn agent(mut self, agent: impl Into<String>) -> Self {
-        self.command = self.command.agent(agent);
-        self
-    }
-
-    /// Set custom agents as a JSON object.
-    #[must_use]
-    pub fn agents_json(mut self, json: impl Into<String>) -> Self {
-        self.command = self.command.agents_json(json);
-        self
-    }
-
-    /// Set the list of available built-in tools.
-    #[must_use]
-    pub fn tools(mut self, tools: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        self.command = self.command.tools(tools);
-        self
-    }
-
-    /// Add a file resource to download at startup.
-    #[must_use]
-    pub fn file(mut self, spec: impl Into<String>) -> Self {
-        self.command = self.command.file(spec);
-        self
-    }
-
-    /// Include partial message chunks as they arrive.
-    #[must_use]
-    pub fn include_partial_messages(mut self) -> Self {
-        self.command = self.command.include_partial_messages();
-        self
-    }
-
-    /// Set the input format.
-    #[must_use]
-    pub fn input_format(mut self, format: InputFormat) -> Self {
-        self.command = self.command.input_format(format);
-        self
-    }
-
-    /// Only use MCP servers from `--mcp-config`.
-    #[must_use]
-    pub fn strict_mcp_config(mut self) -> Self {
-        self.command = self.command.strict_mcp_config();
-        self
-    }
-
-    /// Path to a settings JSON file or a JSON string.
-    #[must_use]
-    pub fn settings(mut self, settings: impl Into<String>) -> Self {
-        self.command = self.command.settings(settings);
-        self
-    }
-
-    /// Set a per-command retry policy.
-    #[must_use]
-    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
-        self.command = self.command.retry(policy);
-        self
-    }
-
-    /// Execute the query, updating the session's cumulative cost and turns.
-    pub async fn execute(self) -> Result<QueryResult> {
-        let result = self.command.execute_json(self.session.claude).await?;
-        self.session.cumulative_cost_usd += result.cost_usd.unwrap_or(0.0);
-        self.session.cumulative_turns += result.num_turns.unwrap_or(0);
-        self.session.session_id.clone_from(&result.session_id);
-        Ok(result)
+    fn record(&mut self, result: &QueryResult) {
+        self.session_id = Some(result.session_id.clone());
+        self.cumulative_cost_usd += result.cost_usd.unwrap_or(0.0);
+        self.cumulative_turns += result.num_turns.unwrap_or(0);
+        self.history.push(result.clone());
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ClaudeCommand;
 
-    fn test_claude() -> Claude {
-        Claude::builder()
-            .binary("/usr/local/bin/claude")
-            .build()
-            .unwrap()
-    }
-
-    fn test_result(session_id: &str, cost: f64, turns: u32) -> QueryResult {
-        QueryResult {
-            result: "test".into(),
-            session_id: session_id.into(),
-            cost_usd: Some(cost),
-            duration_ms: None,
-            num_turns: Some(turns),
-            is_error: false,
-            extra: Default::default(),
-        }
+    fn test_claude() -> Arc<Claude> {
+        Arc::new(
+            Claude::builder()
+                .binary("/usr/local/bin/claude")
+                .build()
+                .unwrap(),
+        )
     }
 
     #[test]
-    fn session_from_result_captures_state() {
-        let claude = test_claude();
-        let result = test_result("sess-abc", 0.05, 3);
-        let session = Session::from_result(&claude, &result);
-
-        assert_eq!(session.id(), "sess-abc");
-        assert!((session.total_cost_usd() - 0.05).abs() < f64::EPSILON);
-        assert_eq!(session.total_turns(), 3);
-    }
-
-    #[test]
-    fn session_from_id_starts_clean() {
-        let claude = test_claude();
-        let session = Session::from_id(&claude, "sess-xyz");
-
-        assert_eq!(session.id(), "sess-xyz");
-        assert!((session.total_cost_usd()).abs() < f64::EPSILON);
+    fn new_session_has_no_id() {
+        let session = Session::new(test_claude());
+        assert!(session.id().is_none());
+        assert_eq!(session.total_cost_usd(), 0.0);
         assert_eq!(session.total_turns(), 0);
+        assert!(session.history().is_empty());
+        assert!(session.last_result().is_none());
     }
 
     #[test]
-    fn session_from_result_handles_none_cost_and_turns() {
-        let claude = test_claude();
-        let result = QueryResult {
-            result: "ok".into(),
-            session_id: "s1".into(),
-            cost_usd: None,
-            duration_ms: None,
-            num_turns: None,
-            is_error: false,
-            extra: Default::default(),
-        };
-        let session = Session::from_result(&claude, &result);
-
+    fn resume_session_has_preset_id() {
+        let session = Session::resume(test_claude(), "sess-abc");
+        assert_eq!(session.id(), Some("sess-abc"));
         assert_eq!(session.total_cost_usd(), 0.0);
         assert_eq!(session.total_turns(), 0);
     }
 
     #[test]
-    fn session_query_sets_resume_flag() {
-        let claude = test_claude();
-        let mut session = Session::from_id(&claude, "sess-123");
-        let sq = session.query("follow up");
+    fn record_updates_state() {
+        let mut session = Session::new(test_claude());
+        let result = QueryResult {
+            result: "ok".into(),
+            session_id: "sess-1".into(),
+            cost_usd: Some(0.05),
+            duration_ms: None,
+            num_turns: Some(3),
+            is_error: false,
+            extra: Default::default(),
+        };
+        session.record(&result);
+        assert_eq!(session.id(), Some("sess-1"));
+        assert!((session.total_cost_usd() - 0.05).abs() < f64::EPSILON);
+        assert_eq!(session.total_turns(), 3);
+        assert_eq!(session.history().len(), 1);
+        assert_eq!(
+            session.last_result().map(|r| r.session_id.as_str()),
+            Some("sess-1")
+        );
+    }
 
-        let args = sq.command.args();
+    #[test]
+    fn record_accumulates_across_turns() {
+        let mut session = Session::new(test_claude());
+        let r1 = QueryResult {
+            result: "a".into(),
+            session_id: "sess-1".into(),
+            cost_usd: Some(0.01),
+            duration_ms: None,
+            num_turns: Some(2),
+            is_error: false,
+            extra: Default::default(),
+        };
+        let r2 = QueryResult {
+            result: "b".into(),
+            session_id: "sess-1".into(),
+            cost_usd: Some(0.02),
+            duration_ms: None,
+            num_turns: Some(1),
+            is_error: false,
+            extra: Default::default(),
+        };
+        session.record(&r1);
+        session.record(&r2);
+        assert_eq!(session.total_turns(), 3);
+        assert!((session.total_cost_usd() - 0.03).abs() < f64::EPSILON);
+        assert_eq!(session.history().len(), 2);
+    }
+
+    #[test]
+    fn replace_session_clears_conflicting_flags() {
+        use crate::command::ClaudeCommand;
+
+        // Verify that replace_session strips --continue/--session-id/
+        // --fork-session and sets --resume to the given id.
+        let cmd = QueryCommand::new("hi")
+            .continue_session()
+            .session_id("old")
+            .fork_session()
+            .replace_session("new-id");
+
+        let args = cmd.args();
         assert!(args.contains(&"--resume".to_string()));
-        assert!(args.contains(&"sess-123".to_string()));
-    }
-
-    #[test]
-    fn session_query_model_delegation() {
-        let claude = test_claude();
-        let mut session = Session::from_id(&claude, "sess-123");
-        let sq = session.query("follow up").model("sonnet");
-
-        let args = sq.command.args();
-        assert!(args.contains(&"--model".to_string()));
-        assert!(args.contains(&"sonnet".to_string()));
-    }
-
-    #[test]
-    fn session_query_effort_delegation() {
-        let claude = test_claude();
-        let mut session = Session::from_id(&claude, "sess-123");
-        let sq = session.query("follow up").effort(Effort::High);
-
-        let args = sq.command.args();
-        assert!(args.contains(&"--effort".to_string()));
-        assert!(args.contains(&"high".to_string()));
-    }
-
-    #[test]
-    fn session_query_max_turns_delegation() {
-        let claude = test_claude();
-        let mut session = Session::from_id(&claude, "sess-123");
-        let sq = session.query("follow up").max_turns(10);
-
-        let args = sq.command.args();
-        assert!(args.contains(&"--max-turns".to_string()));
-        assert!(args.contains(&"10".to_string()));
-    }
-
-    #[test]
-    fn session_query_prompt_is_last_arg() {
-        let claude = test_claude();
-        let mut session = Session::from_id(&claude, "sess-123");
-        let sq = session.query("my prompt");
-
-        let args = sq.command.args();
-        assert_eq!(args.last().unwrap(), "my prompt");
-    }
-
-    #[test]
-    fn session_query_does_not_have_continue_or_fork() {
-        // This is a compile-time check: SessionQuery does not expose
-        // .continue_session(), .session_id(), .fork_session(), or .resume().
-        // If any of those methods existed on SessionQuery, they would appear
-        // in the API. We verify structurally by checking that the inner
-        // command only has --resume set (no --continue, --fork-session, --session-id).
-        let claude = test_claude();
-        let mut session = Session::from_id(&claude, "sess-123");
-        let sq = session.query("test");
-
-        let args = sq.command.args();
+        assert!(args.contains(&"new-id".to_string()));
         assert!(!args.contains(&"--continue".to_string()));
-        assert!(!args.contains(&"--fork-session".to_string()));
         assert!(!args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"--fork-session".to_string()));
     }
 }

--- a/crates/claude-wrapper/src/streaming.rs
+++ b/crates/claude-wrapper/src/streaming.rs
@@ -48,8 +48,14 @@ impl StreamEvent {
     }
 
     /// Get the cost in USD if present (usually on result events).
+    ///
+    /// Prefers `total_cost_usd` (the CLI's primary key) and falls back
+    /// to the legacy `cost_usd` alias.
     pub fn cost_usd(&self) -> Option<f64> {
-        self.data.get("cost_usd").and_then(|v| v.as_f64())
+        self.data
+            .get("total_cost_usd")
+            .or_else(|| self.data.get("cost_usd"))
+            .and_then(|v| v.as_f64())
     }
 }
 

--- a/crates/claude-wrapper/src/types.rs
+++ b/crates/claude-wrapper/src/types.rs
@@ -323,6 +323,23 @@ mod tests {
     }
 
     #[test]
+    fn query_result_from_stream_result_event() {
+        // Exact shape of a --output-format stream-json "result" event.
+        // The flattened `extra` must absorb type/subtype without
+        // breaking typed field parsing.
+        let json = r#"{"type":"result","subtype":"success","result":"streamed","session_id":"sess-1","total_cost_usd":0.03,"num_turns":1,"is_error":false}"#;
+        let qr: QueryResult = serde_json::from_str(json).unwrap();
+        assert_eq!(qr.cost_usd, Some(0.03));
+        assert_eq!(qr.num_turns, Some(1));
+        assert_eq!(qr.session_id, "sess-1");
+        assert_eq!(qr.result, "streamed");
+        assert_eq!(
+            qr.extra.get("type").and_then(|v| v.as_str()),
+            Some("result")
+        );
+    }
+
+    #[test]
     fn query_result_deserializes_num_turns() {
         let json = r#"{"result":"done","session_id":"s2","total_cost_usd":0.1,"num_turns":5,"is_error":false}"#;
         let qr: QueryResult = serde_json::from_str(json).unwrap();

--- a/crates/claude-wrapper/tests/fake_claude.rs
+++ b/crates/claude-wrapper/tests/fake_claude.rs
@@ -322,100 +322,205 @@ async fn command_failed_without_working_dir_is_none() {
     }
 }
 
-/// Verify that Session tracks cumulative cost and turns across queries.
+// ── Session API (#523) ───────────────────────────────────────────────
+
+/// New session: first `send` discovers the id; second `send` reuses it
+/// via --resume, and cumulative cost/turns accumulate.
 #[tokio::test]
-async fn session_query_resumes_and_tracks_cost() {
+async fn session_send_accumulates_across_turns() {
     use claude_wrapper::session::Session;
+    use std::sync::Arc;
 
-    let claude = claude_with_env(&[
-        ("FAKE_CLAUDE_OUTPUT", "first"),
-        ("FAKE_CLAUDE_SESSION_ID", "sess-001"),
-        ("FAKE_CLAUDE_COST_USD", "0.05"),
-        ("FAKE_CLAUDE_NUM_TURNS", "3"),
-    ]);
+    let claude = Arc::new(
+        Claude::builder()
+            .binary(fake_binary())
+            .env("FAKE_CLAUDE_OUTPUT", "hello")
+            .env("FAKE_CLAUDE_SESSION_ID", "sess-001")
+            .env("FAKE_CLAUDE_COST_USD", "0.05")
+            .env("FAKE_CLAUDE_NUM_TURNS", "2")
+            .build()
+            .expect("failed to build client"),
+    );
 
-    // Initial query to get a session
-    let first = QueryCommand::new("start")
-        .execute_json(&claude)
+    let mut session = Session::new(Arc::clone(&claude));
+    assert!(session.id().is_none());
+
+    let first = session
+        .send("start")
         .await
-        .expect("initial query should succeed");
-
+        .expect("first send should succeed");
     assert_eq!(first.session_id, "sess-001");
-
-    let mut session = Session::from_result(&claude, &first);
-    assert_eq!(session.id(), "sess-001");
+    assert_eq!(session.id(), Some("sess-001"));
     assert!((session.total_cost_usd() - 0.05).abs() < f64::EPSILON);
-    assert_eq!(session.total_turns(), 3);
+    assert_eq!(session.total_turns(), 2);
+    assert_eq!(session.history().len(), 1);
 
-    // Follow-up query accumulates
     let second = session
-        .query("follow up")
-        .execute()
+        .send("follow up")
         .await
-        .expect("follow-up query should succeed");
-
+        .expect("second send should succeed");
     assert_eq!(second.session_id, "sess-001");
     assert!((session.total_cost_usd() - 0.10).abs() < f64::EPSILON);
-    assert_eq!(session.total_turns(), 6);
-}
-
-/// Verify that Session::fork() uses --fork-session and returns a new session.
-#[tokio::test]
-async fn session_fork_creates_new_session() {
-    use claude_wrapper::session::Session;
-
-    let claude = claude_with_env(&[
-        ("FAKE_CLAUDE_OUTPUT", "forked"),
-        ("FAKE_CLAUDE_SESSION_ID", "sess-original"),
-        ("FAKE_CLAUDE_FORKED_SESSION_ID", "sess-forked"),
-        ("FAKE_CLAUDE_COST_USD", "0.02"),
-        ("FAKE_CLAUDE_NUM_TURNS", "1"),
-    ]);
-
-    let session = Session::from_id(&claude, "sess-original");
-
-    let (forked, result) = session
-        .fork("branch this conversation")
-        .await
-        .expect("fork should succeed");
-
-    assert_eq!(result.session_id, "sess-forked");
-    assert_eq!(forked.id(), "sess-forked");
-    // Original session is not modified
-    assert_eq!(session.id(), "sess-original");
-}
-
-/// Verify that Session::continue_recent() uses --continue on the first query.
-#[tokio::test]
-async fn session_continue_recent() {
-    use claude_wrapper::session::Session;
-
-    let claude = claude_with_env(&[
-        ("FAKE_CLAUDE_OUTPUT", "continued"),
-        ("FAKE_CLAUDE_SESSION_ID", "sess-recent"),
-        ("FAKE_CLAUDE_COST_USD", "0.01"),
-        ("FAKE_CLAUDE_NUM_TURNS", "2"),
-    ]);
-
-    let (mut session, first) = Session::continue_recent(&claude, "continue from before")
-        .await
-        .expect("continue_recent should succeed");
-
-    assert_eq!(first.session_id, "sess-recent");
-    assert_eq!(session.id(), "sess-recent");
-    assert!((session.total_cost_usd() - 0.01).abs() < f64::EPSILON);
-    assert_eq!(session.total_turns(), 2);
-
-    // Subsequent query uses --resume
-    let second = session
-        .query("and then?")
-        .execute()
-        .await
-        .expect("follow-up should succeed");
-
-    assert_eq!(second.session_id, "sess-recent");
-    assert!((session.total_cost_usd() - 0.02).abs() < f64::EPSILON);
     assert_eq!(session.total_turns(), 4);
+    assert_eq!(session.history().len(), 2);
+    assert_eq!(
+        session.last_result().map(|r| r.result.as_str()),
+        Some("hello")
+    );
+}
+
+/// Session::resume starts with a preset id that gets passed on the
+/// first turn.
+#[tokio::test]
+async fn session_resume_uses_preset_id() {
+    use claude_wrapper::session::Session;
+    use std::sync::Arc;
+
+    let claude = Arc::new(
+        Claude::builder()
+            .binary(fake_binary())
+            .env("FAKE_CLAUDE_OUTPUT", "resumed")
+            .env("FAKE_CLAUDE_SESSION_ID", "sess-preset")
+            .build()
+            .expect("failed to build client"),
+    );
+
+    let mut session = Session::resume(claude, "sess-preset");
+    assert_eq!(session.id(), Some("sess-preset"));
+
+    let result = session
+        .send("pick up where we left off")
+        .await
+        .expect("resumed send should succeed");
+    assert_eq!(result.session_id, "sess-preset");
+}
+
+/// Session::execute accepts a caller-built QueryCommand and overrides
+/// any session-related flags the caller set.
+#[tokio::test]
+async fn session_execute_overrides_conflicting_flags() {
+    use claude_wrapper::session::Session;
+    use std::sync::Arc;
+
+    let claude = Arc::new(
+        Claude::builder()
+            .binary(fake_binary())
+            .env("FAKE_CLAUDE_OUTPUT", "ok")
+            .env("FAKE_CLAUDE_SESSION_ID", "sess-real")
+            .build()
+            .expect("failed to build client"),
+    );
+
+    let mut session = Session::resume(Arc::clone(&claude), "sess-real");
+
+    // Caller builds a command with a stale/conflicting resume id +
+    // continue flag. Session::execute should clear those and inject
+    // the session's actual id.
+    let cmd = QueryCommand::new("hi")
+        .model("sonnet")
+        .resume("stale-id")
+        .continue_session();
+
+    let result = session.execute(cmd).await.expect("execute should succeed");
+    // The fake binary echoes whatever session id is in its env var,
+    // but the important check is that the call succeeded (it would
+    // have errored with conflicting --resume + --continue on a real
+    // CLI).
+    assert_eq!(result.session_id, "sess-real");
+}
+
+/// Session::stream captures the session id from the first event that
+/// carries one, even if the caller ignores the session_id field in
+/// their handler.
+#[tokio::test]
+async fn session_stream_captures_session_id() {
+    use claude_wrapper::session::Session;
+    use std::sync::Arc;
+
+    let claude = Arc::new(
+        Claude::builder()
+            .binary(fake_binary())
+            .env("FAKE_CLAUDE_OUTPUT", "streamed")
+            .env("FAKE_CLAUDE_SESSION_ID", "sess-stream-1")
+            .env("FAKE_CLAUDE_COST_USD", "0.03")
+            .env("FAKE_CLAUDE_NUM_TURNS", "1")
+            .build()
+            .expect("failed to build client"),
+    );
+
+    let mut session = Session::new(Arc::clone(&claude));
+    let mut event_count = 0;
+
+    session
+        .stream("tell me a story", |_| {
+            event_count += 1;
+        })
+        .await
+        .expect("stream should succeed");
+
+    assert!(
+        event_count >= 3,
+        "expected at least 3 events (system/assistant/result)"
+    );
+    assert_eq!(session.id(), Some("sess-stream-1"));
+    assert!((session.total_cost_usd() - 0.03).abs() < f64::EPSILON);
+    assert_eq!(session.total_turns(), 1);
+    assert_eq!(session.history().len(), 1);
+}
+
+/// After a stream, a subsequent plain `send` resumes the captured id.
+#[tokio::test]
+async fn session_stream_then_send_resumes() {
+    use claude_wrapper::session::Session;
+    use std::sync::Arc;
+
+    let claude = Arc::new(
+        Claude::builder()
+            .binary(fake_binary())
+            .env("FAKE_CLAUDE_OUTPUT", "x")
+            .env("FAKE_CLAUDE_SESSION_ID", "sess-stream-2")
+            .build()
+            .expect("failed to build client"),
+    );
+
+    let mut session = Session::new(Arc::clone(&claude));
+    session
+        .stream("first", |_| {})
+        .await
+        .expect("stream should succeed");
+    assert_eq!(session.id(), Some("sess-stream-2"));
+
+    let second = session
+        .send("second")
+        .await
+        .expect("follow-up send should succeed");
+    assert_eq!(second.session_id, "sess-stream-2");
+}
+
+/// Session is Send + Sync (compile check): Arc<Claude> unlocks this.
+#[tokio::test]
+async fn session_is_send_and_sync() {
+    use claude_wrapper::session::Session;
+    use std::sync::Arc;
+
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Session>();
+
+    // And can be moved into a spawned task.
+    let claude = Arc::new(
+        Claude::builder()
+            .binary(fake_binary())
+            .env("FAKE_CLAUDE_OUTPUT", "spawned")
+            .build()
+            .expect("failed to build client"),
+    );
+
+    let session = Session::new(claude);
+    let handle = tokio::spawn(async move {
+        // just exercise that Session moved in
+        session.id().map(|s| s.to_string())
+    });
+    let _ = handle.await.unwrap();
 }
 
 // ── Subcommand execution tests ───────────────────────────────────────

--- a/crates/test-helpers/fake-claude.sh
+++ b/crates/test-helpers/fake-claude.sh
@@ -61,7 +61,7 @@ if [[ "$OUTPUT_FORMAT" == "stream-json" ]]; then
     ESCAPED_OUTPUT=$(printf '%s' "$OUTPUT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g')
     printf '{"type":"system","subtype":"init","session_id":"%s","tools":[],"mcp_servers":[]}\n' "$SESSION_ID"
     printf '{"type":"assistant","message":{"id":"msg_fake","type":"message","role":"assistant","content":[{"type":"text","text":"%s"}],"model":"claude-fake","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":5,"output_tokens":3}},"session_id":"%s"}\n' "$ESCAPED_OUTPUT" "$SESSION_ID"
-    printf '{"type":"result","subtype":"success","result":"%s","session_id":"%s","cost_usd":%s,"total_cost_usd":%s,"num_turns":%s,"is_error":false}\n' "$ESCAPED_OUTPUT" "$SESSION_ID" "$COST_USD" "$COST_USD" "$NUM_TURNS"
+    printf '{"type":"result","subtype":"success","result":"%s","session_id":"%s","total_cost_usd":%s,"num_turns":%s,"is_error":false}\n' "$ESCAPED_OUTPUT" "$SESSION_ID" "$COST_USD" "$NUM_TURNS"
 elif [[ "$OUTPUT_FORMAT" == "json" ]]; then
     # Emit a single JSON object matching QueryResult.
     ESCAPED_OUTPUT=$(printf '%s' "$OUTPUT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g')


### PR DESCRIPTION
Closes #523. Bumps claude-wrapper to **0.5.0** (breaking).

## Why

`Session` previously borrowed `&'a Claude`, which meant sessions couldn't be moved between tasks, stored in long-lived actor state, or shared across async contexts -- which is exactly the shape callers like [centralino](https://github.com/joshrotenberg/centralino) need. The old API also required a 30-method `SessionQuery` delegation wrapper to mirror `QueryCommand`, and had no streaming support at all -- callers had to hand-roll `session_id` capture from raw `StreamEvent`s, and lose it on any error path. #523 describes all of this.

## What changed

### Session ownership: `Arc<Claude>`

```rust
let claude = Arc::new(Claude::builder().build()?);
let mut session = Session::new(Arc::clone(&claude));
```

`Session` is now `Send + Sync` and can be moved into spawned tasks or stored in a long-lived struct. One `Arc::clone` per session; trivial cost in exchange for actually-usable ownership.

### Two entry points, no delegation mirror

```rust
// Simple path
let r = session.send("explain quicksort").await?;

// Full control: pass a fully-configured QueryCommand
let r = session
    .execute(QueryCommand::new("explain mergesort").model("opus").max_turns(5))
    .await?;
```

This replaces the 30-method `SessionQuery` mirror. Any session-related flags on the command (`--resume`, `--continue`, `--session-id`, `--fork-session`) are overridden via a new private `QueryCommand::replace_session` helper so they can't conflict at the CLI.

### Streaming with auto-capture

```rust
session.stream("tell me a story", |event| {
    println!("[{:?}] {:?}", event.event_type(), event.data);
}).await?;
```

The wrapper handler captures `session_id` from the first event that carries one *before* calling the caller's handler, and the session state is updated **regardless of whether the stream succeeds or errors partway through**. This closes #523's explicitly-called-out "worst footgun".

### Resume constructor

```rust
let mut session = Session::resume(claude, "sess-abc123");
let r = session.send("pick up where we left off").await?;
```

First turn immediately passes `--resume <id>`.

### History + state accessors

`id()`, `total_cost_usd()`, `total_turns()`, `history()`, `last_result()`.

## Deleted surface

- `SessionQuery` (the 30-method mirror -- the point of this PR)
- `Session::from_result`, `Session::from_id`, `Session::fork`, `Session::continue_recent`

Callers using the old API update to `Session::new` / `Session::resume` and either `send` or `execute`. No shim: pre-1.0, effectively no external users, hard break is cleaner than noise.

## Side fixes shaken out while doing this

- **`fake-claude.sh` bug**: emitted both `cost_usd` and `total_cost_usd` on result events, which is a duplicate-field error when deserialized into `QueryResult` (which has `rename` + `alias`). Real CLI only emits `total_cost_usd`; fake now matches. This was silently breaking any test that tried to deserialize a streamed result event into a `QueryResult`.
- **`StreamEvent::cost_usd()`** now prefers `total_cost_usd` and falls back to the legacy `cost_usd` alias, matching `QueryResult`'s behavior.

## Test plan

- [x] 108 lib tests (+1 new `QueryResult` round-trip case for the shape `fake-claude.sh` emits)
- [x] 31 integration tests against `fake-claude.sh` -- 6 new Session API tests (send accumulates, resume uses preset id, execute overrides conflicting flags, stream captures id, stream then send resumes, Session is Send + Sync / spawnable), old `fork` / `continue_recent` / `from_result` tests removed
- [x] 38 doc tests
- [x] `cargo clippy -p claude-wrapper --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --workspace`

## Followups I deliberately punted

- Named agent pool / centralino-style coordination -- belongs in a separate crate on top of this reshape.
- `#453` (QueryCommand oversized) -- closed per earlier discussion; the 43-method shape is idiomatic in both elixir and rust.