### PR TITLE
feat: stream_query_sync for blocking NDJSON streaming (PR 3 of sync API series)

### DIFF
--- a/crates/claude-wrapper/src/streaming.rs
+++ b/crates/claude-wrapper/src/streaming.rs
@@ -266,3 +266,234 @@ where
 
     Ok(())
 }
+
+// ---------- sync streaming ----------
+
+/// Blocking mirror of [`stream_query`]. Reads NDJSON lines from the
+/// child's stdout on a worker thread, dispatches each parsed event
+/// to `handler` on the caller's thread, and drains stderr on a
+/// separate worker thread so the child can't deadlock on a full pipe.
+///
+/// Requires both `sync` and `json` features.
+///
+/// The handler is invoked on the caller's thread — no `Send` bound —
+/// so it can capture non-`Send` state. If a timeout is configured on
+/// the [`Claude`] client, the child is SIGKILLed and reaped once the
+/// deadline passes; partial events already dispatched to the handler
+/// are not rolled back.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(all(feature = "sync", feature = "json"))]
+/// # {
+/// use claude_wrapper::{Claude, OutputFormat, QueryCommand};
+/// use claude_wrapper::streaming::{StreamEvent, stream_query_sync};
+///
+/// # fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let cmd = QueryCommand::new("explain quicksort")
+///     .output_format(OutputFormat::StreamJson);
+///
+/// stream_query_sync(&claude, &cmd, |event: StreamEvent| {
+///     if let Some(t) = event.event_type() {
+///         println!("[{t}] {:?}", event.data);
+///     }
+/// })?;
+/// # Ok(())
+/// # }
+/// # }
+/// ```
+#[cfg(all(feature = "sync", feature = "json"))]
+pub fn stream_query_sync<F>(
+    claude: &Claude,
+    cmd: &crate::command::query::QueryCommand,
+    mut handler: F,
+) -> Result<CommandOutput>
+where
+    F: FnMut(StreamEvent),
+{
+    use std::io::{BufRead as _, Read as _};
+    use std::process::{Command as StdCommand, Stdio};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Instant;
+
+    use crate::command::ClaudeCommand;
+
+    let args = cmd.args();
+    let mut command_args = Vec::new();
+    command_args.extend(claude.global_args.clone());
+    command_args.extend(args);
+
+    debug!(
+        binary = %claude.binary.display(),
+        args = ?command_args,
+        timeout = ?claude.timeout,
+        "streaming claude command (sync)"
+    );
+
+    let mut cmd_builder = StdCommand::new(&claude.binary);
+    cmd_builder
+        .args(&command_args)
+        .env_remove("CLAUDECODE")
+        .env_remove("CLAUDE_CODE_ENTRYPOINT")
+        .envs(&claude.env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(ref dir) = claude.working_dir {
+        cmd_builder.current_dir(dir);
+    }
+
+    let mut child = cmd_builder.spawn().map_err(|e| Error::Io {
+        message: format!("failed to spawn claude: {e}"),
+        source: e,
+        working_dir: claude.working_dir.clone(),
+    })?;
+
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let stderr = child.stderr.take().expect("stderr was piped");
+
+    // Reader thread: parse NDJSON lines and push StreamEvents through
+    // the channel. Handler runs on the caller's thread so it doesn't
+    // need Send. Bubbles IO errors out via the thread's return value.
+    let (tx, rx) = mpsc::channel::<StreamEvent>();
+    let reader_wd = claude.working_dir.clone();
+    let reader_thread = thread::spawn(move || -> Result<()> {
+        let reader = std::io::BufReader::new(stdout);
+        for line_res in reader.lines() {
+            let line = line_res.map_err(|e| Error::Io {
+                message: "failed to read stdout line".to_string(),
+                source: e,
+                working_dir: reader_wd.clone(),
+            })?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<StreamEvent>(&line) {
+                Ok(event) => {
+                    if tx.send(event).is_err() {
+                        // Receiver gone — main thread has bailed out.
+                        return Ok(());
+                    }
+                }
+                Err(e) => {
+                    debug!(line = %line, error = %e, "failed to parse stream event, skipping");
+                }
+            }
+        }
+        Ok(())
+    });
+
+    let stderr_thread = thread::spawn(move || -> String {
+        let mut buf = Vec::new();
+        let mut stderr = stderr;
+        let _ = stderr.read_to_end(&mut buf);
+        String::from_utf8_lossy(&buf).into_owned()
+    });
+
+    // Main loop: dispatch events on the caller's thread, honouring the
+    // configured timeout. Break on disconnect (reader done) or timeout.
+    let deadline = claude.timeout.map(|d| Instant::now() + d);
+    let mut timed_out = false;
+
+    loop {
+        let recv_result = match deadline {
+            Some(d) => {
+                let now = Instant::now();
+                if now >= d {
+                    timed_out = true;
+                    break;
+                }
+                rx.recv_timeout(d - now)
+            }
+            None => rx.recv().map_err(|_| mpsc::RecvTimeoutError::Disconnected),
+        };
+
+        match recv_result {
+            Ok(event) => handler(event),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                timed_out = true;
+                break;
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    if timed_out {
+        let _ = child.kill();
+        let _ = child.wait();
+        // Both worker threads can block indefinitely if an orphaned
+        // grandchild inherited our pipe fds and keeps the write end
+        // open (e.g. a `bash` script whose `sleep` subprocess outlives
+        // the SIGKILLed shell). Cap the joins so the timeout error
+        // still returns promptly; any thread that misses the deadline
+        // leaks its JoinHandle, which is acceptable for this edge.
+        let budget = Duration::from_millis(200);
+        let stderr_str = join_with_budget(stderr_thread, budget).unwrap_or_default();
+        let _ = join_with_budget(reader_thread, budget);
+        if !stderr_str.is_empty() {
+            warn!(stderr = %stderr_str, "stderr from timed-out streaming process");
+        }
+        return Err(Error::Timeout {
+            timeout_seconds: claude.timeout.map(|d| d.as_secs()).unwrap_or_default(),
+        });
+    }
+
+    // Normal completion: collect reader result (may carry IO error).
+    let reader_result = reader_thread.join().unwrap_or(Ok(()));
+    if let Err(e) = reader_result {
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = stderr_thread.join();
+        return Err(e);
+    }
+
+    let status = child.wait().map_err(|e| Error::Io {
+        message: "failed to wait for claude process".to_string(),
+        source: e,
+        working_dir: claude.working_dir.clone(),
+    })?;
+    let stderr_str = stderr_thread.join().unwrap_or_default();
+    let exit_code = status.code().unwrap_or(-1);
+
+    if !status.success() {
+        return Err(Error::CommandFailed {
+            command: format!("{} {}", claude.binary.display(), command_args.join(" ")),
+            exit_code,
+            stdout: String::new(),
+            stderr: stderr_str,
+            working_dir: claude.working_dir.clone(),
+        });
+    }
+
+    Ok(CommandOutput {
+        stdout: String::new(),
+        stderr: stderr_str,
+        exit_code,
+        success: true,
+    })
+}
+
+/// Join a worker thread with a time budget. Returns `Some(value)` if
+/// the thread finished in time, `None` if the deadline passed first.
+/// A missed deadline leaks the `JoinHandle`; the thread completes
+/// eventually and its value is dropped.
+#[cfg(all(feature = "sync", feature = "json"))]
+fn join_with_budget<T: Send + 'static>(
+    handle: std::thread::JoinHandle<T>,
+    budget: Duration,
+) -> Option<T> {
+    use std::sync::mpsc;
+    use std::thread;
+
+    let (tx, rx) = mpsc::channel::<T>();
+    thread::spawn(move || {
+        if let Ok(v) = handle.join() {
+            let _ = tx.send(v);
+        }
+    });
+    rx.recv_timeout(budget).ok()
+}

--- a/crates/claude-wrapper/tests/fake_claude_sync.rs
+++ b/crates/claude-wrapper/tests/fake_claude_sync.rs
@@ -208,3 +208,116 @@ fn sync_query_execute_retries_via_policy() {
     assert!(out.success);
     assert!(out.stdout.contains("ok"));
 }
+
+// ── sync streaming tests ─────────────────────────────────────────
+
+#[cfg(feature = "json")]
+#[test]
+fn sync_stream_emits_three_event_types() {
+    use claude_wrapper::streaming::{StreamEvent, stream_query_sync};
+    use claude_wrapper::{OutputFormat, QueryCommand};
+
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "streamed sync")]);
+    let cmd = QueryCommand::new("test prompt")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+
+    let mut events: Vec<StreamEvent> = Vec::new();
+    stream_query_sync(&claude, &cmd, |event| events.push(event))
+        .expect("sync streaming should succeed");
+
+    // Fake binary emits exactly three NDJSON lines: system, assistant,
+    // result. Verify all three surface in order.
+    assert_eq!(events.len(), 3, "expected 3 events, got {}", events.len());
+    assert_eq!(events[0].event_type(), Some("system"));
+    assert_eq!(events[1].event_type(), Some("assistant"));
+    assert_eq!(events[2].event_type(), Some("result"));
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn sync_stream_result_event_carries_metadata() {
+    use claude_wrapper::streaming::{StreamEvent, stream_query_sync};
+    use claude_wrapper::{OutputFormat, QueryCommand};
+
+    let claude = claude_with_env(&[
+        ("FAKE_CLAUDE_OUTPUT", "sync output"),
+        ("FAKE_CLAUDE_SESSION_ID", "sync-stream-123"),
+    ]);
+    let cmd = QueryCommand::new("test")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+
+    let mut result_event: Option<StreamEvent> = None;
+    stream_query_sync(&claude, &cmd, |event| {
+        if event.is_result() {
+            result_event = Some(event);
+        }
+    })
+    .expect("sync streaming should succeed");
+
+    let result = result_event.expect("should have received a result event");
+    assert_eq!(result.session_id(), Some("sync-stream-123"));
+    assert_eq!(result.result_text(), Some("sync output"));
+    assert_eq!(result.cost_usd(), Some(0.0));
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn sync_stream_timeout_fires_and_returns_promptly() {
+    use claude_wrapper::streaming::stream_query_sync;
+    use claude_wrapper::{OutputFormat, QueryCommand};
+
+    // Fake child sleeps 5s before emitting anything.
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .env("FAKE_CLAUDE_DELAY", "5")
+        .env("FAKE_CLAUDE_OUTPUT", "unreachable")
+        .timeout(Duration::from_millis(300))
+        .build()
+        .unwrap();
+
+    let cmd = QueryCommand::new("test")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+
+    let start = Instant::now();
+    let result = stream_query_sync(&claude, &cmd, |_| {});
+    let elapsed = start.elapsed();
+
+    let err = result.expect_err("expected a timeout error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("timed out") || msg.contains("timeout"),
+        "expected timeout error, got: {msg}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "sync streaming timeout should return promptly, took {elapsed:?}"
+    );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn sync_stream_handler_runs_on_caller_thread_non_send_state() {
+    use claude_wrapper::streaming::stream_query_sync;
+    use claude_wrapper::{OutputFormat, QueryCommand};
+    use std::rc::Rc;
+
+    // Rc<RefCell<_>> is !Send, so this compiling and running is the
+    // proof that the handler isn't forced onto a worker thread.
+    let counter = Rc::new(std::cell::RefCell::new(0usize));
+    let counter_clone = Rc::clone(&counter);
+
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "bump")]);
+    let cmd = QueryCommand::new("test")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+
+    stream_query_sync(&claude, &cmd, move |_| {
+        *counter_clone.borrow_mut() += 1;
+    })
+    .expect("sync streaming should succeed");
+
+    assert_eq!(*counter.borrow(), 3);
+}


### PR DESCRIPTION
## Summary

PR 3 of the sync API series for #535. Adds `stream_query_sync` in `streaming.rs` — the blocking mirror of `stream_query` — so sync consumers can consume NDJSON events from the CLI without a tokio runtime.

Gated `#[cfg(all(feature = "sync", feature = "json"))]`.

## Design

Three threads, one channel:

- **Reader thread** owns child stdout, parses each NDJSON line into a `StreamEvent`, pushes through an `mpsc::channel`.
- **Stderr thread** drains child stderr into a buffer (prevents pipe-buffer deadlock on chatty children).
- **Main thread** loops `rx.recv_timeout(remaining)` and runs the caller-supplied handler inline. This keeps the handler non-`Send` — matching the async signature and letting callers capture `Rc<RefCell<_>>`, non-`Send` state, etc.

On timeout: SIGKILL + `wait` + join both workers with a 200ms budget each. If an orphaned grandchild (classic `bash -> sleep 5`) keeps the pipe fds open past SIGKILL, the joins exceed their budget and we return the timeout error anyway — the worker JoinHandles leak until the OS reaps the grandchild, which is acceptable for this edge case.

The async version sidesteps this via `drop(future)` cancelling the reader task; Rust std threads aren't cancellable, so budgeted joins are the sync equivalent.

## Non-Send handler

```rust
use std::rc::Rc;
let counter = Rc::new(std::cell::RefCell::new(0));
let c = Rc::clone(&counter);

stream_query_sync(&claude, &cmd, move |_event| {
    *c.borrow_mut() += 1;  // Rc<RefCell<_>> is !Send
})?;
```

Proves the handler runs on the caller's thread. There's a test for this.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p claude-wrapper --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib -p claude-wrapper --all-features` (147 pass)
- [x] `cargo test --doc -p claude-wrapper --all-features` (47 pass; new `stream_query_sync` doc example)
- [x] `cargo test --test fake_claude_sync -p claude-wrapper --all-features` (14 pass: 4 new covering 3-event parse, result-event metadata, prompt timeout, non-Send handler)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p claude-wrapper --all-features --no-deps`
- [x] `cargo build -p claude-wrapper` (default build, sync off)
- [x] `cargo build -p claude-wrapper --features sync`

## Up next

**PR 4**: make `tokio` optional behind an `async` feature. `default-features = false, features = ["json", "sync"]` drops the tokio dep entirely — the actual win the issue promised for sync-only consumers like conversa.

Refs #535