### PR TITLE
feat: sync execute_sync on commands + Claude version helpers (PR 2 of sync API series)

### DIFF
--- a/crates/claude-wrapper/src/command/auth.rs
+++ b/crates/claude-wrapper/src/command/auth.rs
@@ -49,6 +49,20 @@ impl AuthStatusCommand {
             source: e,
         })
     }
+
+    /// Blocking mirror of [`AuthStatusCommand::execute_json`].
+    #[cfg(all(feature = "sync", feature = "json"))]
+    pub fn execute_json_sync(&self, claude: &Claude) -> Result<crate::types::AuthStatus> {
+        let mut cmd = self.clone();
+        cmd.json = true;
+
+        let output = exec::run_claude_sync(claude, cmd.args())?;
+
+        serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::Json {
+            message: format!("failed to parse auth status: {e}"),
+            source: e,
+        })
+    }
 }
 
 impl ClaudeCommand for AuthStatusCommand {

--- a/crates/claude-wrapper/src/command/mod.rs
+++ b/crates/claude-wrapper/src/command/mod.rs
@@ -28,3 +28,45 @@ pub trait ClaudeCommand: Send + Sync {
     /// Execute the command using the given claude client.
     fn execute(&self, claude: &Claude) -> impl Future<Output = Result<Self::Output>> + Send;
 }
+
+/// Blocking `execute_sync` for any command that returns `CommandOutput`.
+///
+/// Most command builders (all except the json-decoding convenience
+/// methods) produce `CommandOutput` — this extension trait gives them
+/// a one-line blocking entry point that routes through
+/// [`crate::exec::run_claude_sync`].
+///
+/// ```no_run
+/// # #[cfg(feature = "sync")]
+/// # {
+/// use claude_wrapper::{Claude, ClaudeCommandSyncExt, VersionCommand};
+///
+/// # fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let out = VersionCommand::new().execute_sync(&claude)?;
+/// println!("{}", out.stdout);
+/// # Ok(())
+/// # }
+/// # }
+/// ```
+///
+/// Commands with custom execute paths (e.g. [`crate::QueryCommand`],
+/// which honours `retry_policy`) override this via an inherent method
+/// of the same name — inherent-method resolution wins, so callers
+/// don't need to disambiguate.
+#[cfg(feature = "sync")]
+pub trait ClaudeCommandSyncExt {
+    /// Blocking analog of [`ClaudeCommand::execute`] for commands
+    /// producing `CommandOutput`.
+    fn execute_sync(&self, claude: &Claude) -> Result<crate::exec::CommandOutput>;
+}
+
+#[cfg(feature = "sync")]
+impl<T> ClaudeCommandSyncExt for T
+where
+    T: ClaudeCommand<Output = crate::exec::CommandOutput>,
+{
+    fn execute_sync(&self, claude: &Claude) -> Result<crate::exec::CommandOutput> {
+        crate::exec::run_claude_sync(claude, self.args())
+    }
+}

--- a/crates/claude-wrapper/src/command/query.rs
+++ b/crates/claude-wrapper/src/command/query.rs
@@ -509,6 +509,35 @@ impl QueryCommand {
         })
     }
 
+    /// Blocking analog of [`QueryCommand::execute`] that honours the
+    /// configured [`RetryPolicy`](crate::retry::RetryPolicy).
+    ///
+    /// Overrides the blanket
+    /// [`ClaudeCommandSyncExt::execute_sync`](crate::ClaudeCommandSyncExt)
+    /// impl so retries still fire on the sync path.
+    #[cfg(feature = "sync")]
+    pub fn execute_sync(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude_with_retry_sync(claude, self.args(), self.retry_policy.as_ref())
+    }
+
+    /// Blocking mirror of [`QueryCommand::execute_json`].
+    #[cfg(all(feature = "sync", feature = "json"))]
+    pub fn execute_json_sync(&self, claude: &Claude) -> Result<crate::types::QueryResult> {
+        let mut args = self.build_args();
+
+        if self.output_format.is_none() {
+            args.push("--output-format".to_string());
+            args.push("json".to_string());
+        }
+
+        let output = exec::run_claude_with_retry_sync(claude, args, self.retry_policy.as_ref())?;
+
+        serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::Json {
+            message: format!("failed to parse query result: {e}"),
+            source: e,
+        })
+    }
+
     fn build_args(&self) -> Vec<String> {
         let mut args = vec!["--print".to_string()];
 

--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -184,6 +184,8 @@ use std::time::Duration;
 
 pub use budget::{BudgetBuilder, BudgetTracker};
 pub use command::ClaudeCommand;
+#[cfg(feature = "sync")]
+pub use command::ClaudeCommandSyncExt;
 pub use command::agents::AgentsCommand;
 pub use command::auth::{
     AuthLoginCommand, AuthLogoutCommand, AuthStatusCommand, SetupTokenCommand,
@@ -298,6 +300,33 @@ impl Claude {
     /// ```
     pub async fn check_version(&self, minimum: &CliVersion) -> Result<CliVersion> {
         let version = self.cli_version().await?;
+        if version.satisfies_minimum(minimum) {
+            Ok(version)
+        } else {
+            Err(Error::VersionMismatch {
+                found: version,
+                minimum: *minimum,
+            })
+        }
+    }
+
+    /// Blocking mirror of [`Claude::cli_version`]. Requires the
+    /// `sync` feature.
+    #[cfg(feature = "sync")]
+    pub fn cli_version_sync(&self) -> Result<CliVersion> {
+        let output = VersionCommand::new().execute_sync(self)?;
+        CliVersion::parse_version_output(&output.stdout).map_err(|e| Error::Io {
+            message: format!("failed to parse CLI version: {e}"),
+            source: std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()),
+            working_dir: None,
+        })
+    }
+
+    /// Blocking mirror of [`Claude::check_version`]. Requires the
+    /// `sync` feature.
+    #[cfg(feature = "sync")]
+    pub fn check_version_sync(&self, minimum: &CliVersion) -> Result<CliVersion> {
+        let version = self.cli_version_sync()?;
         if version.satisfies_minimum(minimum) {
             Ok(version)
         } else {

--- a/crates/claude-wrapper/tests/fake_claude_sync.rs
+++ b/crates/claude-wrapper/tests/fake_claude_sync.rs
@@ -121,3 +121,90 @@ fn sync_large_output_does_not_deadlock_with_timeout() {
     assert!(output.success);
     assert!(output.stdout.len() >= big.len());
 }
+
+// ── command-surface tests ─────────────────────────────────────────
+
+#[test]
+fn sync_version_command_via_blanket_trait() {
+    use claude_wrapper::{ClaudeCommandSyncExt, VersionCommand};
+
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "1.2.3 (Claude Code)")]);
+    let output = VersionCommand::new()
+        .execute_sync(&claude)
+        .expect("VersionCommand::execute_sync should succeed");
+    assert!(output.success);
+    assert!(output.stdout.contains("1.2.3"));
+}
+
+#[test]
+fn sync_claude_cli_version_helper() {
+    use claude_wrapper::CliVersion;
+
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "1.2.3 (Claude Code)")]);
+    let version = claude
+        .cli_version_sync()
+        .expect("cli_version_sync should succeed");
+    assert_eq!(version, CliVersion::new(1, 2, 3));
+}
+
+#[test]
+fn sync_claude_check_version_helper() {
+    use claude_wrapper::CliVersion;
+
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "2.0.0 (Claude Code)")]);
+    let v = claude
+        .check_version_sync(&CliVersion::new(1, 0, 0))
+        .expect("check_version_sync should satisfy minimum");
+    assert_eq!(v, CliVersion::new(2, 0, 0));
+
+    let err = claude
+        .check_version_sync(&CliVersion::new(3, 0, 0))
+        .expect_err("check_version_sync should reject too-low version");
+    assert!(
+        err.to_string()
+            .contains("does not meet minimum requirement")
+    );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn sync_query_execute_json_parses_result() {
+    use claude_wrapper::QueryCommand;
+
+    let claude = claude_with_env(&[
+        ("FAKE_CLAUDE_OUTPUT", "42"),
+        ("FAKE_CLAUDE_SESSION_ID", "sync-sess"),
+    ]);
+
+    let result = QueryCommand::new("what is 2+2?")
+        .no_session_persistence()
+        .execute_json_sync(&claude)
+        .expect("execute_json_sync should succeed");
+
+    assert_eq!(result.result, "42");
+    assert_eq!(result.session_id, "sync-sess");
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn sync_query_execute_retries_via_policy() {
+    // Sync execute_sync on QueryCommand must go through the retry-aware
+    // helper. We exercise that path indirectly: set a policy and let
+    // a successful call go through without errors.
+    use claude_wrapper::{QueryCommand, RetryPolicy};
+    use std::time::Duration;
+
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "ok")]);
+    let cmd = QueryCommand::new("ping").no_session_persistence().retry(
+        RetryPolicy::new()
+            .max_attempts(2)
+            .initial_backoff(Duration::from_millis(1))
+            .retry_on_timeout(true),
+    );
+
+    let out = cmd
+        .execute_sync(&claude)
+        .expect("sync query with retry policy should succeed");
+    assert!(out.success);
+    assert!(out.stdout.contains("ok"));
+}


### PR DESCRIPTION
## Summary

PR 2 of the sync API series for #535. Builds the blocking command surface on top of the primitives that landed in PR 1 (#547).

- **`ClaudeCommandSyncExt`** — new extension trait with a blanket impl over every `ClaudeCommand<Output = CommandOutput>`. Callers `use claude_wrapper::ClaudeCommandSyncExt` once and every command gains a free `execute_sync(&claude)` routed through `exec::run_claude_sync`. Zero per-command boilerplate for the ~20 commands that all fit this shape.
- **`QueryCommand::execute_sync`** — inherent override of the blanket impl, routes through `run_claude_with_retry_sync` so the builder's retry policy still fires.
- **`QueryCommand::execute_json_sync`** — mirror of `execute_json`. Gated `all(feature = "sync", feature = "json")`.
- **`AuthStatusCommand::execute_json_sync`** — mirror of `execute_json`. Same gating.
- **`Claude::cli_version_sync`** / **`Claude::check_version_sync`** — blocking mirrors of the async helpers.

All new surface is gated `#[cfg(feature = "sync")]`. tokio is still pulled in by default; making it optional is the payoff in PR 4.

## Design note — blanket vs per-type inherent methods

A per-command inherent `fn execute_sync(...)` on ~20 types would be ~125 lines of mechanical duplication. The blanket impl gets every `ClaudeCommand<Output = CommandOutput>` in one shot:

```rust
impl<T> ClaudeCommandSyncExt for T
where
    T: ClaudeCommand<Output = crate::exec::CommandOutput>,
{
    fn execute_sync(&self, claude: &Claude) -> Result<CommandOutput> {
        crate::exec::run_claude_sync(claude, self.args())
    }
}
```

`QueryCommand` is the only type that needs a different sync path (for retry), and its inherent method wins over the trait via standard method resolution — no disambiguation at the call site. Future commands with retry support can follow the same pattern.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p claude-wrapper --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib -p claude-wrapper --all-features` (147 pass)
- [x] `cargo test --doc -p claude-wrapper --all-features` (46 pass; 1 new sync doc example)
- [x] `cargo test --test fake_claude_sync -p claude-wrapper --all-features` (10 pass: 5 new covering VersionCommand via trait, `cli_version_sync`, `check_version_sync` good/bad path, `execute_json_sync` JSON parse, `execute_sync` with retry policy)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p claude-wrapper --all-features --no-deps`
- [x] `cargo build -p claude-wrapper` (default build, sync off)
- [x] `cargo build -p claude-wrapper --features sync`

## Up next

- **PR 3**: `stream_query_sync` for the NDJSON streaming path.
- **PR 4**: make `tokio` optional via an `async` feature. `default-features = false, features = ["json", "sync"]` drops tokio entirely — the actual win for sync-only consumers like conversa.

Refs #535