### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.5.1...v0.6.0) - 2026-04-22
+
+### Added
+
+- isolate bypass-permissions behind `dangerous` module + env-var gate ([#540](https://github.com/joshrotenberg/claude-wrapper/pull/540))
+
 ## [0.5.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.5.0...v0.5.1) - 2026-04-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/claude-wrapper"
 
 [workspace.dependencies]
-claude-wrapper = { path = "crates/claude-wrapper", version = "0.5" }
+claude-wrapper = { path = "crates/claude-wrapper", version = "0.6" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:DangerousNotAllowed in /tmp/.tmp91soED/claude-wrapper/crates/claude-wrapper/src/error.rs:55
  variant Error:DangerousNotAllowed in /tmp/.tmp91soED/claude-wrapper/crates/claude-wrapper/src/error.rs:55
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.5.1...v0.6.0) - 2026-04-22

### Added

- isolate bypass-permissions behind `dangerous` module + env-var gate ([#540](https://github.com/joshrotenberg/claude-wrapper/pull/540))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).