### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.6.0...v0.7.0) - 2026-04-23
+
+### Added
+
+- wrap remaining #552 items (from_pr, plugin tag, update, install) ([#554](https://github.com/joshrotenberg/claude-wrapper/pull/554))
+- wrap --bare + 4 other query flags, add auto-mode subcommands ([#553](https://github.com/joshrotenberg/claude-wrapper/pull/553))
+- [**breaking**] make tokio optional via new async feature ([#550](https://github.com/joshrotenberg/claude-wrapper/pull/550))
+- stream_query_sync for blocking NDJSON streaming ([#549](https://github.com/joshrotenberg/claude-wrapper/pull/549))
+- sync execute_sync on commands + Claude version helpers ([#548](https://github.com/joshrotenberg/claude-wrapper/pull/548))
+- add sync feature with blocking exec/retry twins ([#547](https://github.com/joshrotenberg/claude-wrapper/pull/547))
+- typed ToolPattern for allowed/disallowed tool lists ([#545](https://github.com/joshrotenberg/claude-wrapper/pull/545))
+- add BudgetTracker with warning/exceeded callbacks ([#543](https://github.com/joshrotenberg/claude-wrapper/pull/543))
+
+### Other
+
+- [**breaking**] drop deprecated crates, flatten workspace, rewrite docs ([#551](https://github.com/joshrotenberg/claude-wrapper/pull/551))
+- update changelog ([#542](https://github.com/joshrotenberg/claude-wrapper/pull/542))
+
 ## [0.6.0] - 2026-04-23
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Session is no longer UnwindSafe, in /tmp/.tmpxUbTp8/claude-wrapper/src/session.rs:86
  type Session is no longer RefUnwindSafe, in /tmp/.tmpxUbTp8/claude-wrapper/src/session.rs:86
  type Session is no longer UnwindSafe, in /tmp/.tmpxUbTp8/claude-wrapper/src/session.rs:86
  type Session is no longer RefUnwindSafe, in /tmp/.tmpxUbTp8/claude-wrapper/src/session.rs:86

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:BudgetExceeded in /tmp/.tmpxUbTp8/claude-wrapper/src/error.rs:61
  variant Error:BudgetExceeded in /tmp/.tmpxUbTp8/claude-wrapper/src/error.rs:61

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  claude_wrapper::command::query::QueryCommand::allowed_tools takes 2 generic types instead of 0, in /tmp/.tmpxUbTp8/claude-wrapper/src/command/query.rs:188
  claude_wrapper::command::query::QueryCommand::disallowed_tools takes 2 generic types instead of 0, in /tmp/.tmpxUbTp8/claude-wrapper/src/command/query.rs:206
  claude_wrapper::QueryCommand::allowed_tools takes 2 generic types instead of 0, in /tmp/.tmpxUbTp8/claude-wrapper/src/command/query.rs:188
  claude_wrapper::QueryCommand::disallowed_tools takes 2 generic types instead of 0, in /tmp/.tmpxUbTp8/claude-wrapper/src/command/query.rs:206
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.6.0...v0.7.0) - 2026-04-23

### Added

- wrap remaining #552 items (from_pr, plugin tag, update, install) ([#554](https://github.com/joshrotenberg/claude-wrapper/pull/554))
- wrap --bare + 4 other query flags, add auto-mode subcommands ([#553](https://github.com/joshrotenberg/claude-wrapper/pull/553))
- [**breaking**] make tokio optional via new async feature ([#550](https://github.com/joshrotenberg/claude-wrapper/pull/550))
- stream_query_sync for blocking NDJSON streaming ([#549](https://github.com/joshrotenberg/claude-wrapper/pull/549))
- sync execute_sync on commands + Claude version helpers ([#548](https://github.com/joshrotenberg/claude-wrapper/pull/548))
- add sync feature with blocking exec/retry twins ([#547](https://github.com/joshrotenberg/claude-wrapper/pull/547))
- typed ToolPattern for allowed/disallowed tool lists ([#545](https://github.com/joshrotenberg/claude-wrapper/pull/545))
- add BudgetTracker with warning/exceeded callbacks ([#543](https://github.com/joshrotenberg/claude-wrapper/pull/543))

### Other

- [**breaking**] drop deprecated crates, flatten workspace, rewrite docs ([#551](https://github.com/joshrotenberg/claude-wrapper/pull/551))
- update changelog ([#542](https://github.com/joshrotenberg/claude-wrapper/pull/542))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).