### PR TITLE
feat: add BudgetTracker with warning/exceeded callbacks

### DIFF
--- a/crates/claude-wrapper/src/budget.rs
+++ b/crates/claude-wrapper/src/budget.rs
@@ -3,7 +3,7 @@
 //! A [`BudgetTracker`] accumulates cost across turns and fires
 //! caller-supplied callbacks when configurable thresholds are crossed.
 //! When a `max_usd` ceiling is set, [`BudgetTracker::check`] returns
-//! [`Error::BudgetExceeded`](crate::error::Error::BudgetExceeded) once
+//! [`Error::BudgetExceeded`] once
 //! the total is at or above the ceiling, giving callers a hard stop
 //! before the next CLI invocation.
 //!

--- a/crates/claude-wrapper/src/budget.rs
+++ b/crates/claude-wrapper/src/budget.rs
@@ -1,0 +1,419 @@
+//! Cumulative USD budget tracking for Claude sessions.
+//!
+//! A [`BudgetTracker`] accumulates cost across turns and fires
+//! caller-supplied callbacks when configurable thresholds are crossed.
+//! When a `max_usd` ceiling is set, [`BudgetTracker::check`] returns
+//! [`Error::BudgetExceeded`](crate::error::Error::BudgetExceeded) once
+//! the total is at or above the ceiling, giving callers a hard stop
+//! before the next CLI invocation.
+//!
+//! # Ownership and sharing
+//!
+//! `BudgetTracker` wraps its state in `Arc<Mutex<...>>` so clones share
+//! the same running total and fire-once flags. Attach one tracker to a
+//! [`Session`](crate::session::Session), or clone it across several
+//! sessions to enforce a fleet-wide ceiling.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use claude_wrapper::{Claude, BudgetTracker};
+//! use claude_wrapper::session::Session;
+//!
+//! # async fn example() -> claude_wrapper::Result<()> {
+//! let budget = BudgetTracker::builder()
+//!     .max_usd(5.00)
+//!     .warn_at_usd(4.00)
+//!     .on_warning(|total| eprintln!("warning: ${total:.2} spent"))
+//!     .on_exceeded(|total| eprintln!("budget hit: ${total:.2}"))
+//!     .build();
+//!
+//! let claude = Arc::new(Claude::builder().build()?);
+//! let mut session = Session::new(claude).with_budget(budget.clone());
+//!
+//! session.send("hello").await?;
+//! println!("spent so far: ${:.4}", budget.total_usd());
+//! # Ok(())
+//! # }
+//! ```
+
+use std::sync::{Arc, Mutex};
+
+use crate::error::{Error, Result};
+
+type Callback = Arc<dyn Fn(f64) + Send + Sync>;
+
+struct Config {
+    max_usd: Option<f64>,
+    warn_at_usd: Option<f64>,
+    on_warning: Option<Callback>,
+    on_exceeded: Option<Callback>,
+}
+
+#[derive(Default)]
+struct State {
+    total_usd: f64,
+    warned: bool,
+    exceeded: bool,
+}
+
+struct Inner {
+    config: Config,
+    state: Mutex<State>,
+}
+
+/// Cumulative USD budget tracker with threshold callbacks.
+///
+/// See the [module docs](crate::budget) for the full design.
+#[derive(Clone)]
+pub struct BudgetTracker {
+    inner: Arc<Inner>,
+}
+
+impl BudgetTracker {
+    /// Start building a tracker.
+    pub fn builder() -> BudgetBuilder {
+        BudgetBuilder::default()
+    }
+
+    /// Record an additional cost in USD. Fires `on_warning` the first
+    /// time the running total reaches `warn_at_usd`, and `on_exceeded`
+    /// the first time it reaches `max_usd`.
+    pub fn record(&self, cost_usd: f64) {
+        if cost_usd <= 0.0 || !cost_usd.is_finite() {
+            return;
+        }
+
+        let (warn_fired, exceeded_fired, total) = {
+            let mut state = self.inner.state.lock().expect("budget mutex poisoned");
+            state.total_usd += cost_usd;
+
+            let warn_fired = match self.inner.config.warn_at_usd {
+                Some(threshold) if !state.warned && state.total_usd >= threshold => {
+                    state.warned = true;
+                    true
+                }
+                _ => false,
+            };
+
+            let exceeded_fired = match self.inner.config.max_usd {
+                Some(threshold) if !state.exceeded && state.total_usd >= threshold => {
+                    state.exceeded = true;
+                    true
+                }
+                _ => false,
+            };
+
+            (warn_fired, exceeded_fired, state.total_usd)
+        };
+
+        if warn_fired && let Some(cb) = &self.inner.config.on_warning {
+            cb(total);
+        }
+        if exceeded_fired && let Some(cb) = &self.inner.config.on_exceeded {
+            cb(total);
+        }
+    }
+
+    /// Return `Err(Error::BudgetExceeded)` if the running total is at
+    /// or above the configured `max_usd`. Returns `Ok(())` when no
+    /// ceiling is set.
+    pub fn check(&self) -> Result<()> {
+        let Some(max) = self.inner.config.max_usd else {
+            return Ok(());
+        };
+        let total = self
+            .inner
+            .state
+            .lock()
+            .expect("budget mutex poisoned")
+            .total_usd;
+        if total >= max {
+            Err(Error::BudgetExceeded {
+                total_usd: total,
+                max_usd: max,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Cumulative cost recorded so far, in USD.
+    pub fn total_usd(&self) -> f64 {
+        self.inner
+            .state
+            .lock()
+            .expect("budget mutex poisoned")
+            .total_usd
+    }
+
+    /// Remaining budget in USD, if a ceiling is set. Clamped at zero
+    /// once the ceiling is reached.
+    pub fn remaining_usd(&self) -> Option<f64> {
+        let max = self.inner.config.max_usd?;
+        let total = self
+            .inner
+            .state
+            .lock()
+            .expect("budget mutex poisoned")
+            .total_usd;
+        Some((max - total).max(0.0))
+    }
+
+    /// Configured ceiling, if any.
+    pub fn max_usd(&self) -> Option<f64> {
+        self.inner.config.max_usd
+    }
+
+    /// Configured warning threshold, if any.
+    pub fn warn_at_usd(&self) -> Option<f64> {
+        self.inner.config.warn_at_usd
+    }
+
+    /// Clear the running total and re-arm both callbacks.
+    pub fn reset(&self) {
+        let mut state = self.inner.state.lock().expect("budget mutex poisoned");
+        state.total_usd = 0.0;
+        state.warned = false;
+        state.exceeded = false;
+    }
+}
+
+impl std::fmt::Debug for BudgetTracker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = self.inner.state.lock().expect("budget mutex poisoned");
+        f.debug_struct("BudgetTracker")
+            .field("max_usd", &self.inner.config.max_usd)
+            .field("warn_at_usd", &self.inner.config.warn_at_usd)
+            .field("total_usd", &state.total_usd)
+            .field("warned", &state.warned)
+            .field("exceeded", &state.exceeded)
+            .finish()
+    }
+}
+
+/// Builder for [`BudgetTracker`].
+#[derive(Default)]
+pub struct BudgetBuilder {
+    max_usd: Option<f64>,
+    warn_at_usd: Option<f64>,
+    on_warning: Option<Callback>,
+    on_exceeded: Option<Callback>,
+}
+
+impl BudgetBuilder {
+    /// Hard ceiling in USD. Once the running total hits this value,
+    /// [`BudgetTracker::check`] returns [`Error::BudgetExceeded`].
+    pub fn max_usd(mut self, max: f64) -> Self {
+        self.max_usd = Some(max);
+        self
+    }
+
+    /// Warning threshold in USD. [`BudgetBuilder::on_warning`] fires
+    /// the first time the running total reaches this value.
+    pub fn warn_at_usd(mut self, warn: f64) -> Self {
+        self.warn_at_usd = Some(warn);
+        self
+    }
+
+    /// Callback fired once when `warn_at_usd` is crossed. The argument
+    /// is the running total at the crossing.
+    pub fn on_warning<F>(mut self, f: F) -> Self
+    where
+        F: Fn(f64) + Send + Sync + 'static,
+    {
+        self.on_warning = Some(Arc::new(f));
+        self
+    }
+
+    /// Callback fired once when `max_usd` is crossed. The argument is
+    /// the running total at the crossing.
+    pub fn on_exceeded<F>(mut self, f: F) -> Self
+    where
+        F: Fn(f64) + Send + Sync + 'static,
+    {
+        self.on_exceeded = Some(Arc::new(f));
+        self
+    }
+
+    /// Finish construction.
+    pub fn build(self) -> BudgetTracker {
+        BudgetTracker {
+            inner: Arc::new(Inner {
+                config: Config {
+                    max_usd: self.max_usd,
+                    warn_at_usd: self.warn_at_usd,
+                    on_warning: self.on_warning,
+                    on_exceeded: self.on_exceeded,
+                },
+                state: Mutex::new(State::default()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn record_accumulates() {
+        let b = BudgetTracker::builder().build();
+        b.record(0.01);
+        b.record(0.02);
+        b.record(0.03);
+        assert!((b.total_usd() - 0.06).abs() < 1e-9);
+    }
+
+    #[test]
+    fn record_ignores_non_positive_and_non_finite() {
+        let b = BudgetTracker::builder().build();
+        b.record(0.0);
+        b.record(-0.5);
+        b.record(f64::NAN);
+        b.record(f64::INFINITY);
+        assert_eq!(b.total_usd(), 0.0);
+    }
+
+    #[test]
+    fn warn_callback_fires_once_at_threshold() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&count);
+        let b = BudgetTracker::builder()
+            .warn_at_usd(0.10)
+            .on_warning(move |_| {
+                c.fetch_add(1, Ordering::SeqCst);
+            })
+            .build();
+
+        b.record(0.05);
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+        b.record(0.06); // total 0.11 -> crosses
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+        b.record(0.20); // further spend, no re-fire
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn exceeded_callback_fires_once_at_threshold() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&count);
+        let b = BudgetTracker::builder()
+            .max_usd(1.00)
+            .on_exceeded(move |_| {
+                c.fetch_add(1, Ordering::SeqCst);
+            })
+            .build();
+
+        b.record(0.50);
+        b.record(0.49);
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+        b.record(0.02); // total 1.01 -> crosses
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+        b.record(0.50);
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn check_errors_once_over_max() {
+        let b = BudgetTracker::builder().max_usd(0.10).build();
+        b.record(0.05);
+        assert!(b.check().is_ok());
+        b.record(0.05); // total 0.10 -> at threshold
+        match b.check() {
+            Err(Error::BudgetExceeded { total_usd, max_usd }) => {
+                assert!((total_usd - 0.10).abs() < 1e-9);
+                assert!((max_usd - 0.10).abs() < 1e-9);
+            }
+            other => panic!("expected BudgetExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_noop_without_max() {
+        let b = BudgetTracker::builder().build();
+        b.record(1_000.0);
+        assert!(b.check().is_ok());
+    }
+
+    #[test]
+    fn remaining_usd_clamps_at_zero() {
+        let b = BudgetTracker::builder().max_usd(1.00).build();
+        assert_eq!(b.remaining_usd(), Some(1.00));
+        b.record(0.40);
+        assert!((b.remaining_usd().unwrap() - 0.60).abs() < 1e-9);
+        b.record(10.00);
+        assert_eq!(b.remaining_usd(), Some(0.0));
+    }
+
+    #[test]
+    fn remaining_usd_none_without_max() {
+        let b = BudgetTracker::builder().build();
+        assert!(b.remaining_usd().is_none());
+    }
+
+    #[test]
+    fn reset_clears_total_and_rearms_callbacks() {
+        let warn = Arc::new(AtomicUsize::new(0));
+        let exc = Arc::new(AtomicUsize::new(0));
+        let w = Arc::clone(&warn);
+        let e = Arc::clone(&exc);
+        let b = BudgetTracker::builder()
+            .warn_at_usd(0.10)
+            .max_usd(0.20)
+            .on_warning(move |_| {
+                w.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_exceeded(move |_| {
+                e.fetch_add(1, Ordering::SeqCst);
+            })
+            .build();
+
+        b.record(0.25);
+        assert_eq!(warn.load(Ordering::SeqCst), 1);
+        assert_eq!(exc.load(Ordering::SeqCst), 1);
+        assert!(b.check().is_err());
+
+        b.reset();
+        assert_eq!(b.total_usd(), 0.0);
+        assert!(b.check().is_ok());
+
+        b.record(0.25);
+        assert_eq!(warn.load(Ordering::SeqCst), 2);
+        assert_eq!(exc.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn clones_share_state() {
+        let a = BudgetTracker::builder().max_usd(1.00).build();
+        let b = a.clone();
+        a.record(0.60);
+        b.record(0.50);
+        assert!((a.total_usd() - 1.10).abs() < 1e-9);
+        assert!((b.total_usd() - 1.10).abs() < 1e-9);
+        assert!(a.check().is_err());
+        assert!(b.check().is_err());
+    }
+
+    #[test]
+    fn concurrent_record_preserves_total() {
+        use std::thread;
+
+        let b = BudgetTracker::builder().build();
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let b = b.clone();
+            handles.push(thread::spawn(move || {
+                for _ in 0..1000 {
+                    b.record(0.001);
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert!((b.total_usd() - 8.0).abs() < 1e-6);
+    }
+}

--- a/crates/claude-wrapper/src/error.rs
+++ b/crates/claude-wrapper/src/error.rs
@@ -53,6 +53,12 @@ pub enum Error {
         "dangerous operations are not allowed; set the env var `{env_var}=1` at process start if you really mean it"
     )]
     DangerousNotAllowed { env_var: &'static str },
+
+    /// A configured [`BudgetTracker`](crate::budget::BudgetTracker) has
+    /// hit its `max_usd` ceiling. Raised before the next call is
+    /// dispatched, so the CLI is not invoked.
+    #[error("budget exceeded: ${total_usd:.4} spent, ${max_usd:.4} max")]
+    BudgetExceeded { total_usd: f64, max_usd: f64 },
 }
 
 impl From<std::io::Error> for Error {

--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -164,6 +164,7 @@
 //! # }
 //! ```
 
+pub mod budget;
 pub mod command;
 pub mod dangerous;
 pub mod error;
@@ -180,6 +181,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+pub use budget::{BudgetBuilder, BudgetTracker};
 pub use command::ClaudeCommand;
 pub use command::agents::AgentsCommand;
 pub use command::auth::{

--- a/crates/claude-wrapper/src/session.rs
+++ b/crates/claude-wrapper/src/session.rs
@@ -123,7 +123,7 @@ impl Session {
     /// Attach a [`BudgetTracker`] to this session. Every turn's cost
     /// (from [`QueryResult::cost_usd`]) is recorded on the tracker, and
     /// [`Session::execute`]/[`Session::stream_execute`] return
-    /// [`Error::BudgetExceeded`](crate::error::Error::BudgetExceeded)
+    /// [`crate::error::Error::BudgetExceeded`]
     /// before dispatching a turn if the tracker's ceiling has been hit.
     ///
     /// Clone a tracker across several sessions to enforce a shared

--- a/crates/claude-wrapper/src/session.rs
+++ b/crates/claude-wrapper/src/session.rs
@@ -69,6 +69,7 @@
 use std::sync::Arc;
 
 use crate::Claude;
+use crate::budget::BudgetTracker;
 use crate::command::query::QueryCommand;
 use crate::error::Result;
 use crate::types::QueryResult;
@@ -88,6 +89,7 @@ pub struct Session {
     history: Vec<QueryResult>,
     cumulative_cost_usd: f64,
     cumulative_turns: u32,
+    budget: Option<BudgetTracker>,
 }
 
 impl Session {
@@ -100,6 +102,7 @@ impl Session {
             history: Vec::new(),
             cumulative_cost_usd: 0.0,
             cumulative_turns: 0,
+            budget: None,
         }
     }
 
@@ -113,7 +116,26 @@ impl Session {
             history: Vec::new(),
             cumulative_cost_usd: 0.0,
             cumulative_turns: 0,
+            budget: None,
         }
+    }
+
+    /// Attach a [`BudgetTracker`] to this session. Every turn's cost
+    /// (from [`QueryResult::cost_usd`]) is recorded on the tracker, and
+    /// [`Session::execute`]/[`Session::stream_execute`] return
+    /// [`Error::BudgetExceeded`](crate::error::Error::BudgetExceeded)
+    /// before dispatching a turn if the tracker's ceiling has been hit.
+    ///
+    /// Clone a tracker across several sessions to enforce a shared
+    /// ceiling; each `Session` then sees the same running total.
+    pub fn with_budget(mut self, budget: BudgetTracker) -> Self {
+        self.budget = Some(budget);
+        self
+    }
+
+    /// The attached [`BudgetTracker`], if any.
+    pub fn budget(&self) -> Option<&BudgetTracker> {
+        self.budget.as_ref()
     }
 
     /// Send a plain-prompt turn. Equivalent to
@@ -130,6 +152,10 @@ impl Session {
     /// session's current id, so they can't conflict.
     #[cfg(feature = "json")]
     pub async fn execute(&mut self, cmd: QueryCommand) -> Result<QueryResult> {
+        if let Some(b) = &self.budget {
+            b.check()?;
+        }
+
         let cmd = match &self.session_id {
             Some(id) => cmd.replace_session(id),
             None => cmd,
@@ -164,6 +190,10 @@ impl Session {
         F: FnMut(StreamEvent),
     {
         use crate::types::OutputFormat;
+
+        if let Some(b) = &self.budget {
+            b.check()?;
+        }
 
         let cmd = match &self.session_id {
             Some(id) => cmd.replace_session(id),
@@ -233,8 +263,12 @@ impl Session {
 
     fn record(&mut self, result: &QueryResult) {
         self.session_id = Some(result.session_id.clone());
-        self.cumulative_cost_usd += result.cost_usd.unwrap_or(0.0);
+        let cost = result.cost_usd.unwrap_or(0.0);
+        self.cumulative_cost_usd += cost;
         self.cumulative_turns += result.num_turns.unwrap_or(0);
+        if let Some(b) = &self.budget {
+            b.record(cost);
+        }
         self.history.push(result.clone());
     }
 }
@@ -319,6 +353,49 @@ mod tests {
         assert_eq!(session.total_turns(), 3);
         assert!((session.total_cost_usd() - 0.03).abs() < f64::EPSILON);
         assert_eq!(session.history().len(), 2);
+    }
+
+    #[test]
+    fn record_forwards_cost_to_budget() {
+        use crate::budget::BudgetTracker;
+
+        let budget = BudgetTracker::builder().build();
+        let mut session = Session::new(test_claude()).with_budget(budget.clone());
+
+        let r = QueryResult {
+            result: "ok".into(),
+            session_id: "sess-1".into(),
+            cost_usd: Some(0.07),
+            duration_ms: None,
+            num_turns: Some(1),
+            is_error: false,
+            extra: Default::default(),
+        };
+        session.record(&r);
+
+        assert!((budget.total_usd() - 0.07).abs() < 1e-9);
+        assert!((session.total_cost_usd() - 0.07).abs() < 1e-9);
+    }
+
+    #[test]
+    fn budget_pre_check_would_block_next_turn() {
+        use crate::budget::BudgetTracker;
+        use crate::error::Error;
+
+        // The execute() pre-check defers to BudgetTracker::check().
+        // Exercise that directly with a pre-loaded tracker, so we don't
+        // need a live Claude CLI.
+        let budget = BudgetTracker::builder().max_usd(0.10).build();
+        budget.record(0.15);
+
+        let session = Session::new(test_claude()).with_budget(budget);
+        match session.budget().unwrap().check() {
+            Err(Error::BudgetExceeded { total_usd, max_usd }) => {
+                assert!((total_usd - 0.15).abs() < 1e-9);
+                assert!((max_usd - 0.10).abs() < 1e-9);
+            }
+            other => panic!("expected BudgetExceeded, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- New `BudgetTracker` (in `src/budget.rs`) accumulates cumulative USD cost across turns and fires fire-once callbacks when configurable warning/max thresholds are crossed
- New `Error::BudgetExceeded` variant gives callers a hard stop, returned from `Session::execute`/`Session::stream_execute` before the next CLI invocation once the ceiling is hit
- `Session::with_budget()` attaches a tracker; cloning the tracker across sessions shares the running total

## Design notes

- `BudgetTracker` is cheap to clone (`Arc<Inner>` with `Mutex<State>`), so the same tracker can be shared across tasks or sessions.
- The turn that *crosses* the ceiling still completes (callback fires, history updates). The *next* call is what short-circuits via `BudgetExceeded`. This matches the issue's description of callbacks and hard-stop as separate concerns.
- `record()` ignores non-positive and non-finite inputs so bogus `cost_usd` values from the CLI can't poison the total.
- Session-level attachment first (as the issue leans toward). A process-wide budget still works by sharing one tracker across several `Session`s.

## API surface

```rust
let budget = BudgetTracker::builder()
    .max_usd(5.00)
    .warn_at_usd(4.00)
    .on_warning(|t| eprintln!("warning: ${t:.2}"))
    .on_exceeded(|t| eprintln!("budget hit: ${t:.2}"))
    .build();

let mut session = Session::new(claude).with_budget(budget.clone());
session.send("hello").await?; // records cost automatically
budget.total_usd(); // 0.0123
budget.remaining_usd(); // Some(4.9877)
```

Methods: `record`, `check`, `total_usd`, `remaining_usd`, `max_usd`, `warn_at_usd`, `reset`.

Closes #536

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p claude-wrapper --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib -p claude-wrapper --all-features` (125 pass, 10 new)
- [x] `cargo test --doc -p claude-wrapper --all-features` (40 pass)
- [ ] Manual smoke with a live session to observe a callback firing