### PR TITLE
feat: wrap --bare + 4 other query flags, add auto-mode subcommands

### DIFF
--- a/src/command/auto_mode.rs
+++ b/src/command/auto_mode.rs
@@ -1,0 +1,188 @@
+//! `claude auto-mode` subcommands: inspect the auto-mode classifier
+//! configuration.
+//!
+//! The CLI exposes three children under `auto-mode`:
+//!
+//! - [`AutoModeConfigCommand`] -- `auto-mode config`, the effective
+//!   merged config as JSON.
+//! - [`AutoModeDefaultsCommand`] -- `auto-mode defaults`, the default
+//!   rules as JSON.
+//! - [`AutoModeCritiqueCommand`] -- `auto-mode critique`, AI feedback
+//!   on your custom auto-mode rules.
+
+#[cfg(feature = "async")]
+use crate::Claude;
+use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
+use crate::error::Result;
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
+
+/// Print the effective auto-mode config as JSON.
+///
+/// Emits your settings where set and defaults otherwise, merged.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(feature = "async")] {
+/// use claude_wrapper::{AutoModeConfigCommand, Claude, ClaudeCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let output = AutoModeConfigCommand::new().execute(&claude).await?;
+/// println!("{}", output.stdout);
+/// # Ok(()) }
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct AutoModeConfigCommand;
+
+impl AutoModeConfigCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ClaudeCommand for AutoModeConfigCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["auto-mode".to_string(), "config".to_string()]
+    }
+
+    #[cfg(feature = "async")]
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
+/// Print the default auto-mode environment, allow, and deny rules as
+/// JSON. Useful as a reference when writing custom rules.
+#[derive(Debug, Clone, Default)]
+pub struct AutoModeDefaultsCommand;
+
+impl AutoModeDefaultsCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ClaudeCommand for AutoModeDefaultsCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["auto-mode".to_string(), "defaults".to_string()]
+    }
+
+    #[cfg(feature = "async")]
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
+/// Get AI feedback on your custom auto-mode rules.
+///
+/// Takes an optional model override; without one the CLI picks its
+/// default. Output is free-form text.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(feature = "async")] {
+/// use claude_wrapper::{AutoModeCritiqueCommand, Claude, ClaudeCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let output = AutoModeCritiqueCommand::new()
+///     .model("opus")
+///     .execute(&claude)
+///     .await?;
+/// println!("{}", output.stdout);
+/// # Ok(()) }
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct AutoModeCritiqueCommand {
+    model: Option<String>,
+}
+
+impl AutoModeCritiqueCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the model used for the critique.
+    #[must_use]
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+}
+
+impl ClaudeCommand for AutoModeCritiqueCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["auto-mode".to_string(), "critique".to_string()];
+        if let Some(ref model) = self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+        args
+    }
+
+    #[cfg(feature = "async")]
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_command_args() {
+        let cmd = AutoModeConfigCommand::new();
+        assert_eq!(
+            ClaudeCommand::args(&cmd),
+            vec!["auto-mode".to_string(), "config".to_string()]
+        );
+    }
+
+    #[test]
+    fn defaults_command_args() {
+        let cmd = AutoModeDefaultsCommand::new();
+        assert_eq!(
+            ClaudeCommand::args(&cmd),
+            vec!["auto-mode".to_string(), "defaults".to_string()]
+        );
+    }
+
+    #[test]
+    fn critique_command_defaults_omit_model() {
+        let cmd = AutoModeCritiqueCommand::new();
+        let args = ClaudeCommand::args(&cmd);
+        assert_eq!(args, vec!["auto-mode".to_string(), "critique".to_string()]);
+    }
+
+    #[test]
+    fn critique_command_with_model() {
+        let cmd = AutoModeCritiqueCommand::new().model("opus");
+        let args = ClaudeCommand::args(&cmd);
+        assert_eq!(
+            args,
+            vec![
+                "auto-mode".to_string(),
+                "critique".to_string(),
+                "--model".to_string(),
+                "opus".to_string(),
+            ]
+        );
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,5 +1,6 @@
 pub mod agents;
 pub mod auth;
+pub mod auto_mode;
 pub mod doctor;
 pub mod marketplace;
 pub mod mcp;

--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -67,6 +67,11 @@ pub struct QueryCommand {
     plugin_dirs: Vec<String>,
     setting_sources: Option<String>,
     tmux: bool,
+    bare: bool,
+    disable_slash_commands: bool,
+    include_hook_events: bool,
+    exclude_dynamic_system_prompt_sections: bool,
+    name: Option<String>,
 }
 
 impl QueryCommand {
@@ -112,6 +117,11 @@ impl QueryCommand {
             plugin_dirs: Vec::new(),
             setting_sources: None,
             tmux: false,
+            bare: false,
+            disable_slash_commands: false,
+            include_hook_events: false,
+            exclude_dynamic_system_prompt_sections: false,
+            name: None,
         }
     }
 
@@ -430,6 +440,62 @@ impl QueryCommand {
         self
     }
 
+    /// Run in minimal mode (`--bare`).
+    ///
+    /// Skips hooks, LSP, plugin sync, attribution, auto-memory,
+    /// background prefetches, keychain reads, and CLAUDE.md
+    /// auto-discovery. Sets `CLAUDE_CODE_SIMPLE=1` inside the child.
+    /// Anthropic auth is restricted to `ANTHROPIC_API_KEY` or
+    /// `apiKeyHelper` via `--settings`; OAuth and keychain are never
+    /// read. Third-party providers (Bedrock/Vertex/Foundry) use their
+    /// own credentials as normal.
+    ///
+    /// Intended for headless/CI use where you want deterministic
+    /// context: provide everything explicitly via `--system-prompt`,
+    /// `--append-system-prompt`, `--add-dir`, `--mcp-config`,
+    /// `--settings`, `--agents`, and `--plugin-dir`. Skills still
+    /// resolve via explicit `/skill-name` references.
+    #[must_use]
+    pub fn bare(mut self) -> Self {
+        self.bare = true;
+        self
+    }
+
+    /// Disable all slash-command skills (`--disable-slash-commands`).
+    #[must_use]
+    pub fn disable_slash_commands(mut self) -> Self {
+        self.disable_slash_commands = true;
+        self
+    }
+
+    /// Include every hook lifecycle event in the stream-json output
+    /// (`--include-hook-events`). Only meaningful with
+    /// `OutputFormat::StreamJson`.
+    #[must_use]
+    pub fn include_hook_events(mut self) -> Self {
+        self.include_hook_events = true;
+        self
+    }
+
+    /// Move per-machine sections (cwd, env info, memory paths, git
+    /// status) out of the system prompt and into the first user
+    /// message (`--exclude-dynamic-system-prompt-sections`). Improves
+    /// cross-user prompt-cache reuse. Only applies with the default
+    /// system prompt; ignored with `--system-prompt`.
+    #[must_use]
+    pub fn exclude_dynamic_system_prompt_sections(mut self) -> Self {
+        self.exclude_dynamic_system_prompt_sections = true;
+        self
+    }
+
+    /// Set a display name for this session (`--name`). Shown in the
+    /// prompt box, `/resume` picker, and terminal title.
+    #[must_use]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
     /// Set a per-command retry policy, overriding the client default.
     ///
     /// # Example
@@ -716,6 +782,27 @@ impl QueryCommand {
             args.push("--tmux".to_string());
         }
 
+        if self.bare {
+            args.push("--bare".to_string());
+        }
+
+        if self.disable_slash_commands {
+            args.push("--disable-slash-commands".to_string());
+        }
+
+        if self.include_hook_events {
+            args.push("--include-hook-events".to_string());
+        }
+
+        if self.exclude_dynamic_system_prompt_sections {
+            args.push("--exclude-dynamic-system-prompt-sections".to_string());
+        }
+
+        if let Some(ref name) = self.name {
+            args.push("--name".to_string());
+            args.push(name.clone());
+        }
+
         // Separator to prevent flags like --allowed-tools from consuming the prompt.
         args.push("--".to_string());
         args.push(self.prompt.clone());
@@ -854,6 +941,37 @@ mod tests {
         let strs: Vec<ToolPattern> = vec!["Bash".into(), ToolPattern::all("Read")];
         let cmd = QueryCommand::new("hi").allowed_tools(strs);
         assert!(cmd.args().contains(&"--allowed-tools".to_string()));
+    }
+
+    #[test]
+    fn new_bool_flags_emit_correct_cli_args() {
+        let args = QueryCommand::new("hi")
+            .bare()
+            .disable_slash_commands()
+            .include_hook_events()
+            .exclude_dynamic_system_prompt_sections()
+            .args();
+        assert!(args.contains(&"--bare".to_string()));
+        assert!(args.contains(&"--disable-slash-commands".to_string()));
+        assert!(args.contains(&"--include-hook-events".to_string()));
+        assert!(args.contains(&"--exclude-dynamic-system-prompt-sections".to_string()));
+    }
+
+    #[test]
+    fn name_flag_renders_with_value() {
+        let args = QueryCommand::new("hi").name("my session").args();
+        let pos = args.iter().position(|a| a == "--name").unwrap();
+        assert_eq!(args[pos + 1], "my session");
+    }
+
+    #[test]
+    fn new_bool_flags_default_to_off() {
+        let args = QueryCommand::new("hi").args();
+        assert!(!args.contains(&"--bare".to_string()));
+        assert!(!args.contains(&"--disable-slash-commands".to_string()));
+        assert!(!args.contains(&"--include-hook-events".to_string()));
+        assert!(!args.contains(&"--exclude-dynamic-system-prompt-sections".to_string()));
+        assert!(!args.contains(&"--name".to_string()));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,9 @@ pub use command::agents::AgentsCommand;
 pub use command::auth::{
     AuthLoginCommand, AuthLogoutCommand, AuthStatusCommand, SetupTokenCommand,
 };
+pub use command::auto_mode::{
+    AutoModeConfigCommand, AutoModeCritiqueCommand, AutoModeDefaultsCommand,
+};
 pub use command::doctor::DoctorCommand;
 pub use command::marketplace::{
     MarketplaceAddCommand, MarketplaceListCommand, MarketplaceRemoveCommand,


### PR DESCRIPTION
## Summary

First slice of the CLI coverage gap tracked in #552. Covers the top priorities from the audit.

### QueryCommand flags

Five new builder methods, each gated behind the existing `async` path (no-op on args emission otherwise):

| Method | CLI flag | Purpose |
|---|---|---|
| `.bare()` | `--bare` | Minimal mode: skips hooks, LSP, plugin sync, attribution, auto-memory, background prefetches, keychain reads, CLAUDE.md discovery. Sets `CLAUDE_CODE_SIMPLE=1`. Auth restricted to `ANTHROPIC_API_KEY` / `apiKeyHelper`. |
| `.disable_slash_commands()` | `--disable-slash-commands` | Disable all skills. |
| `.include_hook_events()` | `--include-hook-events` | Emit every hook lifecycle event in the stream-json output. |
| `.exclude_dynamic_system_prompt_sections()` | `--exclude-dynamic-system-prompt-sections` | Move cwd/env/memory/git-status from the system prompt into the first user message for cross-user prompt-cache reuse. |
| `.name(impl Into<String>)` | `--name <name>` | Display name for the session. |

### auto-mode module

New `src/command/auto_mode.rs` with three command builders matching `claude auto-mode`:

- `AutoModeConfigCommand` -> `auto-mode config` (effective merged config as JSON)
- `AutoModeDefaultsCommand` -> `auto-mode defaults` (default rules as JSON)
- `AutoModeCritiqueCommand::new().model(...)` -> `auto-mode critique [--model M]` (AI feedback on custom auto-mode rules)

All three re-exported at the crate root.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features "json,sync" -- -D warnings`
- [x] `cargo test --lib --all-features` (154 pass, 7 new)
- [x] `cargo test --doc --all-features` (52 pass, 2 new)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- [x] `cargo build` (default)
- [x] `cargo build --no-default-features --features "json,sync"`

## Still open from #552

- `--from-pr` (priority 4)
- `plugin tag` subcommand (niche release tooling)
- `update` / `upgrade` subcommand
- `install` subcommand
- `--allow-dangerously-skip-permissions` (probably belongs on `DangerousClient` if at all)

Refs #552