### PR TITLE
feat!: make tokio optional via new async feature (PR 4 of sync API series)

### DIFF
--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -17,20 +17,21 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["json", "tempfile"]
+default = ["async", "json", "tempfile"]
+# Async API (tokio-backed). In default features for back-compat;
+# disable via `default-features = false` to drop the tokio dep.
+async = ["dep:tokio"]
 json = ["serde_json"]
 tempfile = ["dep:tempfile"]
-# Blocking/synchronous API alongside the async default. Enables the
-# *_sync execution paths in exec::/retry:: (no tokio runtime required
-# at call sites). tokio is still pulled in by default; future work
-# will let sync-only callers drop it via `default-features = false`.
+# Blocking/synchronous API. With `default-features = false,
+# features = ["json", "sync"]` you get a tokio-free build.
 sync = ["dep:wait-timeout"]
 
 [dependencies]
 serde = { workspace = true }
 serde_json = { version = "1", optional = true }
 thiserror = { workspace = true }
-tokio = { version = "1", features = ["process", "time", "io-util", "macros"] }
+tokio = { version = "1", features = ["process", "time", "io-util", "macros"], optional = true }
 tracing = { workspace = true }
 tempfile = { version = "3", optional = true }
 wait-timeout = { version = "0.2", optional = true }
@@ -40,3 +41,33 @@ which = "8"
 serde_json = "1"
 tempfile = "3"
 tokio = { workspace = true }
+
+# All examples use the async API; require the feature so they're
+# skipped automatically on sync-only builds.
+[[example]]
+name = "agent_worker"
+required-features = ["async", "json"]
+
+[[example]]
+name = "health_check"
+required-features = ["async"]
+
+[[example]]
+name = "json_output"
+required-features = ["async", "json"]
+
+[[example]]
+name = "mcp_config"
+required-features = ["async"]
+
+[[example]]
+name = "oneshot"
+required-features = ["async"]
+
+[[example]]
+name = "stream_query"
+required-features = ["async", "json"]
+
+[[example]]
+name = "supervised_worker"
+required-features = ["async", "json"]

--- a/crates/claude-wrapper/src/command/agents.rs
+++ b/crates/claude-wrapper/src/command/agents.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
 use crate::error::Result;
-use crate::exec::{self, CommandOutput};
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
 
 /// List configured agents.
 ///
@@ -51,6 +55,7 @@ impl ClaudeCommand for AgentsCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }

--- a/crates/claude-wrapper/src/command/auth.rs
+++ b/crates/claude-wrapper/src/command/auth.rs
@@ -37,7 +37,7 @@ impl AuthStatusCommand {
     }
 
     /// Execute and parse the JSON result into an [`AuthStatus`](crate::types::AuthStatus).
-    #[cfg(feature = "json")]
+    #[cfg(all(feature = "json", feature = "async"))]
     pub async fn execute_json(&self, claude: &Claude) -> Result<crate::types::AuthStatus> {
         let mut cmd = self.clone();
         cmd.json = true;
@@ -78,6 +78,7 @@ impl ClaudeCommand for AuthStatusCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -143,6 +144,7 @@ impl ClaudeCommand for AuthLoginCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -179,6 +181,7 @@ impl ClaudeCommand for AuthLogoutCommand {
         vec!["auth".to_string(), "logout".to_string()]
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -215,6 +218,7 @@ impl ClaudeCommand for SetupTokenCommand {
         vec!["setup-token".to_string()]
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }

--- a/crates/claude-wrapper/src/command/doctor.rs
+++ b/crates/claude-wrapper/src/command/doctor.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
 use crate::error::Result;
-use crate::exec::{self, CommandOutput};
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
 
 /// Run `claude doctor` to check CLI health.
 ///
@@ -34,6 +38,7 @@ impl ClaudeCommand for DoctorCommand {
         vec!["doctor".to_string()]
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }

--- a/crates/claude-wrapper/src/command/marketplace.rs
+++ b/crates/claude-wrapper/src/command/marketplace.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
 use crate::error::Result;
-use crate::exec::{self, CommandOutput};
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
 use crate::types::Scope;
 
 /// List configured plugin marketplaces.
@@ -53,6 +57,7 @@ impl ClaudeCommand for MarketplaceListCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -128,6 +133,7 @@ impl ClaudeCommand for MarketplaceAddCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -159,6 +165,7 @@ impl ClaudeCommand for MarketplaceRemoveCommand {
         ]
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -201,6 +208,7 @@ impl ClaudeCommand for MarketplaceUpdateCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }

--- a/crates/claude-wrapper/src/command/mcp.rs
+++ b/crates/claude-wrapper/src/command/mcp.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
 use crate::error::Result;
-use crate::exec::{self, CommandOutput};
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
 use crate::types::{Scope, Transport};
 
 /// List configured MCP servers.
@@ -36,6 +40,7 @@ impl ClaudeCommand for McpListCommand {
         vec!["mcp".to_string(), "list".to_string()]
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -62,6 +67,7 @@ impl ClaudeCommand for McpGetCommand {
         vec!["mcp".to_string(), "get".to_string(), self.name.clone()]
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -234,6 +240,7 @@ impl ClaudeCommand for McpAddCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -283,6 +290,7 @@ impl ClaudeCommand for McpAddJsonCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -329,6 +337,7 @@ impl ClaudeCommand for McpRemoveCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -367,6 +376,7 @@ impl ClaudeCommand for McpAddFromDesktopCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -430,6 +440,7 @@ impl ClaudeCommand for McpServeCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -453,6 +464,7 @@ impl ClaudeCommand for McpResetProjectChoicesCommand {
         vec!["mcp".to_string(), "reset-project-choices".to_string()]
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }

--- a/crates/claude-wrapper/src/command/mod.rs
+++ b/crates/claude-wrapper/src/command/mod.rs
@@ -8,6 +8,7 @@ pub mod query;
 pub mod raw;
 pub mod version;
 
+#[cfg(feature = "async")]
 use std::future::Future;
 
 use crate::Claude;
@@ -18,6 +19,10 @@ use crate::error::Result;
 /// Each command defines its own `Output` type and builds its argument
 /// list via `args()`. Execution is dispatched through the shared `Claude`
 /// client which provides binary path, environment, and timeout config.
+///
+/// The async `execute` method is only present when the `async` feature
+/// is enabled. In sync-only builds, callers reach the blocking path
+/// via [`ClaudeCommandSyncExt::execute_sync`].
 pub trait ClaudeCommand: Send + Sync {
     /// The typed result of executing this command.
     type Output: Send;
@@ -26,6 +31,7 @@ pub trait ClaudeCommand: Send + Sync {
     fn args(&self) -> Vec<String>;
 
     /// Execute the command using the given claude client.
+    #[cfg(feature = "async")]
     fn execute(&self, claude: &Claude) -> impl Future<Output = Result<Self::Output>> + Send;
 }
 

--- a/crates/claude-wrapper/src/command/plugin.rs
+++ b/crates/claude-wrapper/src/command/plugin.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
 use crate::error::Result;
-use crate::exec::{self, CommandOutput};
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
 use crate::types::Scope;
 
 /// List installed plugins.
@@ -60,6 +64,7 @@ impl ClaudeCommand for PluginListCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -118,6 +123,7 @@ impl ClaudeCommand for PluginInstallCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -161,6 +167,7 @@ impl ClaudeCommand for PluginUninstallCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -204,6 +211,7 @@ impl ClaudeCommand for PluginEnableCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -264,6 +272,7 @@ impl ClaudeCommand for PluginDisableCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -307,6 +316,7 @@ impl ClaudeCommand for PluginUpdateCommand {
         args
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }
@@ -337,6 +347,7 @@ impl ClaudeCommand for PluginValidateCommand {
         ]
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }

--- a/crates/claude-wrapper/src/command/query.rs
+++ b/crates/claude-wrapper/src/command/query.rs
@@ -271,7 +271,7 @@ impl QueryCommand {
     /// `--continue`, `--session-id`, or `--fork-session`). Keeping the
     /// override logic in one place prevents conflicting flags from reaching
     /// the CLI.
-    #[cfg(feature = "json")]
+    #[cfg(all(feature = "json", feature = "async"))]
     pub(crate) fn replace_session(mut self, id: impl Into<String>) -> Self {
         self.continue_session = false;
         self.resume = Some(id.into());
@@ -490,7 +490,7 @@ impl QueryCommand {
     ///
     /// This is a convenience method that sets `OutputFormat::Json` and
     /// deserializes the response into a [`QueryResult`](crate::types::QueryResult).
-    #[cfg(feature = "json")]
+    #[cfg(all(feature = "json", feature = "async"))]
     pub async fn execute_json(&self, claude: &Claude) -> Result<crate::types::QueryResult> {
         // Build args with JSON output format forced
         let mut args = self.build_args();
@@ -731,6 +731,7 @@ impl ClaudeCommand for QueryCommand {
         self.build_args()
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude_with_retry(claude, self.args(), self.retry_policy.as_ref()).await
     }

--- a/crates/claude-wrapper/src/command/raw.rs
+++ b/crates/claude-wrapper/src/command/raw.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
 use crate::error::Result;
-use crate::exec::{self, CommandOutput};
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
 
 /// Escape hatch for running arbitrary claude subcommands not yet
 /// covered by dedicated command builders.
@@ -60,6 +64,7 @@ impl ClaudeCommand for RawCommand {
         self.command_args.clone()
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }

--- a/crates/claude-wrapper/src/command/version.rs
+++ b/crates/claude-wrapper/src/command/version.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
 use crate::error::Result;
-use crate::exec::{self, CommandOutput};
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
 
 /// Run `claude --version` to get the CLI version.
 ///
@@ -34,6 +38,7 @@ impl ClaudeCommand for VersionCommand {
         vec!["--version".to_string()]
     }
 
+    #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
         exec::run_claude(claude, self.args()).await
     }

--- a/crates/claude-wrapper/src/dangerous.rs
+++ b/crates/claude-wrapper/src/dangerous.rs
@@ -51,7 +51,9 @@
 //! through `DangerousClient`.
 
 use crate::Claude;
-use crate::command::{ClaudeCommand, query::QueryCommand};
+#[cfg(feature = "async")]
+use crate::command::ClaudeCommand;
+use crate::command::query::QueryCommand;
 use crate::error::{Error, Result};
 use crate::exec::CommandOutput;
 #[allow(deprecated)]
@@ -91,11 +93,21 @@ impl DangerousClient {
 
     /// Run `cmd` with `--permission-mode bypassPermissions`
     /// unconditionally overridden. Any permission mode the caller
-    /// already set on `cmd` is replaced.
+    /// already set on `cmd` is replaced. Requires the `async` feature.
+    #[cfg(feature = "async")]
     pub async fn query_bypass(&self, cmd: QueryCommand) -> Result<CommandOutput> {
         #[allow(deprecated)]
         let cmd = cmd.permission_mode(PermissionMode::BypassPermissions);
         cmd.execute(&self.inner).await
+    }
+
+    /// Blocking mirror of [`DangerousClient::query_bypass`]. Requires
+    /// the `sync` feature.
+    #[cfg(feature = "sync")]
+    pub fn query_bypass_sync(&self, cmd: QueryCommand) -> Result<CommandOutput> {
+        #[allow(deprecated)]
+        let cmd = cmd.permission_mode(PermissionMode::BypassPermissions);
+        cmd.execute_sync(&self.inner)
     }
 }
 

--- a/crates/claude-wrapper/src/exec.rs
+++ b/crates/claude-wrapper/src/exec.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
+#[cfg(feature = "async")]
 use tokio::io::AsyncReadExt;
+#[cfg(feature = "async")]
 use tokio::process::Command;
 use tracing::{debug, warn};
 
@@ -21,11 +23,13 @@ pub struct CommandOutput {
 /// If the [`Claude`] client has a retry policy set, transient errors will be
 /// retried according to that policy. A per-command retry policy can be passed
 /// to override the client default.
+#[cfg(feature = "async")]
 pub async fn run_claude(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
     run_claude_with_retry(claude, args, None).await
 }
 
 /// Run a claude command with an optional per-command retry policy override.
+#[cfg(feature = "async")]
 pub async fn run_claude_with_retry(
     claude: &Claude,
     args: Vec<String>,
@@ -41,6 +45,7 @@ pub async fn run_claude_with_retry(
     }
 }
 
+#[cfg(feature = "async")]
 async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
     let mut command_args = Vec::new();
 
@@ -75,6 +80,7 @@ async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOu
 }
 
 /// Run a claude command and allow specific non-zero exit codes.
+#[cfg(feature = "async")]
 pub async fn run_claude_allow_exit_codes(
     claude: &Claude,
     args: Vec<String>,
@@ -98,6 +104,7 @@ pub async fn run_claude_allow_exit_codes(
     }
 }
 
+#[cfg(feature = "async")]
 async fn run_internal(
     binary: &std::path::Path,
     args: &[String],
@@ -161,6 +168,7 @@ async fn run_internal(
 /// On timeout, partial stdout/stderr captured before the kill is logged at
 /// warn level; the returned `Error::Timeout` itself does not carry the
 /// partial output.
+#[cfg(feature = "async")]
 async fn run_with_timeout(
     binary: &std::path::Path,
     args: &[String],
@@ -257,6 +265,7 @@ async fn run_with_timeout(
     }
 }
 
+#[cfg(feature = "async")]
 async fn drain<R: AsyncReadExt + Unpin>(reader: &mut R) -> String {
     let mut buf = Vec::new();
     let _ = reader.read_to_end(&mut buf).await;

--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -171,7 +171,7 @@ pub mod error;
 pub mod exec;
 pub mod mcp_config;
 pub mod retry;
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", feature = "async"))]
 pub mod session;
 pub mod streaming;
 pub mod tool_pattern;
@@ -212,7 +212,7 @@ pub use exec::CommandOutput;
 pub use mcp_config::TempMcpConfig;
 pub use mcp_config::{McpConfigBuilder, McpServerConfig};
 pub use retry::{BackoffStrategy, RetryPolicy};
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", feature = "async"))]
 pub use session::Session;
 pub use tool_pattern::{PatternError, ToolPattern};
 pub use types::*;
@@ -272,6 +272,7 @@ impl Claude {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "async")]
     pub async fn cli_version(&self) -> Result<CliVersion> {
         let output = VersionCommand::new().execute(self).await?;
         CliVersion::parse_version_output(&output.stdout).map_err(|e| Error::Io {
@@ -298,6 +299,7 @@ impl Claude {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "async")]
     pub async fn check_version(&self, minimum: &CliVersion) -> Result<CliVersion> {
         let version = self.cli_version().await?;
         if version.satisfies_minimum(minimum) {

--- a/crates/claude-wrapper/src/retry.rs
+++ b/crates/claude-wrapper/src/retry.rs
@@ -133,6 +133,7 @@ impl RetryPolicy {
 }
 
 /// Execute a fallible async operation with retry.
+#[cfg(feature = "async")]
 pub(crate) async fn with_retry<F, Fut, T>(
     policy: &RetryPolicy,
     mut operation: F,
@@ -304,6 +305,7 @@ mod tests {
         assert!(!policy.should_retry(&error));
     }
 
+    #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_with_retry_succeeds_first_try() {
         let policy = RetryPolicy::new().max_attempts(3);
@@ -311,6 +313,7 @@ mod tests {
         assert_eq!(result.unwrap(), 42);
     }
 
+    #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_with_retry_succeeds_after_failures() {
         let policy = RetryPolicy::new()
@@ -340,6 +343,7 @@ mod tests {
         assert_eq!(attempt.load(std::sync::atomic::Ordering::SeqCst), 3);
     }
 
+    #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_with_retry_exhausts_attempts() {
         let policy = RetryPolicy::new()
@@ -357,6 +361,7 @@ mod tests {
         assert!(matches!(result, Err(Error::Timeout { .. })));
     }
 
+    #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_with_retry_no_retry_on_non_retryable() {
         let policy = RetryPolicy::new()

--- a/crates/claude-wrapper/src/streaming.rs
+++ b/crates/claude-wrapper/src/streaming.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "json")]
 use std::time::Duration;
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", feature = "async"))]
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", feature = "async"))]
 use tokio::process::{ChildStderr, Command};
 #[cfg(feature = "json")]
 use tracing::{debug, warn};
@@ -92,7 +92,7 @@ impl StreamEvent {
 /// # Ok(())
 /// # }
 /// ```
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", feature = "async"))]
 pub async fn stream_query<F>(
     claude: &Claude,
     cmd: &crate::command::query::QueryCommand,
@@ -115,7 +115,7 @@ where
 /// warn level. The returned `Error::Timeout` does not carry partial
 /// output -- streamed stdout events were already dispatched to the
 /// handler as they arrived.
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", feature = "async"))]
 async fn stream_query_impl<F>(
     claude: &Claude,
     cmd: &crate::command::query::QueryCommand,
@@ -232,14 +232,14 @@ where
     })
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", feature = "async"))]
 async fn drain_stderr(stderr: &mut ChildStderr) -> String {
     let mut buf = Vec::new();
     let _ = stderr.read_to_end(&mut buf).await;
     String::from_utf8_lossy(&buf).into_owned()
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", feature = "async"))]
 async fn read_lines<F>(
     reader: &mut tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
     handler: &mut F,

--- a/crates/claude-wrapper/tests/fake_claude.rs
+++ b/crates/claude-wrapper/tests/fake_claude.rs
@@ -2,6 +2,8 @@
 //!
 //! These tests do not require a real `claude` binary or authentication.
 
+#![cfg(feature = "async")]
+
 use std::path::PathBuf;
 
 use claude_wrapper::{Claude, ClaudeCommand, OutputFormat, QueryCommand, RetryPolicy};

--- a/crates/claude-wrapper/tests/integration.rs
+++ b/crates/claude-wrapper/tests/integration.rs
@@ -5,6 +5,8 @@
 //! cargo test --test integration -- --ignored
 //! ```
 
+#![cfg(feature = "async")]
+
 use claude_wrapper::{Claude, ClaudeCommand, QueryCommand, VersionCommand};
 
 fn claude_client() -> Claude {


### PR DESCRIPTION
## Summary

Final PR of the sync API series for #535 — the payoff. Makes `tokio` an optional dependency gated on a new `async` feature. Default features include `async`, so existing users see no behavior change; sync-only consumers now get a tokio-free build.

```toml
[dependencies.claude-wrapper]
version = "..."
default-features = false
features = ["json", "sync"]
```

**Verified**: `cargo tree -p claude-wrapper --no-default-features --features "json,sync" --edges=no-dev | grep -c tokio` → `0`.

## Surface changes

- `ClaudeCommand::execute` is now `#[cfg(feature = "async")]`. `args()` and `type Output` remain always-available, so `ClaudeCommandSyncExt`'s blanket impl (which only needs those two) still works in sync-only builds.
- Every `async fn execute` / `async fn execute_json` on command builders is `cfg(feature = "async")`. Sync twins from PR 2 stay on unconditionally (with `sync`).
- `streaming::stream_query`, `Session`, `Claude::cli_version`, `Claude::check_version`, `DangerousClient::query_bypass`, and `retry::with_retry` are all gated on `async`.
- New: `DangerousClient::query_bypass_sync` for symmetry in sync-only builds.
- Every example now has `required-features = ["async", ...]` in `Cargo.toml`, so Cargo skips them cleanly on sync-only builds. Async integration test files get top-level `#![cfg(feature = "async")]`.

## Is this a breaking change?

Technically yes — the `!` in the commit type reflects that. In practice no call site that compiles today breaks, because default features still include `async`. The only way this breaks someone is if they have:

```toml
claude-wrapper = { version = "...", default-features = false, features = ["json"] }
```

…and relied on tokio still being in the tree via transitive guarantees. That wasn't a supported configuration before (there was no sync API to use), so the practical blast radius is zero.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p claude-wrapper --all-targets --all-features -- -D warnings`
- [x] `cargo clippy -p claude-wrapper --all-targets -- -D warnings` (default features)
- [x] `cargo clippy -p claude-wrapper --all-targets --no-default-features --features "json,sync" -- -D warnings`
- [x] `cargo test --lib -p claude-wrapper --all-features` (147 pass)
- [x] `cargo test --doc -p claude-wrapper --all-features` (47 pass)
- [x] `cargo test --test fake_claude_sync -p claude-wrapper --all-features` (14 pass)
- [x] `cargo test --test fake_claude_sync -p claude-wrapper --no-default-features --features "json,sync"` (14 pass, tokio-free)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p claude-wrapper --all-features --no-deps`
- [x] `cargo build -p claude-wrapper` (default)
- [x] `cargo build -p claude-wrapper --no-default-features --features "json,sync"`
- [x] `cargo tree --no-default-features --features "json,sync" --edges=no-dev` confirms zero tokio

## Series complete

- PR 1 (#547): sync exec/retry primitives + `wait-timeout` dep.
- PR 2 (#548): sync command surface (`ClaudeCommandSyncExt` blanket, inherent `execute_sync` on `QueryCommand`, `Claude::cli_version_sync`).
- PR 3 (#549): `stream_query_sync` with non-Send handler support.
- **PR 4 (this one)**: tokio optional. Sync-only consumers drop the runtime dep.

Closes #535