### PR TITLE
feat: add sync feature with blocking exec/retry twins (PR 1 of sync API series)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "wait-timeout",
  "which",
 ]
 
@@ -461,6 +462,15 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -20,6 +20,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["json", "tempfile"]
 json = ["serde_json"]
 tempfile = ["dep:tempfile"]
+# Blocking/synchronous API alongside the async default. Enables the
+# *_sync execution paths in exec::/retry:: (no tokio runtime required
+# at call sites). tokio is still pulled in by default; future work
+# will let sync-only callers drop it via `default-features = false`.
+sync = ["dep:wait-timeout"]
 
 [dependencies]
 serde = { workspace = true }
@@ -28,6 +33,7 @@ thiserror = { workspace = true }
 tokio = { version = "1", features = ["process", "time", "io-util", "macros"] }
 tracing = { workspace = true }
 tempfile = { version = "3", optional = true }
+wait-timeout = { version = "0.2", optional = true }
 which = "8"
 
 [dev-dependencies]

--- a/crates/claude-wrapper/src/exec.rs
+++ b/crates/claude-wrapper/src/exec.rs
@@ -262,3 +262,286 @@ async fn drain<R: AsyncReadExt + Unpin>(reader: &mut R) -> String {
     let _ = reader.read_to_end(&mut buf).await;
     String::from_utf8_lossy(&buf).into_owned()
 }
+
+// ---------- sync twins ----------
+
+/// Blocking mirror of [`run_claude`]. Available with the `sync` feature.
+#[cfg(feature = "sync")]
+pub fn run_claude_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
+    run_claude_with_retry_sync(claude, args, None)
+}
+
+/// Blocking mirror of [`run_claude_with_retry`].
+#[cfg(feature = "sync")]
+pub fn run_claude_with_retry_sync(
+    claude: &Claude,
+    args: Vec<String>,
+    retry_override: Option<&crate::retry::RetryPolicy>,
+) -> Result<CommandOutput> {
+    let policy = retry_override.or(claude.retry_policy.as_ref());
+
+    match policy {
+        Some(policy) => {
+            crate::retry::with_retry_sync(policy, || run_claude_once_sync(claude, args.clone()))
+        }
+        None => run_claude_once_sync(claude, args),
+    }
+}
+
+#[cfg(feature = "sync")]
+fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
+    let mut command_args = Vec::new();
+    command_args.extend(claude.global_args.clone());
+    command_args.extend(args);
+
+    debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command (sync)");
+
+    if let Some(timeout) = claude.timeout {
+        run_with_timeout_sync(
+            &claude.binary,
+            &command_args,
+            &claude.env,
+            claude.working_dir.as_deref(),
+            timeout,
+        )
+    } else {
+        run_internal_sync(
+            &claude.binary,
+            &command_args,
+            &claude.env,
+            claude.working_dir.as_deref(),
+        )
+    }
+}
+
+/// Blocking mirror of [`run_claude_allow_exit_codes`].
+#[cfg(feature = "sync")]
+pub fn run_claude_allow_exit_codes_sync(
+    claude: &Claude,
+    args: Vec<String>,
+    allowed_codes: &[i32],
+) -> Result<CommandOutput> {
+    match run_claude_sync(claude, args) {
+        Err(Error::CommandFailed {
+            exit_code,
+            stdout,
+            stderr,
+            ..
+        }) if allowed_codes.contains(&exit_code) => Ok(CommandOutput {
+            stdout,
+            stderr,
+            exit_code,
+            success: false,
+        }),
+        other => other,
+    }
+}
+
+#[cfg(feature = "sync")]
+fn run_internal_sync(
+    binary: &std::path::Path,
+    args: &[String],
+    env: &std::collections::HashMap<String, String>,
+    working_dir: Option<&std::path::Path>,
+) -> Result<CommandOutput> {
+    use std::process::{Command as StdCommand, Stdio};
+
+    let mut cmd = StdCommand::new(binary);
+    cmd.args(args);
+    cmd.stdin(Stdio::null());
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+
+    let output = cmd.output().map_err(|e| Error::Io {
+        message: format!("failed to spawn claude: {e}"),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    if !output.status.success() {
+        return Err(Error::CommandFailed {
+            command: format!("{} {}", binary.display(), args.join(" ")),
+            exit_code,
+            stdout,
+            stderr,
+            working_dir: working_dir.map(|p| p.to_path_buf()),
+        });
+    }
+
+    Ok(CommandOutput {
+        stdout,
+        stderr,
+        exit_code,
+        success: true,
+    })
+}
+
+/// Blocking run with a timeout. Mirrors [`run_with_timeout`]: spawns
+/// the child, drains stdout/stderr on dedicated threads so neither
+/// pipe buffer can fill up while we wait, then uses
+/// [`wait_timeout::ChildExt::wait_timeout`] to enforce the deadline.
+/// On timeout, the child is SIGKILLed and reaped; partial output is
+/// logged at warn but the returned [`Error::Timeout`] does not carry it.
+#[cfg(feature = "sync")]
+fn run_with_timeout_sync(
+    binary: &std::path::Path,
+    args: &[String],
+    env: &std::collections::HashMap<String, String>,
+    working_dir: Option<&std::path::Path>,
+    timeout: Duration,
+) -> Result<CommandOutput> {
+    use std::process::{Command as StdCommand, Stdio};
+    use std::thread;
+    use wait_timeout::ChildExt;
+
+    let mut cmd = StdCommand::new(binary);
+    cmd.args(args);
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| Error::Io {
+        message: format!("failed to spawn claude: {e}"),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
+
+    // Detach stdout/stderr onto their own threads so neither can block
+    // the child by filling its pipe buffer. Each thread owns its half
+    // and drops it on completion, which closes the parent's fd and
+    // lets read_to_end() return EOF once the child exits.
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let stderr = child.stderr.take().expect("stderr was piped");
+
+    let stdout_thread = thread::spawn(move || drain_sync(stdout));
+    let stderr_thread = thread::spawn(move || drain_sync(stderr));
+
+    match child.wait_timeout(timeout).map_err(|e| Error::Io {
+        message: "failed to wait for claude process".to_string(),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })? {
+        Some(status) => {
+            let stdout = stdout_thread.join().unwrap_or_default();
+            let stderr = stderr_thread.join().unwrap_or_default();
+            let exit_code = status.code().unwrap_or(-1);
+
+            if !status.success() {
+                return Err(Error::CommandFailed {
+                    command: format!("{} {}", binary.display(), args.join(" ")),
+                    exit_code,
+                    stdout,
+                    stderr,
+                    working_dir: working_dir.map(|p| p.to_path_buf()),
+                });
+            }
+
+            Ok(CommandOutput {
+                stdout,
+                stderr,
+                exit_code,
+                success: true,
+            })
+        }
+        None => {
+            // Timeout: SIGKILL and reap. If the child has spawned
+            // subprocesses that inherited our pipe fds, the drain
+            // threads can block indefinitely; cap the join with a
+            // short budget so the timeout error returns promptly.
+            let _ = child.kill();
+            let _ = child.wait();
+
+            let (stdout_str, stderr_str) =
+                join_with_deadline(stdout_thread, stderr_thread, Duration::from_millis(200));
+
+            if !stdout_str.is_empty() || !stderr_str.is_empty() {
+                warn!(
+                    stdout = %stdout_str,
+                    stderr = %stderr_str,
+                    "partial output from timed-out process",
+                );
+            }
+
+            Err(Error::Timeout {
+                timeout_seconds: timeout.as_secs(),
+            })
+        }
+    }
+}
+
+#[cfg(feature = "sync")]
+fn drain_sync<R: std::io::Read>(mut reader: R) -> String {
+    let mut buf = Vec::new();
+    let _ = reader.read_to_end(&mut buf);
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Wait for both drain threads to finish, returning "" for any that
+/// miss the deadline. Threads aren't cancellable in std; if the child's
+/// subprocesses are still holding a pipe fd open after kill(), the
+/// drain thread leaks. That's a pathological case; the common timeout
+/// path with a responsive child joins in microseconds.
+#[cfg(feature = "sync")]
+fn join_with_deadline(
+    stdout_thread: std::thread::JoinHandle<String>,
+    stderr_thread: std::thread::JoinHandle<String>,
+    budget: Duration,
+) -> (String, String) {
+    use std::sync::mpsc;
+    use std::thread;
+
+    let (tx, rx) = mpsc::channel::<(&'static str, String)>();
+
+    let tx_out = tx.clone();
+    let tx_err = tx;
+
+    thread::spawn(move || {
+        let s = stdout_thread.join().unwrap_or_default();
+        let _ = tx_out.send(("stdout", s));
+    });
+    thread::spawn(move || {
+        let s = stderr_thread.join().unwrap_or_default();
+        let _ = tx_err.send(("stderr", s));
+    });
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let deadline = std::time::Instant::now() + budget;
+
+    for _ in 0..2 {
+        let now = std::time::Instant::now();
+        if now >= deadline {
+            break;
+        }
+        match rx.recv_timeout(deadline - now) {
+            Ok(("stdout", s)) => stdout = s,
+            Ok(("stderr", s)) => stderr = s,
+            Ok(_) => unreachable!(),
+            Err(_) => break,
+        }
+    }
+
+    (stdout, stderr)
+}

--- a/crates/claude-wrapper/src/retry.rs
+++ b/crates/claude-wrapper/src/retry.rs
@@ -168,6 +168,43 @@ where
     Err(last_error.expect("at least one attempt was made"))
 }
 
+/// Execute a fallible blocking operation with retry. Sync mirror of
+/// [`with_retry`]; waits between attempts with [`std::thread::sleep`].
+#[cfg(feature = "sync")]
+pub(crate) fn with_retry_sync<F, T>(
+    policy: &RetryPolicy,
+    mut operation: F,
+) -> crate::error::Result<T>
+where
+    F: FnMut() -> crate::error::Result<T>,
+{
+    let mut last_error = None;
+
+    for attempt in 0..policy.max_attempts {
+        match operation() {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                if attempt + 1 < policy.max_attempts && policy.should_retry(&e) {
+                    let delay = policy.delay_for_attempt(attempt);
+                    warn!(
+                        attempt = attempt + 1,
+                        max_attempts = policy.max_attempts,
+                        delay_ms = delay.as_millis() as u64,
+                        error = %e,
+                        "retrying after transient error"
+                    );
+                    std::thread::sleep(delay);
+                    last_error = Some(e);
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    Err(last_error.expect("at least one attempt was made"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -344,5 +381,78 @@ mod tests {
         assert!(result.is_err());
         // Should only attempt once since timeout is not retryable
         assert_eq!(attempt.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_with_retry_sync_succeeds_first_try() {
+        let policy = RetryPolicy::new().max_attempts(3);
+        let result = with_retry_sync(&policy, || Ok::<_, Error>(42));
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_with_retry_sync_succeeds_after_failures() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let policy = RetryPolicy::new()
+            .max_attempts(3)
+            .initial_backoff(Duration::from_millis(1))
+            .retry_on_timeout(true);
+
+        let attempt = AtomicU32::new(0);
+        let result = with_retry_sync(&policy, || {
+            let n = attempt.fetch_add(1, Ordering::SeqCst);
+            if n < 2 {
+                Err(Error::Timeout {
+                    timeout_seconds: 60,
+                })
+            } else {
+                Ok(42)
+            }
+        });
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempt.load(Ordering::SeqCst), 3);
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_with_retry_sync_exhausts_attempts() {
+        let policy = RetryPolicy::new()
+            .max_attempts(2)
+            .initial_backoff(Duration::from_millis(1))
+            .retry_on_timeout(true);
+
+        let result: crate::error::Result<()> = with_retry_sync(&policy, || {
+            Err(Error::Timeout {
+                timeout_seconds: 60,
+            })
+        });
+
+        assert!(matches!(result, Err(Error::Timeout { .. })));
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_with_retry_sync_no_retry_on_non_retryable() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let policy = RetryPolicy::new()
+            .max_attempts(3)
+            .initial_backoff(Duration::from_millis(1))
+            .retry_on_timeout(false);
+
+        let attempt = AtomicU32::new(0);
+        let result: crate::error::Result<()> = with_retry_sync(&policy, || {
+            attempt.fetch_add(1, Ordering::SeqCst);
+            Err(Error::Timeout {
+                timeout_seconds: 60,
+            })
+        });
+
+        assert!(result.is_err());
+        assert_eq!(attempt.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/claude-wrapper/tests/fake_claude_sync.rs
+++ b/crates/claude-wrapper/tests/fake_claude_sync.rs
@@ -1,0 +1,123 @@
+//! Integration tests for the blocking/sync exec path.
+//!
+//! These cover the primitives in `exec::*_sync` against the fake-claude
+//! shell script. The sync command surface (per-builder `execute_sync`)
+//! is landing in a follow-up PR, so these tests reach into the exec
+//! module directly.
+
+#![cfg(feature = "sync")]
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use claude_wrapper::Claude;
+use claude_wrapper::exec::run_claude_sync;
+
+const FAKE_CLAUDE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../test-helpers/fake-claude.sh"
+);
+
+fn fake_binary() -> PathBuf {
+    PathBuf::from(FAKE_CLAUDE)
+}
+
+fn claude_with_env(pairs: &[(&str, &str)]) -> Claude {
+    let mut builder = Claude::builder().binary(fake_binary());
+    for (k, v) in pairs {
+        builder = builder.env(*k, *v);
+    }
+    builder.build().expect("failed to build Claude client")
+}
+
+#[test]
+fn sync_basic_execution_returns_stdout() {
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "hello sync")]);
+    let output = run_claude_sync(&claude, vec!["--version".to_string()])
+        .expect("sync execution should succeed");
+    assert!(output.success);
+    assert!(
+        output.stdout.contains("hello sync"),
+        "unexpected stdout: {:?}",
+        output.stdout
+    );
+    assert_eq!(output.exit_code, 0);
+}
+
+#[test]
+fn sync_non_zero_exit_surfaces_error() {
+    let claude = claude_with_env(&[
+        ("FAKE_CLAUDE_EXIT_CODE", "1"),
+        ("FAKE_CLAUDE_ERROR_MSG", "sync boom"),
+    ]);
+    let result = run_claude_sync(&claude, vec!["--version".to_string()]);
+    let err = result.expect_err("non-zero exit must be an error");
+    assert!(
+        err.to_string().contains("exit code 1"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn sync_timeout_fires_and_returns_promptly() {
+    // Fake child sleeps 5s; timeout is 300ms. Without a working
+    // concurrent drain + wait-timeout path, this either hangs (pipe
+    // buffer deadlock) or overshoots massively.
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_DELAY", "5")
+        .timeout(Duration::from_millis(300))
+        .build()
+        .unwrap();
+
+    let start = Instant::now();
+    let result = run_claude_sync(&claude, vec!["--version".to_string()]);
+    let elapsed = start.elapsed();
+
+    let err = result.expect_err("expected a timeout error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("timed out") || msg.contains("timeout"),
+        "expected timeout error, got: {msg}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "sync timeout should return promptly, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn sync_large_output_does_not_deadlock() {
+    // Emit ~256KB of output — larger than any reasonable pipe buffer —
+    // so the test catches a naive "wait then read" implementation
+    // that would block the child once the pipe fills.
+    let big = "x".repeat(256 * 1024);
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", &big)]);
+
+    let output = run_claude_sync(&claude, vec!["--version".to_string()])
+        .expect("sync execution with large output should succeed");
+
+    assert!(output.success);
+    assert!(output.stdout.len() >= big.len());
+}
+
+#[test]
+fn sync_large_output_does_not_deadlock_with_timeout() {
+    // Same as above but routed through the run_with_timeout_sync path
+    // (i.e. a Claude with a timeout set, even though we finish well
+    // under it). This is the one that proves the concurrent-drain
+    // threads in the sync timeout code path actually work.
+    let big = "x".repeat(256 * 1024);
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_OUTPUT", &big)
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+
+    let output = run_claude_sync(&claude, vec!["--version".to_string()])
+        .expect("sync timeout-path execution with large output should succeed");
+
+    assert!(output.success);
+    assert!(output.stdout.len() >= big.len());
+}


### PR DESCRIPTION
## Summary

First PR of the sync-API series for #535. Adds a new `sync` feature that exposes blocking primitives under `exec::` and `retry::`, alongside the existing async API. Nothing public changes on the default build.

- `exec::run_claude_sync`, `run_claude_with_retry_sync`, `run_claude_once_sync`, `run_claude_allow_exit_codes_sync`, `run_internal_sync`, `run_with_timeout_sync` — all gated `#[cfg(feature = "sync")]`.
- `retry::with_retry_sync` — sync mirror of `with_retry`, uses `std::thread::sleep`.
- New optional dep: `wait-timeout = "0.2"` (pulled in only when `sync` is enabled).
- tokio still required on default features. Making tokio optional is the payoff in PR 4 of the series.

## Concurrent-drain design

`run_with_timeout_sync` is the only non-trivial bit. The async version uses `tokio::join!` to poll `child.wait()`, `drain(stdout)`, and `drain(stderr)` on one task. The sync version does the same shape with `std::thread`:

```rust
let stdout_thread = thread::spawn(move || drain_sync(stdout));
let stderr_thread = thread::spawn(move || drain_sync(stderr));

match child.wait_timeout(timeout)? {
    Some(status) => { /* join drain threads, build CommandOutput */ }
    None => {
        child.kill();
        child.wait();
        // cap the drain-thread join with a 200ms budget so a grandchild
        // holding our pipe fds open doesn't hang the timeout path
        let (stdout, stderr) = join_with_deadline(..., Duration::from_millis(200));
        Err(Error::Timeout { ... })
    }
}
```

`wait-timeout` handles the SIGKILL-on-expiry and reap without us writing a manual poll loop. The `join_with_deadline` helper runs both `.join()` calls on auxiliary threads that send results over an mpsc channel; if they miss the deadline, the main thread moves on and the drain threads die when the process exits. This matches the async 200ms drain cap.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p claude-wrapper --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib -p claude-wrapper --all-features` (147 pass, 4 new sync retry tests)
- [x] `cargo test --doc -p claude-wrapper --all-features` (45 pass)
- [x] `cargo build -p claude-wrapper` (default, sync off)
- [x] `cargo build -p claude-wrapper --features sync`
- [x] `cargo test --test fake_claude_sync -p claude-wrapper --features sync` (5 new integration tests, including 256KB-output-under-timeout case to prove the concurrent-drain threading prevents pipe-buffer deadlock)

## Follow-ups in this series

- **PR 2**: sync methods on each command builder (`execute_sync`, `execute_json_sync`) + `Claude::cli_version_sync`.
- **PR 3**: `stream_query_sync`.
- **PR 4**: make `tokio` optional (new `async` feature), so `default-features = false, features = ["json", "sync"]` drops tokio entirely. This is the payoff for consumers like conversa.

Refs #535