### PR TITLE
feat: wrap remaining #552 items (from_pr, plugin tag, update, install)

### DIFF
--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -1,0 +1,98 @@
+//! `claude install` -- install a Claude Code native build.
+
+#[cfg(feature = "async")]
+use crate::Claude;
+use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
+use crate::error::Result;
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
+
+/// Run `claude install [target] [--force]`.
+///
+/// Installs a Claude Code native build. `target` accepts `"stable"`,
+/// `"latest"`, or a specific version; omit it to use the CLI's default.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(feature = "async")] {
+/// use claude_wrapper::{Claude, ClaudeCommand, InstallCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let out = InstallCommand::new()
+///     .target("stable")
+///     .force()
+///     .execute(&claude)
+///     .await?;
+/// println!("{}", out.stdout);
+/// # Ok(()) }
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct InstallCommand {
+    target: Option<String>,
+    force: bool,
+}
+
+impl InstallCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Target to install: `"stable"`, `"latest"`, or a specific version.
+    #[must_use]
+    pub fn target(mut self, target: impl Into<String>) -> Self {
+        self.target = Some(target.into());
+        self
+    }
+
+    /// Force installation even if already installed.
+    #[must_use]
+    pub fn force(mut self) -> Self {
+        self.force = true;
+        self
+    }
+}
+
+impl ClaudeCommand for InstallCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["install".to_string()];
+        if self.force {
+            args.push("--force".to_string());
+        }
+        if let Some(ref target) = self.target {
+            args.push(target.clone());
+        }
+        args
+    }
+
+    #[cfg(feature = "async")]
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_command_defaults() {
+        assert_eq!(ClaudeCommand::args(&InstallCommand::new()), vec!["install"]);
+    }
+
+    #[test]
+    fn install_command_with_target_and_force() {
+        let cmd = InstallCommand::new().target("latest").force();
+        assert_eq!(
+            ClaudeCommand::args(&cmd),
+            vec!["install", "--force", "latest"]
+        );
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -2,11 +2,13 @@ pub mod agents;
 pub mod auth;
 pub mod auto_mode;
 pub mod doctor;
+pub mod install;
 pub mod marketplace;
 pub mod mcp;
 pub mod plugin;
 pub mod query;
 pub mod raw;
+pub mod update;
 pub mod version;
 
 #[cfg(feature = "async")]

--- a/src/command/plugin.rs
+++ b/src/command/plugin.rs
@@ -353,6 +353,125 @@ impl ClaudeCommand for PluginValidateCommand {
     }
 }
 
+/// Create a `{name}--v{version}` git tag for a plugin release.
+///
+/// Runs `claude plugin tag [path]`, validating that the plugin's
+/// `plugin.json` and any enclosing marketplace entry agree on the
+/// version before tagging.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(feature = "async")] {
+/// use claude_wrapper::{Claude, ClaudeCommand, PluginTagCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let out = PluginTagCommand::new()
+///     .path("./my-plugin")
+///     .message("release %s")
+///     .push()
+///     .execute(&claude)
+///     .await?;
+/// println!("{}", out.stdout);
+/// # Ok(()) }
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct PluginTagCommand {
+    path: Option<String>,
+    dry_run: bool,
+    force: bool,
+    message: Option<String>,
+    push: bool,
+    remote: Option<String>,
+}
+
+impl PluginTagCommand {
+    /// Create a new tag command. Without [`path`](Self::path), the CLI
+    /// uses the current directory.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Path to the plugin directory.
+    #[must_use]
+    pub fn path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Print what would be tagged without creating anything.
+    #[must_use]
+    pub fn dry_run(mut self) -> Self {
+        self.dry_run = true;
+        self
+    }
+
+    /// Skip dirty-working-tree and tag-already-exists checks.
+    #[must_use]
+    pub fn force(mut self) -> Self {
+        self.force = true;
+        self
+    }
+
+    /// Tag annotation message; `%s` is substituted with the version.
+    #[must_use]
+    pub fn message(mut self, msg: impl Into<String>) -> Self {
+        self.message = Some(msg.into());
+        self
+    }
+
+    /// Push the tag after creating it.
+    #[must_use]
+    pub fn push(mut self) -> Self {
+        self.push = true;
+        self
+    }
+
+    /// Override the remote pushed to with [`push`](Self::push) (default `origin`).
+    #[must_use]
+    pub fn remote(mut self, remote: impl Into<String>) -> Self {
+        self.remote = Some(remote.into());
+        self
+    }
+}
+
+impl ClaudeCommand for PluginTagCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["plugin".to_string(), "tag".to_string()];
+        if self.dry_run {
+            args.push("--dry-run".to_string());
+        }
+        if self.force {
+            args.push("--force".to_string());
+        }
+        if let Some(ref msg) = self.message {
+            args.push("--message".to_string());
+            args.push(msg.clone());
+        }
+        if self.push {
+            args.push("--push".to_string());
+        }
+        if let Some(ref remote) = self.remote {
+            args.push("--remote".to_string());
+            args.push(remote.clone());
+        }
+        if let Some(ref path) = self.path {
+            args.push(path.clone());
+        }
+        args
+    }
+
+    #[cfg(feature = "async")]
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -427,6 +546,38 @@ mod tests {
         assert_eq!(
             ClaudeCommand::args(&cmd),
             vec!["plugin", "validate", "/path/to/manifest"]
+        );
+    }
+
+    #[test]
+    fn plugin_tag_defaults_to_just_subcommand() {
+        let cmd = PluginTagCommand::new();
+        assert_eq!(ClaudeCommand::args(&cmd), vec!["plugin", "tag"]);
+    }
+
+    #[test]
+    fn plugin_tag_with_all_options() {
+        let cmd = PluginTagCommand::new()
+            .path("./plugin")
+            .dry_run()
+            .force()
+            .message("release %s")
+            .push()
+            .remote("upstream");
+        assert_eq!(
+            ClaudeCommand::args(&cmd),
+            vec![
+                "plugin",
+                "tag",
+                "--dry-run",
+                "--force",
+                "--message",
+                "release %s",
+                "--push",
+                "--remote",
+                "upstream",
+                "./plugin",
+            ]
         );
     }
 }

--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -72,6 +72,7 @@ pub struct QueryCommand {
     include_hook_events: bool,
     exclude_dynamic_system_prompt_sections: bool,
     name: Option<String>,
+    from_pr: Option<String>,
 }
 
 impl QueryCommand {
@@ -122,6 +123,7 @@ impl QueryCommand {
             include_hook_events: false,
             exclude_dynamic_system_prompt_sections: false,
             name: None,
+            from_pr: None,
         }
     }
 
@@ -496,6 +498,18 @@ impl QueryCommand {
         self
     }
 
+    /// Resume a session linked to a PR by number or URL
+    /// (`--from-pr <value>`).
+    ///
+    /// This wrapper only supports the valued form; the CLI's
+    /// no-value mode opens an interactive picker and would hang a
+    /// headless caller.
+    #[must_use]
+    pub fn from_pr(mut self, pr: impl Into<String>) -> Self {
+        self.from_pr = Some(pr.into());
+        self
+    }
+
     /// Set a per-command retry policy, overriding the client default.
     ///
     /// # Example
@@ -803,6 +817,11 @@ impl QueryCommand {
             args.push(name.clone());
         }
 
+        if let Some(ref pr) = self.from_pr {
+            args.push("--from-pr".to_string());
+            args.push(pr.clone());
+        }
+
         // Separator to prevent flags like --allowed-tools from consuming the prompt.
         args.push("--".to_string());
         args.push(self.prompt.clone());
@@ -962,6 +981,13 @@ mod tests {
         let args = QueryCommand::new("hi").name("my session").args();
         let pos = args.iter().position(|a| a == "--name").unwrap();
         assert_eq!(args[pos + 1], "my session");
+    }
+
+    #[test]
+    fn from_pr_flag_renders_with_value() {
+        let args = QueryCommand::new("hi").from_pr("42").args();
+        let pos = args.iter().position(|a| a == "--from-pr").unwrap();
+        assert_eq!(args[pos + 1], "42");
     }
 
     #[test]

--- a/src/command/update.rs
+++ b/src/command/update.rs
@@ -1,0 +1,60 @@
+//! `claude update` -- check for CLI updates and install if available.
+
+#[cfg(feature = "async")]
+use crate::Claude;
+use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
+use crate::error::Result;
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
+
+/// Run `claude update` (alias `upgrade`).
+///
+/// Checks for updates and installs if available. Takes no options.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(feature = "async")] {
+/// use claude_wrapper::{Claude, ClaudeCommand, UpdateCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let out = UpdateCommand::new().execute(&claude).await?;
+/// println!("{}", out.stdout);
+/// # Ok(()) }
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct UpdateCommand;
+
+impl UpdateCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ClaudeCommand for UpdateCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["update".to_string()]
+    }
+
+    #[cfg(feature = "async")]
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_command_args() {
+        assert_eq!(ClaudeCommand::args(&UpdateCommand::new()), vec!["update"]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,6 +275,7 @@ pub use command::auto_mode::{
     AutoModeConfigCommand, AutoModeCritiqueCommand, AutoModeDefaultsCommand,
 };
 pub use command::doctor::DoctorCommand;
+pub use command::install::InstallCommand;
 pub use command::marketplace::{
     MarketplaceAddCommand, MarketplaceListCommand, MarketplaceRemoveCommand,
     MarketplaceUpdateCommand,
@@ -285,10 +286,11 @@ pub use command::mcp::{
 };
 pub use command::plugin::{
     PluginDisableCommand, PluginEnableCommand, PluginInstallCommand, PluginListCommand,
-    PluginUninstallCommand, PluginUpdateCommand, PluginValidateCommand,
+    PluginTagCommand, PluginUninstallCommand, PluginUpdateCommand, PluginValidateCommand,
 };
 pub use command::query::QueryCommand;
 pub use command::raw::RawCommand;
+pub use command::update::UpdateCommand;
 pub use command::version::VersionCommand;
 pub use error::{Error, Result};
 pub use exec::CommandOutput;


### PR DESCRIPTION
## Summary

Final slice of the CLI coverage audit in #552. Brings `claude-wrapper` to parity with the non-TUI surface of the `claude` CLI.

### New surface

| Builder / method | CLI equivalent | Notes |
|---|---|---|
| `QueryCommand::from_pr(value)` | `--from-pr <value>` | Only the valued form (PR number or URL). The no-value variant opens an interactive picker and is unsafe for headless callers. |
| `PluginTagCommand` | `claude plugin tag [path]` | Options: `--dry-run`, `--force`, `--message <msg>`, `--push`, `--remote <name>`. |
| `UpdateCommand` | `claude update` (alias `upgrade`) | No options. Self-update the CLI. |
| `InstallCommand` | `claude install [target] [--force]` | `target` can be `"stable"`, `"latest"`, or a specific version. |

All re-exported at the crate root.

### Deliberately not added: `--allow-dangerously-skip-permissions`

This flag enables the bypass-permissions mode as a runtime option without engaging it by default. Plain `QueryCommand` does not expose it on purpose -- `DangerousClient` (env-var gated) is the isolated entry point for any bypass-adjacent behaviour, and exposing `--allow-dangerously-skip-permissions` on every query would undo that type-level fencing. If someone needs it, it belongs on `DangerousClient` with the same acknowledgement pattern.

### Still out of scope

The TUI-adjacent flags (`--chrome`, `--ide`, `--remote-control-*`, `--replay-user-messages`, `--tmux`, `--verbose`, deprecated `--mcp-debug`) remain unwrapped per the original #552 analysis -- they only make sense in the interactive Claude Code session.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features "json,sync" -- -D warnings`
- [x] `cargo test --lib --all-features` (160 pass, 6 new)
- [x] `cargo test --doc --all-features` (55 pass, 3 new)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- [x] `cargo build` (default)
- [x] `cargo build --no-default-features --features "json,sync"`

Closes #552