### PR TITLE
docs: deprecation banners and README audit for 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,55 @@
 # claude-wrapper
 
-Rust tooling for the Claude Code CLI.
+Type-safe Rust wrapper around the Claude Code CLI.
 
 [![Crates.io](https://img.shields.io/crates/v/claude-wrapper.svg)](https://crates.io/crates/claude-wrapper)
 [![Documentation](https://docs.rs/claude-wrapper/badge.svg)](https://docs.rs/claude-wrapper)
 [![CI](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml)
 [![License](https://img.shields.io/crates/l/claude-wrapper.svg)](LICENSE-MIT)
 
-## Crates
-
-| Crate | Purpose | Status |
-|---|---|---|
-| **[claude-wrapper](crates/claude-wrapper/)** | Type-safe Rust interface to Claude Code CLI | Stable |
-| **[claudes](crates/claudes/)** | Manifest-driven parallel execution engine | Active development |
-| **[claude-pool](crates/claude-pool/)** | Coordinator/worker orchestration | Deprecated (use claudes) |
-| **[claude-pool-mcp](crates/claude-pool-mcp/)** | MCP server exposing pool as tools | Deprecated (use claudes) |
-
-## claudes
-
-Run headless Claude Code sessions in parallel from a manifest. Write a JSON or TOML
-document describing your tasks, and claudes runs them concurrently in isolated git
-worktrees with streaming output and post-hook validation.
-
-```bash
-# Run tasks from prompts
-claudes run -p "fix the pagination bug" -p "add unit tests" -v
-
-# Use AI to generate a manifest
-claudes generate -p "work on the three open bugs as separate tasks"
-
-# Run from a manifest file
-claudes run --manifest plan.json -v
-
-# Check results
-claudes status
-claudes metrics
-```
-
-### Example manifest (TOML)
-
-```toml
-[shared]
-model = "sonnet"
-max_turns = 30
-post_hooks = ["cargo fmt --check", "cargo test --lib"]
-
-[[tasks]]
-name = "fix-pagination"
-prompt = "Fix the pagination bug in src/api/list.rs"
-
-[[tasks]]
-name = "add-tests"
-prompt = "Add unit tests for the auth module"
-```
-
-### Features
-
-- Parallel execution in isolated git worktrees
-- JSON and TOML manifest formats
-- Shared blocks and named profiles
-- Pre/post/finally hooks for validation and cleanup
-- Streaming output with per-task colors (`-v`, `-vv`)
-- Run state with timestamped IDs and cost tracking
-- Auto-discovery of project manifest files
-- `claudes fix` to retry failed tasks with error context
-- `claudes generate` for AI-assisted manifest creation
-- `claudes metrics` for historical analysis
-
-See the [claudes README](crates/claudes/README.md) for full documentation and the
-[prompt guide](crates/claudes/PROMPTING.md) for best practices.
-
-## claude-wrapper
-
-Type-safe Rust wrapper around the Claude Code CLI with builder pattern, typed outputs,
-and async execution.
+This repo publishes a single crate: **[`claude-wrapper`](crates/claude-wrapper/)**, a builder-pattern interface for the `claude` CLI with typed outputs, retry policy, streaming NDJSON, and multi-turn sessions.
 
 ```rust
-use claude_wrapper::{Claude, ClaudeCommand, QueryCommand};
+use std::sync::Arc;
+use claude_wrapper::{Claude, QueryCommand};
+use claude_wrapper::session::Session;
 
 #[tokio::main]
 async fn main() -> claude_wrapper::Result<()> {
-    let claude = Claude::builder().build()?;
+    let claude = Arc::new(Claude::builder().build()?);
+
+    // One-shot query
     let output = QueryCommand::new("explain this error")
         .model("sonnet")
         .max_turns(1)
-        .no_session_persistence()
         .execute(&claude)
         .await?;
     println!("{}", output.stdout);
+
+    // Multi-turn session (auto-resume)
+    let mut session = Session::new(claude);
+    let first = session.send("what's 2 + 2?").await?;
+    let second = session.send("and squared?").await?;
+    println!("cost: ${:.4}", session.total_cost_usd());
+
     Ok(())
 }
 ```
 
-See the [claude-wrapper README](crates/claude-wrapper/README.md) for full API docs.
+See the [crate README](crates/claude-wrapper/README.md) for the full API.
+
+## Deprecated crates
+
+The following crates live in-tree for git history but are **not published, not maintained, and excluded from the workspace build**:
+
+| Crate | Status | Notes |
+|---|---|---|
+| [claudes](crates/claudes/) | Deprecated | Manifest-driven parallel execution engine. Superseded by similar tooling elsewhere. |
+| [claude-pool](crates/claude-pool/) | Deprecated | Slot pool orchestration. |
+| [claude-pool-mcp](crates/claude-pool-mcp/) | Deprecated | MCP server over claude-pool. |
+| [claude-runner](crates/claude-runner/) | Deprecated | Autonomous GitHub issue runner. |
+
+To revive one, move it from `[workspace] exclude` back into `[workspace] members` in the root `Cargo.toml`.
 
 ## Development
 
@@ -102,8 +59,11 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo test --lib --all-features
 cargo test --doc --all-features
 
-# claudes integration tests (requires fake-claude binary)
-cargo test --test fake_claude -p claudes -- --ignored
+# Integration tests against the fake-claude binary (no real CLI needed)
+cargo test -p claude-wrapper --test fake_claude --all-features
+
+# Integration tests against a real claude binary (ignored by default)
+cargo test -p claude-wrapper --test integration -- --ignored
 ```
 
 ## License

--- a/crates/claude-pool-mcp/README.md
+++ b/crates/claude-pool-mcp/README.md
@@ -1,5 +1,13 @@
 # claude-pool-mcp
 
+> **⚠ DEPRECATED — unmaintained and not published.**
+>
+> `claude-pool-mcp` is kept in the repo for git history but is `publish = false`, excluded from the workspace build, and will not receive updates. This crate depends on the also-deprecated [`claude-pool`](../claude-pool/). The maintained crate in this repo is [`claude-wrapper`](../claude-wrapper/).
+>
+> To revive this crate, move it from `[workspace] exclude` back into `[workspace] members` in the root `Cargo.toml`.
+
+---
+
 MCP server exposing claude-pool as tools for Claude Code.
 
 ## Overview

--- a/crates/claude-pool/README.md
+++ b/crates/claude-pool/README.md
@@ -1,10 +1,16 @@
 # claude-pool
 
-Slot pool orchestration library for Claude CLI
+> **⚠ DEPRECATED — unmaintained and not published.**
+>
+> `claude-pool` is kept in the repo for git history but is `publish = false`, excluded from the workspace build, and will not receive updates. The maintained crate in this repo is [`claude-wrapper`](../claude-wrapper/).
+>
+> Old published versions of `claude-pool` (up to 0.4.0) remain on crates.io and will continue to resolve for existing dependents, but no further releases are planned. To revive this crate, move it from `[workspace] exclude` back into `[workspace] members` in the root `Cargo.toml`.
+
+---
+
+Slot pool orchestration library for Claude CLI.
 
 [![Crates.io](https://img.shields.io/crates/v/claude-pool.svg)](https://crates.io/crates/claude-pool)
-[![Documentation](https://docs.rs/claude-pool/badge.svg)](https://docs.rs/claude-pool)
-[![CI](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude-wrapper/actions/workflows/ci.yml)
 [![License](https://img.shields.io/crates/l/claude-pool.svg)](LICENSE-MIT)
 
 ## Overview

--- a/crates/claude-runner/README.md
+++ b/crates/claude-runner/README.md
@@ -1,6 +1,14 @@
 # claude-runner
 
-Autonomous GitHub issue runner — turns issues into pull requests.
+> **⚠ DEPRECATED — unmaintained and not published.**
+>
+> `claude-runner` is kept in the repo for git history but is `publish = false`, excluded from the workspace build, and will not receive updates. The maintained crate in this repo is [`claude-wrapper`](../claude-wrapper/).
+>
+> To revive this crate, move it from `[workspace] exclude` back into `[workspace] members` in the root `Cargo.toml`.
+
+---
+
+Autonomous GitHub issue runner -- turns issues into pull requests.
 
 ## How it works
 

--- a/crates/claude-wrapper/README.md
+++ b/crates/claude-wrapper/README.md
@@ -52,72 +52,70 @@ let claude = Claude::builder()
 ```
 
 Options:
-- `binary_path()` - Path to `claude` binary (auto-detected by default)
+- `binary()` - Path to `claude` binary (auto-detected from PATH by default)
 - `working_dir()` - Working directory for commands
-- `env()` - Set environment variables
-- `timeout_secs()` - Command timeout (default: 300)
-- `global_args()` - Additional global args
+- `env()` / `envs()` - Set environment variables
+- `timeout_secs()` / `timeout()` - Command timeout (no default)
+- `arg()` - Add a global argument applied to every command
+- `retry()` - Default [`RetryPolicy`] applied to every command
 
 ### Command Builders
 
-Each command is a separate builder. Available commands:
+Each CLI subcommand is a separate builder. Available commands:
 
-- **QueryCommand** - Execute queries with full option coverage (28 options)
-- **McpListCommand** - List MCP servers
-- **McpAddCommand** - Add HTTP or stdio MCP server
-- **McpAddJsonCommand** - Add server from JSON config
-- **McpRemoveCommand** - Remove MCP server
-- **McpAddFromDesktopCommand** - Add desktop MCP server
-- **McpResetProjectChoicesCommand** - Reset project-specific choices
-- **PluginListCommand** - List plugins
-- **PluginInstallCommand** - Install plugin
-- **PluginUninstallCommand** - Uninstall plugin
-- **PluginEnableCommand** - Enable plugin
-- **PluginDisableCommand** - Disable plugin
-- **PluginUpdateCommand** - Update plugin
-- **PluginValidateCommand** - Validate plugin
-- **AuthStatusCommand** - Check authentication status
-- **VersionCommand** - Get CLI version
-- **DoctorCommand** - Run health check
-- **AgentsListCommand** - List available agents
-- **RawCommand** - Escape hatch for unsupported options
+**Query**
+- `QueryCommand` - The workhorse; `claude -p` with full option coverage
+
+**MCP server management**
+- `McpListCommand` / `McpGetCommand` / `McpAddCommand` / `McpAddJsonCommand` / `McpRemoveCommand` / `McpAddFromDesktopCommand` / `McpResetProjectChoicesCommand` / `McpServeCommand`
+
+**Plugins**
+- `PluginListCommand` / `PluginInstallCommand` / `PluginUninstallCommand` / `PluginEnableCommand` / `PluginDisableCommand` / `PluginUpdateCommand` / `PluginValidateCommand`
+
+**Plugin marketplace**
+- `MarketplaceListCommand` / `MarketplaceAddCommand` / `MarketplaceRemoveCommand` / `MarketplaceUpdateCommand`
+
+**Auth**
+- `AuthStatusCommand` / `AuthLoginCommand` / `AuthLogoutCommand` / `SetupTokenCommand`
+
+**Misc**
+- `VersionCommand` - Get CLI version
+- `DoctorCommand` - Run health check
+- `AgentsCommand` - List available agents
+- `RawCommand` - Escape hatch for unsupported subcommands
 
 ## QueryCommand: The Workhorse
 
-Full coverage of `claude -p` (print mode) options.
+Full coverage of `claude -p` (print mode). `QueryCommand` exposes a builder method for every CLI flag; see [`docs.rs`](https://docs.rs/claude-wrapper/latest/claude_wrapper/struct.QueryCommand.html) for the full list. The common ones:
 
-### All QueryCommand Options
+| Method | CLI flag | Purpose |
+|---|---|---|
+| `model()` | `--model` | Model alias or full ID |
+| `system_prompt()` / `append_system_prompt()` | `--system-prompt` / `--append-system-prompt` | Override or extend the system prompt |
+| `output_format()` | `--output-format` | `text`, `json`, `stream-json` |
+| `effort()` | `--effort` | `low`, `medium`, `high` |
+| `max_turns()` | `--max-turns` | Turn cap |
+| `max_budget_usd()` | `--max-budget-usd` | Spend cap |
+| `permission_mode()` | `--permission-mode` | `default`, `acceptEdits`, `bypassPermissions`, `dontAsk`, `plan`, `auto` |
+| `allowed_tools()` / `disallowed_tools()` / `tools()` | tool-filter flags | Allow/deny/restrict tools |
+| `mcp_config()` / `strict_mcp_config()` | `--mcp-config` / `--strict-mcp-config` | MCP server config |
+| `json_schema()` | `--json-schema` | Structured output validation |
+| `agent()` / `agents_json()` | `--agent` / `--agents` | Agent or custom agents JSON |
+| `no_session_persistence()` | `--no-session-persistence` | Don't save the session to disk |
+| `dangerously_skip_permissions()` | `--dangerously-skip-permissions` | Sandbox escape hatch |
+| `input_format()` / `include_partial_messages()` | `--input-format` / `--include-partial-messages` | Input/streaming shape |
+| `settings()` / `fallback_model()` / `add_dir()` / `file()` | various | Misc per-turn knobs |
 
-| Method | CLI Flag | Type | Description |
-|--------|----------|------|-------------|
-| `model()` | `--model` | `&str` | Model alias or full ID |
-| `system_prompt()` | `--system-prompt` | `&str` | Replace default system prompt |
-| `append_system_prompt()` | `--append-system-prompt` | `&str` | Append to system prompt |
-| `output_format()` | `--output-format` | `OutputFormat` | text, json, stream-json |
-| `max_budget_usd()` | `--max-budget-usd` | `f64` | Spending cap |
-| `permission_mode()` | `--permission-mode` | `PermissionMode` | default, acceptEdits, bypassPermissions, plan, auto |
-| `allowed_tools()` | `--allowed-tools` | `&[&str]` | Tool permission allow list |
-| `disallowed_tools()` | `--disallowed-tools` | `&[&str]` | Tool permission deny list |
-| `tools()` | `--tools` | `&[&str]` | Restrict available tools |
-| `mcp_config()` | `--mcp-config` | `&str` | MCP server config file |
-| `strict_mcp_config()` | `--strict-mcp-config` | - | Only use MCP from config |
-| `add_dir()` | `--add-dir` | `&str` | Additional accessible directories |
-| `effort()` | `--effort` | `Effort` | low, medium, high |
-| `max_turns()` | `--max-turns` | `u32` | Conversation turn limit |
-| `json_schema()` | `--json-schema` | `&str` | Structured output validation |
-| `agent()` | `--agent` | `&str` | Agent for session |
-| `agents_json()` | `--agents` | `&str` | Custom agents JSON |
-| `continue_session()` | `--continue` | - | Resume most recent session |
-| `resume()` | `--resume` | `&str` | Resume by session ID |
-| `session_id()` | `--session-id` | `&str` | Use specific session ID |
-| `fork_session()` | `--fork-session` | - | Fork when resuming |
-| `fallback_model()` | `--fallback-model` | `&str` | Fallback model |
-| `no_session_persistence()` | `--no-session-persistence` | - | Don't save session |
-| `dangerously_skip_permissions()` | `--dangerously-skip-permissions` | - | Bypass permissions |
-| `file()` | `--file` | `&str` | File resources to download |
-| `input_format()` | `--input-format` | `InputFormat` | text or stream-json |
-| `include_partial_messages()` | `--include-partial-messages` | - | Partial chunks |
-| `settings()` | `--settings` | `&str` | Settings JSON file |
+### Raw session flags (prefer `Session` for multi-turn)
+
+| Method | CLI flag | Purpose |
+|---|---|---|
+| `continue_session()` | `--continue` | Resume most recent session |
+| `resume()` | `--resume` | Resume a specific session id |
+| `session_id()` | `--session-id` | Force a session id |
+| `fork_session()` | `--fork-session` | Fork when resuming |
+
+For multi-turn conversations you almost always want [`Session`](#session-management) instead, which threads the id across turns automatically.
 
 ### Usage Examples
 
@@ -153,10 +151,10 @@ let output = QueryCommand::new("implement the feature in TASK.md")
     .await?;
 ```
 
-Session management (low-level):
+Low-level session flags on `QueryCommand` (rarely needed):
 
 ```rust
-// Start new session
+// Force a specific session id
 let output = QueryCommand::new("analyze the codebase")
     .session_id("my-session")
     .execute(&claude)
@@ -169,7 +167,11 @@ let output = QueryCommand::new("what did we find?")
     .await?;
 ```
 
-Session management (multi-turn, auto-resume):
+<a id="session-management"></a>
+
+## Session management
+
+For multi-turn conversations, wrap the client in an `Arc` and use `Session`. It threads the CLI `session_id` across turns automatically, tracks cumulative cost + history, and supports both plain-prompt and streaming turns:
 
 ```rust
 use std::sync::Arc;
@@ -207,22 +209,31 @@ turns use `Session::stream` / `Session::stream_execute`, which capture
 the session id from the first event that carries one — and persist
 it even if the stream errors partway through.
 
-## Streaming NDJSON Events
+## Streaming NDJSON events
 
-For real-time output, use `stream_query()`:
+For real-time output, use `stream_query()`. The handler is called once per parsed NDJSON line:
 
 ```rust
-use claude_wrapper::streaming::stream_query;
+use claude_wrapper::{Claude, QueryCommand, OutputFormat};
+use claude_wrapper::streaming::{StreamEvent, stream_query};
 
-let output = stream_query(&claude, &cmd, |event| {
-    if event.is_result() {
-        println!("Result: {}", event.result_text().unwrap_or(""));
+let claude = Claude::builder().build()?;
+let cmd = QueryCommand::new("explain quicksort")
+    .output_format(OutputFormat::StreamJson);
+
+stream_query(&claude, &cmd, |event: StreamEvent| {
+    if let Some(t) = event.event_type() {
+        println!("[{t}]");
     }
-    if event.is_error() {
-        eprintln!("Error: {}", event.error().unwrap_or(""));
+    if event.is_result() {
+        println!("result: {}", event.result_text().unwrap_or(""));
+        println!("session: {}", event.session_id().unwrap_or(""));
+        println!("cost: ${:?}", event.cost_usd());
     }
 }).await?;
 ```
+
+For multi-turn streaming with automatic session-id capture, use `Session::stream` / `Session::stream_execute` instead.
 
 ## MCP Server Commands
 
@@ -270,7 +281,7 @@ McpRemoveCommand::new("old-server")
     .await?;
 ```
 
-## MCP Config Builder
+## MCP config builder
 
 Generate `.mcp.json` files programmatically:
 
@@ -283,9 +294,7 @@ McpConfigBuilder::new()
     .write_to("/tmp/my-project/.mcp.json")?;
 ```
 
-Also supports:
-- `env()` - Environment variables for servers
-- `environment_file()` - Load from env file
+With the `tempfile` feature (on by default), `build_temp()` writes to a temporary file that is deleted when the returned `TempMcpConfig` is dropped — useful for one-shot queries.
 
 ## Plugin Management
 
@@ -325,13 +334,12 @@ DoctorCommand::new().execute(&claude).await?;
 AgentsListCommand::new().execute(&claude).await?;
 ```
 
-## Escape Hatch: RawCommand
+## Escape hatch: RawCommand
 
-For unsupported options, use `RawCommand`:
+For subcommands not yet wrapped, use `RawCommand`. Pass the subcommand name to `new()` and any flags via `.arg()`:
 
 ```rust
-let output = RawCommand::new()
-    .arg("custom-subcommand")
+let output = RawCommand::new("custom-subcommand")
     .arg("--unsupported-flag")
     .arg("value")
     .execute(&claude)

--- a/crates/claudes/README.md
+++ b/crates/claudes/README.md
@@ -1,5 +1,13 @@
 # claudes
 
+> **⚠ DEPRECATED — unmaintained and not published.**
+>
+> `claudes` is kept in the repo for git history but is `publish = false`, excluded from the workspace build, and will not receive updates. This tool was an experiment in manifest-driven parallel execution; similar functionality is being pursued in a separate project. The maintained crate in this repo is [`claude-wrapper`](../claude-wrapper/).
+>
+> To revive this crate, move it from `[workspace] exclude` back into `[workspace] members` in the root `Cargo.toml`.
+
+---
+
 Manifest-driven execution engine for headless Claude Code sessions.
 
 Write a manifest describing your tasks. claudes runs them in parallel, each in its own git


### PR DESCRIPTION
Release-prep docs pass. Two themes:

## Deprecation banners

All four unmaintained crates now lead with a visible deprecation callout:

- `crates/claude-pool/README.md`
- `crates/claude-pool-mcp/README.md`
- `crates/claudes/README.md`
- `crates/claude-runner/README.md`

Each banner explains: `publish = false`, excluded from the workspace, no further updates, and how to revive (move back into `[workspace] members`). This matches the state set by #524 (dist/docker removal) and #530 (workspace prune) so the READMEs don't mislead anyone browsing the repo or landing on an old crates.io page.

## Root README overhaul

Replaces the old claudes-centric landing page with a claude-wrapper-focused one:

- Quick start actually reflects the 0.5.0 `Arc<Claude>` + `Session` API
- Deprecated-crates table points at each banner
- Dev section no longer tries to run `cargo test -p claudes` (which doesn't work after #530)

## `claude-wrapper` README audit

Fixes a pile of stale references that accumulated across 0.3 / 0.4 / 0.5. All verified against current source:

- **Claude builder options**: `binary_path` → `binary`, `global_args` → `arg`; added `retry()` which existed but wasn't documented.
- **Command builder list**: added `McpGetCommand`, `McpServeCommand`, `McpAddFromDesktopCommand`, `McpResetProjectChoicesCommand`, the four `Marketplace*` commands, `AuthLoginCommand` / `AuthLogoutCommand` / `SetupTokenCommand`, `PluginValidateCommand`; renamed `AgentsListCommand` to the actual name (`AgentsCommand`).
- **QueryCommand table**: removed the `(28 options)` stale count and the exhaustive column-heavy table (it drifted every release). Kept the common options and pointed at docs.rs for the rest. Split session flags into their own sub-table with a pointer to the high-level `Session` API.
- **Streaming example**: removed calls to `.is_error()` and `.error()` on `StreamEvent` -- neither method exists. Rewrote around the actual `event_type` / `is_result` / `result_text` / `session_id` / `cost_usd` accessors.
- **`McpConfigBuilder`**: removed the phantom `environment_file()` method; added a mention of `build_temp()` + `TempMcpConfig` under the `tempfile` feature.
- **`RawCommand` example**: `RawCommand::new()` requires a subcommand argument; old example didn't pass one and wouldn't compile.

## Test plan

- [x] Docs-only change; no source modified
- [x] `cargo test -p claude-wrapper --all-features` -- 108 lib + 31 integration + 38 doc tests
- [x] Each fix cross-checked against the actual source: `src/lib.rs` exports, `src/command/*.rs` constructors, `src/streaming.rs` public methods, `src/mcp_config.rs` builder surface.