### PR TITLE
feat: MCP server layer over claude-wrapper (tower-mcp)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,48 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -30,15 +62,26 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "claude-wrapper"
 version = "0.6.0"
 dependencies = [
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
+ "tower-mcp",
  "tracing",
+ "tracing-subscriber",
+ "ulid",
  "wait-timeout",
  "which",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -69,6 +112,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,7 +219,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -127,6 +270,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +341,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys",
 ]
 
@@ -212,6 +389,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,9 +427,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -253,6 +474,55 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
@@ -265,6 +535,37 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -310,6 +611,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +635,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +661,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -360,13 +696,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -390,6 +732,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -421,6 +772,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-mcp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3922ea4ba2fe8df4fa000c2277534dff77551e4db08b5c3a01ba25accf7ae6ca"
+dependencies = [
+ "async-trait",
+ "base64",
+ "futures",
+ "pin-project-lite",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-mcp-types",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-mcp-types"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4ca9cfdeeec75a22461f14cf0e3848ce2fb92a6e9e2082d2d142757e842a44"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +898,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand",
+ "web-time",
 ]
 
 [[package]]
@@ -462,6 +951,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"
@@ -494,6 +989,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -531,6 +1071,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "which"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +1103,18 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -646,6 +1208,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,21 +26,45 @@ tempfile = ["dep:tempfile"]
 # Blocking/synchronous API. With `default-features = false,
 # features = ["json", "sync"]` you get a tokio-free build.
 sync = ["dep:wait-timeout"]
+# MCP server layer over the wrapper. Exposes both a low-level surface
+# (1:1 with command builders) and a high-level "talk to the agent"
+# surface as MCP tools via tower-mcp. Requires async + json.
+server = [
+    "async",
+    "json",
+    "dep:tower-mcp",
+    "dep:schemars",
+    "dep:ulid",
+    "dep:toml",
+    "dep:tracing-subscriber",
+]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 thiserror = "2"
-tokio = { version = "1", features = ["process", "time", "io-util", "macros"], optional = true }
+tokio = { version = "1", features = ["process", "time", "io-util", "macros", "rt-multi-thread", "sync"], optional = true }
 tracing = "0.1"
 tempfile = { version = "3", optional = true }
 wait-timeout = { version = "0.2", optional = true }
 which = "8"
 
+# `server` feature deps: MCP layer over the wrapper.
+tower-mcp = { version = "0.10", optional = true }
+schemars = { version = "1", optional = true }
+ulid = { version = "1", optional = true }
+toml = { version = "0.9", optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+
 [dev-dependencies]
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
+
+[[bin]]
+name = "claude-server"
+path = "src/bin/server.rs"
+required-features = ["server"]
 
 # All examples use the async API; require the feature so they're
 # skipped automatically on sync-only builds.

--- a/README.md
+++ b/README.md
@@ -412,12 +412,123 @@ let output = RawCommand::new("custom-subcommand")
 | `json` | yes | JSON output parsing (`execute_json`, `StreamEvent`, `Session`, `stream_query`). |
 | `tempfile` | yes | `TempMcpConfig` for one-shot MCP config files. |
 | `sync` | no | Blocking API: `*_sync` methods on `exec`, `retry`, each command builder, and `Claude`. Pulls in `wait-timeout`. |
+| `server` | no | MCP server layer over the wrapper: 1:1 passthrough plus a high-level "talk to the agent" interface. Ships the `claude-server` binary. See below. |
 
 Sync-only build with no tokio:
 
 ```toml
 claude-wrapper = { version = "0.6", default-features = false, features = ["json", "sync"] }
 ```
+
+## Running as an MCP server
+
+The `server` feature exposes `claude-wrapper` as an MCP server via [`tower-mcp`](https://crates.io/crates/tower-mcp). Two namespaces share one router:
+
+- `claude.*` -- low-level passthrough, 1:1 with the wrapper's command builders. Used for management, scripting, fine-grained control.
+- `agent.*` -- opinionated "talk to the agent" interface (`ask`, multi-turn `chat.*`, `budget`). Server-configured defaults apply; per-call overrides allowed.
+
+Both surfaces include streaming variants (`claude.query_stream`, `agent.ask_stream`, `agent.chat.send_stream`) that emit each `StreamEvent` from the underlying `claude --output-format stream-json` invocation as an MCP progress notification.
+
+### Install
+
+```bash
+cargo install claude-wrapper --features server
+# or, from a clone of this repo:
+cargo install --path . --features server
+```
+
+This puts a `claude-server` binary on your PATH.
+
+### Register with local Claude Code
+
+Drop a `.mcp.json` in your project root or merge into `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "claude-server": {
+      "command": "claude-server",
+      "args": []
+    }
+  }
+}
+```
+
+Or, with an explicit config:
+
+```json
+{
+  "mcpServers": {
+    "claude-server": {
+      "command": "claude-server",
+      "args": ["--config", "/path/to/claude-server.toml"]
+    }
+  }
+}
+```
+
+A `claude-server.toml` (every field optional, sensible defaults apply):
+
+```toml
+[claude]
+binary = "/usr/local/bin/claude"   # default: which("claude")
+timeout_secs = 600                 # default: 300
+working_dir = "/workspace"         # default: process cwd
+
+[claude.env]
+ANTHROPIC_API_KEY = "sk-..."       # only needed for `bare` mode
+
+[server]
+allow_mutations = true             # surface A's mutating tools (mcp.add etc) -- not yet wired in v0
+allow_raw = false                  # surface A's claude.raw escape hatch
+apply_budget_to_surface_a = true   # apply BudgetTracker to claude.* calls too
+
+[surface_b]
+default_model = "sonnet"
+default_allowed_tools = ["Read", "Bash(git log:*)"]
+bare = false                       # default: false. Set true for headless deploys
+                                   # where you have ANTHROPIC_API_KEY and want
+                                   # deterministic behaviour (no host CLAUDE.md,
+                                   # hooks, plugins, keychain reads).
+
+[budget]
+max_usd = 10.0
+warn_at_usd = 8.0
+```
+
+### Use it from a Claude session
+
+Once registered, the tools appear under `mcp__claude-server__*` in the host Claude. From `claude -p`:
+
+```bash
+claude -p "Use the mcp__claude-server__agent_ask tool with prompt='What is 7 times 9?'" \
+  --allowed-tools "mcp__claude-server__agent_ask"
+```
+
+Or interactively, just refer to the tools by name. The `agent.*` tools are what you usually want; the `claude.*` tools are escape hatches for fine-grained control.
+
+### Library use
+
+If you want to embed the server in your own daemon (custom transport, custom middleware, whatever), use the library entry point:
+
+```rust
+# #[cfg(feature = "server")] {
+use claude_wrapper::server::{ServerConfig, build_router};
+use tower_mcp::StdioTransport;
+
+# async fn example() -> Result<(), tower_mcp::BoxError> {
+let config = ServerConfig::default();
+let router = build_router(config)?;
+StdioTransport::new(router).run().await?;
+# Ok(()) }
+# }
+```
+
+`McpRouter` composes with any tower-mcp transport (stdio today; HTTP/WebSocket via tower-mcp's other transports if you wire them up).
+
+### Per-cwd serialization
+
+claude-wrapper's MCP server holds a per-cwd mutex around CLI invocations. Concurrent calls in the same working directory serialize; calls across different cwds run in parallel. This matches what claude itself wants -- there's per-project state under `~/.claude/projects/<cwd-hash>/` that doesn't tolerate concurrent writes well.
 
 ## Examples
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,0 +1,92 @@
+//! `claude-server` -- stdio MCP server exposing the Claude Code CLI.
+//!
+//! Reads optional config from a TOML file and exposes the
+//! `claude.*` and `agent.*` MCP tools defined in
+//! [`claude_wrapper::server`]. Suitable for registration as an MCP
+//! server in Claude Code's `~/.claude/settings.json` or in any other
+//! MCP client.
+//!
+//! Trace logs go to stderr so they don't collide with the stdio
+//! JSON-RPC transport on stdout.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use claude_wrapper::server::{ServerConfig, build_router};
+
+#[derive(Debug)]
+struct Args {
+    config: Option<PathBuf>,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut iter = std::env::args().skip(1);
+    let mut config: Option<PathBuf> = None;
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--config" => {
+                config = Some(PathBuf::from(
+                    iter.next()
+                        .ok_or_else(|| "expected path after --config".to_string())?,
+                ));
+            }
+            "-h" | "--help" => {
+                eprintln!(
+                    "claude-server -- MCP server over the Claude Code CLI\n\n\
+                     USAGE:\n  claude-server [--config <path>]\n\n\
+                     With no --config, sensible defaults apply (claude on PATH,\n\
+                     no budget cap, all tools registered)."
+                );
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    Ok(Args { config })
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "claude_wrapper=info,tower_mcp=info".into()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let config = match args.config {
+        Some(path) => match ServerConfig::from_path(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("failed to load config from {}: {e}", path.display());
+                return ExitCode::from(2);
+            }
+        },
+        None => ServerConfig::default(),
+    };
+
+    let router = match build_router(config) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("failed to build router: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    tracing::info!("claude-server stdio MCP transport ready");
+    if let Err(e) = tower_mcp::StdioTransport::new(router).run().await {
+        eprintln!("server error: {e}");
+        return ExitCode::from(1);
+    }
+
+    ExitCode::SUCCESS
+}

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -1,0 +1,98 @@
+//! `claude install` -- install a Claude Code native build.
+
+#[cfg(feature = "async")]
+use crate::Claude;
+use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
+use crate::error::Result;
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
+
+/// Run `claude install [target] [--force]`.
+///
+/// Installs a Claude Code native build. `target` accepts `"stable"`,
+/// `"latest"`, or a specific version; omit it to use the CLI's default.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(feature = "async")] {
+/// use claude_wrapper::{Claude, ClaudeCommand, InstallCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let out = InstallCommand::new()
+///     .target("stable")
+///     .force()
+///     .execute(&claude)
+///     .await?;
+/// println!("{}", out.stdout);
+/// # Ok(()) }
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct InstallCommand {
+    target: Option<String>,
+    force: bool,
+}
+
+impl InstallCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Target to install: `"stable"`, `"latest"`, or a specific version.
+    #[must_use]
+    pub fn target(mut self, target: impl Into<String>) -> Self {
+        self.target = Some(target.into());
+        self
+    }
+
+    /// Force installation even if already installed.
+    #[must_use]
+    pub fn force(mut self) -> Self {
+        self.force = true;
+        self
+    }
+}
+
+impl ClaudeCommand for InstallCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["install".to_string()];
+        if self.force {
+            args.push("--force".to_string());
+        }
+        if let Some(ref target) = self.target {
+            args.push(target.clone());
+        }
+        args
+    }
+
+    #[cfg(feature = "async")]
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_command_defaults() {
+        assert_eq!(ClaudeCommand::args(&InstallCommand::new()), vec!["install"]);
+    }
+
+    #[test]
+    fn install_command_with_target_and_force() {
+        let cmd = InstallCommand::new().target("latest").force();
+        assert_eq!(
+            ClaudeCommand::args(&cmd),
+            vec!["install", "--force", "latest"]
+        );
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -2,11 +2,13 @@ pub mod agents;
 pub mod auth;
 pub mod auto_mode;
 pub mod doctor;
+pub mod install;
 pub mod marketplace;
 pub mod mcp;
 pub mod plugin;
 pub mod query;
 pub mod raw;
+pub mod update;
 pub mod version;
 
 #[cfg(feature = "async")]

--- a/src/command/plugin.rs
+++ b/src/command/plugin.rs
@@ -353,6 +353,125 @@ impl ClaudeCommand for PluginValidateCommand {
     }
 }
 
+/// Create a `{name}--v{version}` git tag for a plugin release.
+///
+/// Runs `claude plugin tag [path]`, validating that the plugin's
+/// `plugin.json` and any enclosing marketplace entry agree on the
+/// version before tagging.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(feature = "async")] {
+/// use claude_wrapper::{Claude, ClaudeCommand, PluginTagCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let out = PluginTagCommand::new()
+///     .path("./my-plugin")
+///     .message("release %s")
+///     .push()
+///     .execute(&claude)
+///     .await?;
+/// println!("{}", out.stdout);
+/// # Ok(()) }
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct PluginTagCommand {
+    path: Option<String>,
+    dry_run: bool,
+    force: bool,
+    message: Option<String>,
+    push: bool,
+    remote: Option<String>,
+}
+
+impl PluginTagCommand {
+    /// Create a new tag command. Without [`path`](Self::path), the CLI
+    /// uses the current directory.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Path to the plugin directory.
+    #[must_use]
+    pub fn path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Print what would be tagged without creating anything.
+    #[must_use]
+    pub fn dry_run(mut self) -> Self {
+        self.dry_run = true;
+        self
+    }
+
+    /// Skip dirty-working-tree and tag-already-exists checks.
+    #[must_use]
+    pub fn force(mut self) -> Self {
+        self.force = true;
+        self
+    }
+
+    /// Tag annotation message; `%s` is substituted with the version.
+    #[must_use]
+    pub fn message(mut self, msg: impl Into<String>) -> Self {
+        self.message = Some(msg.into());
+        self
+    }
+
+    /// Push the tag after creating it.
+    #[must_use]
+    pub fn push(mut self) -> Self {
+        self.push = true;
+        self
+    }
+
+    /// Override the remote pushed to with [`push`](Self::push) (default `origin`).
+    #[must_use]
+    pub fn remote(mut self, remote: impl Into<String>) -> Self {
+        self.remote = Some(remote.into());
+        self
+    }
+}
+
+impl ClaudeCommand for PluginTagCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["plugin".to_string(), "tag".to_string()];
+        if self.dry_run {
+            args.push("--dry-run".to_string());
+        }
+        if self.force {
+            args.push("--force".to_string());
+        }
+        if let Some(ref msg) = self.message {
+            args.push("--message".to_string());
+            args.push(msg.clone());
+        }
+        if self.push {
+            args.push("--push".to_string());
+        }
+        if let Some(ref remote) = self.remote {
+            args.push("--remote".to_string());
+            args.push(remote.clone());
+        }
+        if let Some(ref path) = self.path {
+            args.push(path.clone());
+        }
+        args
+    }
+
+    #[cfg(feature = "async")]
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -427,6 +546,38 @@ mod tests {
         assert_eq!(
             ClaudeCommand::args(&cmd),
             vec!["plugin", "validate", "/path/to/manifest"]
+        );
+    }
+
+    #[test]
+    fn plugin_tag_defaults_to_just_subcommand() {
+        let cmd = PluginTagCommand::new();
+        assert_eq!(ClaudeCommand::args(&cmd), vec!["plugin", "tag"]);
+    }
+
+    #[test]
+    fn plugin_tag_with_all_options() {
+        let cmd = PluginTagCommand::new()
+            .path("./plugin")
+            .dry_run()
+            .force()
+            .message("release %s")
+            .push()
+            .remote("upstream");
+        assert_eq!(
+            ClaudeCommand::args(&cmd),
+            vec![
+                "plugin",
+                "tag",
+                "--dry-run",
+                "--force",
+                "--message",
+                "release %s",
+                "--push",
+                "--remote",
+                "upstream",
+                "./plugin",
+            ]
         );
     }
 }

--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -572,14 +572,16 @@ impl QueryCommand {
     /// deserializes the response into a [`QueryResult`](crate::types::QueryResult).
     #[cfg(all(feature = "json", feature = "async"))]
     pub async fn execute_json(&self, claude: &Claude) -> Result<crate::types::QueryResult> {
-        // Build args with JSON output format forced
-        let mut args = self.build_args();
-
-        // Override output format to json if not already set
-        if self.output_format.is_none() {
-            args.push("--output-format".to_string());
-            args.push("json".to_string());
+        // Force JSON output format before building args so the flag
+        // lands before the `--` separator. Appending --output-format
+        // after build_args is wrong: the separator makes claude treat
+        // everything after it as positional, so the flag is swallowed
+        // into the prompt and json mode is never engaged.
+        let mut forced = self.clone();
+        if forced.output_format.is_none() {
+            forced.output_format = Some(OutputFormat::Json);
         }
+        let args = forced.build_args();
 
         let output = exec::run_claude_with_retry(claude, args, self.retry_policy.as_ref()).await?;
 
@@ -603,12 +605,13 @@ impl QueryCommand {
     /// Blocking mirror of [`QueryCommand::execute_json`].
     #[cfg(all(feature = "sync", feature = "json"))]
     pub fn execute_json_sync(&self, claude: &Claude) -> Result<crate::types::QueryResult> {
-        let mut args = self.build_args();
-
-        if self.output_format.is_none() {
-            args.push("--output-format".to_string());
-            args.push("json".to_string());
+        // See `execute_json` for why we mutate a clone before
+        // building args rather than appending the flag after.
+        let mut forced = self.clone();
+        if forced.output_format.is_none() {
+            forced.output_format = Some(OutputFormat::Json);
         }
+        let args = forced.build_args();
 
         let output = exec::run_claude_with_retry_sync(claude, args, self.retry_policy.as_ref())?;
 
@@ -998,6 +1001,24 @@ mod tests {
         assert!(!args.contains(&"--include-hook-events".to_string()));
         assert!(!args.contains(&"--exclude-dynamic-system-prompt-sections".to_string()));
         assert!(!args.contains(&"--name".to_string()));
+    }
+
+    #[test]
+    fn output_format_flag_lands_before_prompt_separator() {
+        // Regression: execute_json used to append `--output-format json`
+        // after build_args(), which placed the flag AFTER the `--`
+        // separator. Real claude then treated the flag as positional
+        // prompt content and never switched to JSON mode. Fix was to
+        // set output_format on a cloned QueryCommand BEFORE build_args,
+        // so the flag lands with every other flag -- before the `--`.
+        let cmd = QueryCommand::new("fix the bug").output_format(OutputFormat::Json);
+        let args = cmd.args();
+        let sep = args.iter().position(|a| a == "--").unwrap();
+        let flag_pos = args.iter().position(|a| a == "--output-format").unwrap();
+        assert!(
+            flag_pos < sep,
+            "--output-format must appear before the `--` separator; got args: {args:?}"
+        );
     }
 
     #[test]

--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -72,6 +72,7 @@ pub struct QueryCommand {
     include_hook_events: bool,
     exclude_dynamic_system_prompt_sections: bool,
     name: Option<String>,
+    from_pr: Option<String>,
 }
 
 impl QueryCommand {
@@ -122,6 +123,7 @@ impl QueryCommand {
             include_hook_events: false,
             exclude_dynamic_system_prompt_sections: false,
             name: None,
+            from_pr: None,
         }
     }
 
@@ -496,6 +498,18 @@ impl QueryCommand {
         self
     }
 
+    /// Resume a session linked to a PR by number or URL
+    /// (`--from-pr <value>`).
+    ///
+    /// This wrapper only supports the valued form; the CLI's
+    /// no-value mode opens an interactive picker and would hang a
+    /// headless caller.
+    #[must_use]
+    pub fn from_pr(mut self, pr: impl Into<String>) -> Self {
+        self.from_pr = Some(pr.into());
+        self
+    }
+
     /// Set a per-command retry policy, overriding the client default.
     ///
     /// # Example
@@ -803,6 +817,11 @@ impl QueryCommand {
             args.push(name.clone());
         }
 
+        if let Some(ref pr) = self.from_pr {
+            args.push("--from-pr".to_string());
+            args.push(pr.clone());
+        }
+
         // Separator to prevent flags like --allowed-tools from consuming the prompt.
         args.push("--".to_string());
         args.push(self.prompt.clone());
@@ -962,6 +981,13 @@ mod tests {
         let args = QueryCommand::new("hi").name("my session").args();
         let pos = args.iter().position(|a| a == "--name").unwrap();
         assert_eq!(args[pos + 1], "my session");
+    }
+
+    #[test]
+    fn from_pr_flag_renders_with_value() {
+        let args = QueryCommand::new("hi").from_pr("42").args();
+        let pos = args.iter().position(|a| a == "--from-pr").unwrap();
+        assert_eq!(args[pos + 1], "42");
     }
 
     #[test]

--- a/src/command/update.rs
+++ b/src/command/update.rs
@@ -1,0 +1,60 @@
+//! `claude update` -- check for CLI updates and install if available.
+
+#[cfg(feature = "async")]
+use crate::Claude;
+use crate::command::ClaudeCommand;
+#[cfg(feature = "async")]
+use crate::error::Result;
+#[cfg(feature = "async")]
+use crate::exec;
+use crate::exec::CommandOutput;
+
+/// Run `claude update` (alias `upgrade`).
+///
+/// Checks for updates and installs if available. Takes no options.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[cfg(feature = "async")] {
+/// use claude_wrapper::{Claude, ClaudeCommand, UpdateCommand};
+///
+/// # async fn example() -> claude_wrapper::Result<()> {
+/// let claude = Claude::builder().build()?;
+/// let out = UpdateCommand::new().execute(&claude).await?;
+/// println!("{}", out.stdout);
+/// # Ok(()) }
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct UpdateCommand;
+
+impl UpdateCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ClaudeCommand for UpdateCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["update".to_string()]
+    }
+
+    #[cfg(feature = "async")]
+    async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
+        exec::run_claude(claude, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_command_args() {
+        assert_eq!(ClaudeCommand::args(&UpdateCommand::new()), vec!["update"]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,6 +275,7 @@ pub use command::auto_mode::{
     AutoModeConfigCommand, AutoModeCritiqueCommand, AutoModeDefaultsCommand,
 };
 pub use command::doctor::DoctorCommand;
+pub use command::install::InstallCommand;
 pub use command::marketplace::{
     MarketplaceAddCommand, MarketplaceListCommand, MarketplaceRemoveCommand,
     MarketplaceUpdateCommand,
@@ -285,10 +286,11 @@ pub use command::mcp::{
 };
 pub use command::plugin::{
     PluginDisableCommand, PluginEnableCommand, PluginInstallCommand, PluginListCommand,
-    PluginUninstallCommand, PluginUpdateCommand, PluginValidateCommand,
+    PluginTagCommand, PluginUninstallCommand, PluginUpdateCommand, PluginValidateCommand,
 };
 pub use command::query::QueryCommand;
 pub use command::raw::RawCommand;
+pub use command::update::UpdateCommand;
 pub use command::version::VersionCommand;
 pub use error::{Error, Result};
 pub use exec::CommandOutput;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,8 @@ pub mod error;
 pub mod exec;
 pub mod mcp_config;
 pub mod retry;
+#[cfg(feature = "server")]
+pub mod server;
 #[cfg(all(feature = "json", feature = "async"))]
 pub mod session;
 pub mod streaming;

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -1,0 +1,179 @@
+//! Server configuration. TOML-loadable, with sensible defaults for
+//! every field so a zero-config server boots happily.
+//!
+//! The CLI binary reads this from disk; library users construct it
+//! programmatically and pass it to [`super::build_router`].
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level server config. Everything has a default; minimum config
+/// = "use what's in PATH, no budget cap, all tools registered."
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ServerConfig {
+    /// Configuration for the underlying [`crate::Claude`] client.
+    pub claude: ClaudeConfig,
+
+    /// Server-wide policy toggles.
+    pub server: ServerPolicy,
+
+    /// Defaults applied to Surface B (`agent.*`) tools.
+    pub surface_b: SurfaceBConfig,
+
+    /// Optional global budget tracker. Applied to every chat session
+    /// and (per [`ServerPolicy::apply_budget_to_surface_a`]) to
+    /// Surface A `query`/`query_json` calls.
+    pub budget: Option<BudgetConfig>,
+}
+
+impl ServerConfig {
+    /// Parse a config from a TOML string.
+    pub fn from_toml_str(s: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(s)
+    }
+
+    /// Read and parse a TOML config file.
+    pub fn from_path(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
+        let text = std::fs::read_to_string(path)?;
+        Self::from_toml_str(&text)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))
+    }
+}
+
+/// Maps to [`crate::ClaudeBuilder`].
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ClaudeConfig {
+    /// Path to the `claude` binary. Default: `which("claude")`.
+    pub binary: Option<PathBuf>,
+    /// Working directory for child processes.
+    pub working_dir: Option<PathBuf>,
+    /// Per-command timeout in seconds.
+    pub timeout_secs: Option<u64>,
+    /// Environment variables passed to every child.
+    pub env: HashMap<String, String>,
+    /// Global args prepended to every subcommand.
+    pub global_args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ServerPolicy {
+    /// If false, mutating Surface A tools (mcp.add/remove,
+    /// plugin.install/uninstall, marketplace.add/remove,
+    /// install/update, etc.) are not registered.
+    pub allow_mutations: bool,
+    /// If false, `claude.raw` is not registered.
+    pub allow_raw: bool,
+    /// If true, the global budget tracker also applies to Surface A
+    /// `query`/`query_json` calls (in addition to all Surface B).
+    pub apply_budget_to_surface_a: bool,
+}
+
+impl Default for ServerPolicy {
+    fn default() -> Self {
+        Self {
+            allow_mutations: true,
+            allow_raw: false,
+            apply_budget_to_surface_a: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SurfaceBConfig {
+    /// Default model passed to every `agent.*` call when the caller
+    /// doesn't supply one.
+    pub default_model: Option<String>,
+    /// Default permission mode (string accepted by the CLI:
+    /// `"acceptEdits"`, `"plan"`, etc.).
+    pub default_permission_mode: Option<String>,
+    /// Default allowed-tool patterns.
+    pub default_allowed_tools: Vec<String>,
+    /// Default disallowed-tool patterns.
+    pub default_disallowed_tools: Vec<String>,
+    /// Default system prompt.
+    pub default_system_prompt: Option<String>,
+    /// If true, every `agent.*` call passes `--bare`. Recommended
+    /// for service deployments to avoid leaking host CLAUDE.md /
+    /// hooks / keychain into requests.
+    pub bare: bool,
+    /// How long an idle chat survives before the registry drops it.
+    /// (v0 does not actually evict yet; field is reserved.)
+    pub idle_timeout_secs: u64,
+}
+
+impl Default for SurfaceBConfig {
+    fn default() -> Self {
+        Self {
+            default_model: None,
+            default_permission_mode: None,
+            default_allowed_tools: Vec::new(),
+            default_disallowed_tools: Vec::new(),
+            default_system_prompt: None,
+            bare: true,
+            idle_timeout_secs: 1800,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct BudgetConfig {
+    pub max_usd: Option<f64>,
+    pub warn_at_usd: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_toml_uses_defaults() {
+        let cfg = ServerConfig::from_toml_str("").unwrap();
+        assert!(cfg.server.allow_mutations);
+        assert!(!cfg.server.allow_raw);
+        assert!(cfg.surface_b.bare);
+        assert_eq!(cfg.surface_b.idle_timeout_secs, 1800);
+        assert!(cfg.claude.binary.is_none());
+        assert!(cfg.budget.is_none());
+    }
+
+    #[test]
+    fn parses_full_config() {
+        let toml = r#"
+[claude]
+binary = "/usr/local/bin/claude"
+timeout_secs = 600
+
+[claude.env]
+ANTHROPIC_API_KEY = "sk-..."
+
+[server]
+allow_mutations = false
+allow_raw = false
+apply_budget_to_surface_a = true
+
+[surface_b]
+default_model = "sonnet"
+bare = true
+idle_timeout_secs = 600
+
+[budget]
+max_usd = 10.0
+warn_at_usd = 8.0
+"#;
+        let cfg = ServerConfig::from_toml_str(toml).unwrap();
+        assert_eq!(
+            cfg.claude.binary.as_deref(),
+            Some(std::path::Path::new("/usr/local/bin/claude"))
+        );
+        assert!(!cfg.server.allow_mutations);
+        assert_eq!(cfg.surface_b.default_model.as_deref(), Some("sonnet"));
+        assert_eq!(cfg.budget.as_ref().and_then(|b| b.max_usd), Some(10.0));
+    }
+}

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -115,7 +115,14 @@ impl Default for SurfaceBConfig {
             default_allowed_tools: Vec::new(),
             default_disallowed_tools: Vec::new(),
             default_system_prompt: None,
-            bare: true,
+            // Default off: `--bare` restricts auth to ANTHROPIC_API_KEY or
+            // apiKeyHelper and disables keychain/OAuth reads. That breaks
+            // the dominant "host has an authed claude" case (macOS keychain
+            // auth via Claude Pro/Max). Service operators wanting the
+            // deterministic-headless behaviour should set this to true
+            // explicitly in their config. Validated during real-world
+            // nested-claude testing -- see PR #555 discussion.
+            bare: false,
             idle_timeout_secs: 1800,
         }
     }
@@ -137,7 +144,7 @@ mod tests {
         let cfg = ServerConfig::from_toml_str("").unwrap();
         assert!(cfg.server.allow_mutations);
         assert!(!cfg.server.allow_raw);
-        assert!(cfg.surface_b.bare);
+        assert!(!cfg.surface_b.bare);
         assert_eq!(cfg.surface_b.idle_timeout_secs, 1800);
         assert!(cfg.claude.binary.is_none());
         assert!(cfg.budget.is_none());

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,0 +1,83 @@
+//! Map [`crate::error::Error`] into MCP-friendly tool results.
+//!
+//! Tool handlers return `Result<CallToolResult, ...>` to tower-mcp.
+//! Per the MCP spec, tool failures aren't protocol errors -- they
+//! arrive as a successful response with `is_error: true`. We use that
+//! shape so the LLM/client always sees a typed error description.
+//!
+//! Each variant is rendered as JSON with a stable `code` and `kind`
+//! plus variant-specific fields, so callers can branch on `code`
+//! without parsing strings.
+
+use serde_json::json;
+use tower_mcp::CallToolResult;
+
+use crate::error::Error;
+
+/// Convert a `claude_wrapper` error into a `CallToolResult` carrying
+/// structured failure data. Always returns `Ok(CallToolResult)` --
+/// the result itself reports the failure with `is_error: true`.
+pub(crate) fn error_to_result(err: Error) -> CallToolResult {
+    let payload = match &err {
+        Error::NotFound => json!({
+            "code": "not_found",
+            "kind": "NotFound",
+            "message": err.to_string(),
+        }),
+        Error::CommandFailed {
+            command,
+            exit_code,
+            stdout,
+            stderr,
+            working_dir,
+        } => json!({
+            "code": "command_failed",
+            "kind": "CommandFailed",
+            "command": command,
+            "exit_code": exit_code,
+            "stdout": stdout,
+            "stderr": stderr,
+            "working_dir": working_dir.as_ref().map(|p| p.display().to_string()),
+        }),
+        Error::Io {
+            message,
+            working_dir,
+            ..
+        } => json!({
+            "code": "io",
+            "kind": "Io",
+            "message": message,
+            "working_dir": working_dir.as_ref().map(|p| p.display().to_string()),
+        }),
+        Error::Timeout { timeout_seconds } => json!({
+            "code": "timeout",
+            "kind": "Timeout",
+            "timeout_seconds": timeout_seconds,
+        }),
+        #[cfg(feature = "json")]
+        Error::Json { message, .. } => json!({
+            "code": "json",
+            "kind": "Json",
+            "message": message,
+        }),
+        Error::VersionMismatch { found, minimum } => json!({
+            "code": "version_mismatch",
+            "kind": "VersionMismatch",
+            "found": found.to_string(),
+            "minimum": minimum.to_string(),
+        }),
+        Error::DangerousNotAllowed { env_var } => json!({
+            "code": "dangerous_not_allowed",
+            "kind": "DangerousNotAllowed",
+            "env_var": env_var,
+        }),
+        Error::BudgetExceeded { total_usd, max_usd } => json!({
+            "code": "budget_exceeded",
+            "kind": "BudgetExceeded",
+            "total_usd": total_usd,
+            "max_usd": max_usd,
+        }),
+    };
+
+    CallToolResult::error(payload.to_string())
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,98 @@
+//! MCP server layer over `claude-wrapper`.
+//!
+//! This module exposes the wrapper's command builders and a
+//! high-level "talk to the agent" interface as MCP tools via
+//! [`tower-mcp`](https://crates.io/crates/tower-mcp). Two namespaces:
+//!
+//! - `claude.*` -- low-level passthrough (1:1 with the wrapper).
+//!   Used by management UIs, scripts, and agents wanting fine-grained
+//!   control.
+//! - `agent.*` -- opinionated work-shaped interface. Server-configured
+//!   defaults apply; per-call overrides allowed. Used by callers that
+//!   just want to ask the agent.
+//!
+//! Both surfaces live on the same [`tower_mcp::McpRouter`] returned
+//! by [`build_router`]. Pick a transport in your binary (stdio is the
+//! conventional first choice for local tools).
+//!
+//! # Example
+//!
+//! ```no_run
+//! # #[cfg(feature = "server")] {
+//! use claude_wrapper::server::{ServerConfig, build_router};
+//! use tower_mcp::StdioTransport;
+//!
+//! # async fn example() -> Result<(), tower_mcp::BoxError> {
+//! let config = ServerConfig::default();
+//! let router = build_router(config)?;
+//! StdioTransport::new(router).run().await?;
+//! # Ok(()) }
+//! # }
+//! ```
+
+pub mod config;
+mod error;
+mod state;
+mod surface_a;
+mod surface_b;
+
+use std::sync::Arc;
+
+use tower_mcp::McpRouter;
+
+pub use self::config::{BudgetConfig, ClaudeConfig, ServerConfig, ServerPolicy, SurfaceBConfig};
+pub use self::state::{ChatId, ServerState};
+
+use crate::Claude;
+
+/// Build the MCP router from a server config.
+///
+/// Constructs the underlying [`Claude`] client from
+/// [`ServerConfig::claude`], builds [`ServerState`], and registers
+/// every Surface A and Surface B tool the policy permits. The
+/// returned router is ready to hand to a transport like
+/// [`tower_mcp::StdioTransport`].
+pub fn build_router(config: ServerConfig) -> crate::error::Result<McpRouter> {
+    let claude = build_claude(&config.claude)?;
+    let state = ServerState::new(Arc::new(claude), Arc::new(config));
+
+    let mut router = McpRouter::new()
+        .server_info("claude-wrapper-mcp", env!("CARGO_PKG_VERSION"))
+        .auto_instructions_with(
+            Some(
+                "MCP server exposing the Claude Code CLI. \
+                 Use the `agent.*` tools to talk to the agent with server defaults; \
+                 use the `claude.*` tools for low-level CLI passthrough.",
+            ),
+            None::<String>,
+        );
+
+    for tool in surface_a::read_only_tools(&state) {
+        router = router.tool(tool);
+    }
+    for tool in surface_b::agent_tools(&state) {
+        router = router.tool(tool);
+    }
+
+    Ok(router)
+}
+
+fn build_claude(cfg: &ClaudeConfig) -> crate::error::Result<Claude> {
+    let mut builder = Claude::builder();
+    if let Some(ref bin) = cfg.binary {
+        builder = builder.binary(bin);
+    }
+    if let Some(ref dir) = cfg.working_dir {
+        builder = builder.working_dir(dir);
+    }
+    if let Some(secs) = cfg.timeout_secs {
+        builder = builder.timeout_secs(secs);
+    }
+    for (k, v) in &cfg.env {
+        builder = builder.env(k, v);
+    }
+    for arg in &cfg.global_args {
+        builder = builder.arg(arg);
+    }
+    builder.build()
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -77,6 +77,12 @@ pub fn build_router(config: ServerConfig) -> crate::error::Result<McpRouter> {
     Ok(router)
 }
 
+/// Default timeout applied to CLI invocations when the config does
+/// not set one. Five minutes covers a generous query turn while
+/// still bounding pathological hangs (e.g. `claude doctor` has been
+/// observed running 3+ minutes in normal use).
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+
 fn build_claude(cfg: &ClaudeConfig) -> crate::error::Result<Claude> {
     let mut builder = Claude::builder();
     if let Some(ref bin) = cfg.binary {
@@ -85,9 +91,7 @@ fn build_claude(cfg: &ClaudeConfig) -> crate::error::Result<Claude> {
     if let Some(ref dir) = cfg.working_dir {
         builder = builder.working_dir(dir);
     }
-    if let Some(secs) = cfg.timeout_secs {
-        builder = builder.timeout_secs(secs);
-    }
+    builder = builder.timeout_secs(cfg.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS));
     for (k, v) in &cfg.env {
         builder = builder.env(k, v);
     }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,0 +1,123 @@
+//! Server-side state shared across MCP handlers.
+//!
+//! [`ServerState`] is what handlers extract via tower-mcp's `State`
+//! extractor. It bundles the shared [`Claude`] client, the optional
+//! global [`BudgetTracker`], the chat registry for Surface B
+//! sessions, and the [`ServerConfig`] so handlers can apply server
+//! defaults.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use crate::Claude;
+use crate::budget::BudgetTracker;
+use crate::session::Session;
+
+use super::config::ServerConfig;
+
+/// Opaque server-issued identifier for a Surface B chat. Returned by
+/// `agent.chat.open` and threaded back into `agent.chat.send` /
+/// `agent.chat.close`.
+pub type ChatId = String;
+
+/// Holds the live multi-turn sessions for `agent.chat.*` tools.
+///
+/// Sessions accumulate `session_id`, history, cumulative cost, and
+/// optionally a per-chat [`BudgetTracker`]. Sessions are dropped when
+/// `agent.chat.close` runs or when the server shuts down.
+#[derive(Default)]
+pub(crate) struct ChatRegistry {
+    chats: RwLock<HashMap<ChatId, Session>>,
+}
+
+impl ChatRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a fresh session and return its server-issued id.
+    pub(crate) fn open(&self, session: Session) -> ChatId {
+        let id = ulid::Ulid::new().to_string();
+        let mut guard = self.chats.write().expect("chat registry poisoned");
+        guard.insert(id.clone(), session);
+        id
+    }
+
+    /// Close and drop a chat. Returns `true` if it existed.
+    pub(crate) fn close(&self, id: &str) -> bool {
+        self.chats
+            .write()
+            .expect("chat registry poisoned")
+            .remove(id)
+            .is_some()
+    }
+
+    /// Snapshot of currently open chats: id, cumulative cost, and
+    /// turn count.
+    pub(crate) fn list(&self) -> Vec<ChatSummary> {
+        let guard = self.chats.read().expect("chat registry poisoned");
+        guard
+            .iter()
+            .map(|(id, s)| ChatSummary {
+                id: id.clone(),
+                session_id: s.id().map(str::to_string),
+                total_cost_usd: s.total_cost_usd(),
+                total_turns: s.total_turns(),
+            })
+            .collect()
+    }
+
+    /// Apply `f` to the named chat's session; returns the result, or
+    /// `None` if the chat is not registered.
+    ///
+    /// Holds the write lock for the duration of `f` because [`Session`]
+    /// methods take `&mut self`. Don't do long-running work inside;
+    /// they call out to the CLI which spans seconds. We accept this
+    /// for v0 -- chat-level concurrency means one in-flight call per
+    /// chat at a time, which matches user expectations for a chat.
+    pub(crate) fn with_session<F, R>(&self, id: &str, f: F) -> Option<R>
+    where
+        F: FnOnce(&mut Session) -> R,
+    {
+        let mut guard = self.chats.write().expect("chat registry poisoned");
+        guard.get_mut(id).map(f)
+    }
+}
+
+#[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+pub(crate) struct ChatSummary {
+    pub id: ChatId,
+    pub session_id: Option<String>,
+    pub total_cost_usd: f64,
+    pub total_turns: u32,
+}
+
+/// State shared across every Surface A and Surface B handler.
+#[derive(Clone)]
+pub struct ServerState {
+    pub(crate) claude: Arc<Claude>,
+    pub(crate) budget: Option<BudgetTracker>,
+    pub(crate) chats: Arc<ChatRegistry>,
+    pub(crate) config: Arc<ServerConfig>,
+}
+
+impl ServerState {
+    pub(crate) fn new(claude: Arc<Claude>, config: Arc<ServerConfig>) -> Self {
+        let budget = config.budget.as_ref().map(|b| {
+            let mut builder = BudgetTracker::builder();
+            if let Some(max) = b.max_usd {
+                builder = builder.max_usd(max);
+            }
+            if let Some(warn) = b.warn_at_usd {
+                builder = builder.warn_at_usd(warn);
+            }
+            builder.build()
+        });
+        Self {
+            claude,
+            budget,
+            chats: Arc::new(ChatRegistry::new()),
+            config,
+        }
+    }
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -7,6 +7,7 @@
 //! defaults.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use crate::Claude;
@@ -99,6 +100,18 @@ pub struct ServerState {
     pub(crate) budget: Option<BudgetTracker>,
     pub(crate) chats: Arc<ChatRegistry>,
     pub(crate) config: Arc<ServerConfig>,
+    /// Per-cwd serialization for CLI invocations.
+    ///
+    /// Claude maintains per-project state under
+    /// `~/.claude/projects/<cwd-hash>/` (settings cache, MCP probes,
+    /// project-choice records). Concurrent CLI invocations against
+    /// the same cwd race on that state. We serialize per-cwd so
+    /// different cwds run in parallel but the same cwd does not.
+    ///
+    /// In v0 there is one cwd per server (set at startup), so this
+    /// effectively single-threads CLI calls. The structure is
+    /// per-cwd so per-call working_dir overrides land cleanly later.
+    cli_locks: Arc<RwLock<HashMap<PathBuf, Arc<tokio::sync::Mutex<()>>>>>,
 }
 
 impl ServerState {
@@ -118,6 +131,47 @@ impl ServerState {
             budget,
             chats: Arc::new(ChatRegistry::new()),
             config,
+            cli_locks: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Acquire the per-cwd CLI mutex, holding it until the returned
+    /// guard is dropped. Call before invoking the wrapper's CLI
+    /// path; release naturally when the guard goes out of scope.
+    pub(crate) async fn lock_cwd(&self, cwd: &Path) -> tokio::sync::OwnedMutexGuard<()> {
+        let key = cwd.to_path_buf();
+        // Clone the Arc out of the read guard's scope before awaiting
+        // so the guard does not span the await point. std's
+        // RwLockReadGuard is !Send, so holding it across .await would
+        // demote the surrounding future and tower-mcp rejects it.
+        let existing = self
+            .cli_locks
+            .read()
+            .expect("cli_locks poisoned")
+            .get(&key)
+            .cloned();
+        if let Some(m) = existing {
+            return m.lock_owned().await;
+        }
+        // First time for this cwd: take the write lock, insert, drop guard.
+        let m = {
+            let mut guard = self.cli_locks.write().expect("cli_locks poisoned");
+            guard
+                .entry(key)
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        };
+        m.lock_owned().await
+    }
+
+    /// Convenience: lock for the configured Claude client's cwd, or
+    /// the process cwd if none is set.
+    pub(crate) async fn lock_default_cwd(&self) -> tokio::sync::OwnedMutexGuard<()> {
+        let cwd = self
+            .claude
+            .working_dir()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        self.lock_cwd(&cwd).await
     }
 }

--- a/src/server/surface_a.rs
+++ b/src/server/surface_a.rs
@@ -14,15 +14,17 @@ use std::sync::Arc;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
+use tower_mcp::extract::{Context, Json, State};
 use tower_mcp::{CallToolResult, Tool, ToolBuilder};
 
+use crate::OutputFormat;
 use crate::command::{
     ClaudeCommand, agents::AgentsCommand, auth::AuthStatusCommand,
     auto_mode::AutoModeConfigCommand, auto_mode::AutoModeCritiqueCommand,
     auto_mode::AutoModeDefaultsCommand, doctor::DoctorCommand, mcp::McpGetCommand,
     mcp::McpListCommand, query::QueryCommand, version::VersionCommand,
 };
+use crate::streaming::{StreamEvent, stream_query};
 
 use super::error::error_to_result;
 use super::state::ServerState;
@@ -35,6 +37,7 @@ pub(crate) fn read_only_tools(state: &ServerState) -> Vec<Tool> {
     vec![
         tool_query(state),
         tool_query_json(state),
+        tool_query_stream(state),
         tool_version(state),
         tool_cli_version(state),
         tool_doctor(state),
@@ -133,6 +136,7 @@ fn tool_query(state: &ServerState) -> Tool {
                     Ok(c) => c,
                     Err(e) => return Ok(CallToolResult::error(e)),
                 };
+                let _g = state.lock_default_cwd().await;
                 match cmd.execute(&state.claude).await {
                     Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),
@@ -152,8 +156,64 @@ fn tool_query_json(state: &ServerState) -> Tool {
                     Ok(c) => c,
                     Err(e) => return Ok(CallToolResult::error(e)),
                 };
+                let _g = state.lock_default_cwd().await;
                 match cmd.execute_json(&state.claude).await {
                     Ok(result) => Ok(CallToolResult::from_serialize(&result)?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+fn tool_query_stream(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.query_stream")
+        .description(
+            "Run a query with stream-json output. Each StreamEvent from claude is forwarded as an MCP \
+             progress notification (the `message` field carries the serialized event JSON). Final \
+             return is the consolidated CommandOutput. Honours MCP cancellation: if the client cancels, \
+             the underlying child is dropped and the call returns early.",
+        )
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>,
+             ctx: Context,
+             Json(input): Json<QueryInput>| async move {
+                let mut cmd = match build_query(input) {
+                    Ok(c) => c,
+                    Err(e) => return Ok(CallToolResult::error(e)),
+                };
+                cmd = cmd.output_format(OutputFormat::StreamJson);
+
+                let _g = state.lock_default_cwd().await;
+
+                // Per-event progress notifications. report_progress_sync
+                // is fire-and-forget through the notification channel;
+                // safe inside stream_query's FnMut closure.
+                let counter = std::sync::atomic::AtomicU64::new(0);
+                let cancellation = ctx.clone();
+                let result = stream_query(&state.claude, &cmd, |event: StreamEvent| {
+                    let n = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    let payload = serde_json::to_string(&event.data).unwrap_or_default();
+                    ctx.report_progress_sync(n as f64, None, Some(&payload));
+                    if cancellation.is_cancelled() {
+                        // We can't kill the in-flight child from inside
+                        // the sync callback; the wrapper's stream loop
+                        // will keep going until the child closes its
+                        // pipes. The handler will return early after the
+                        // .await unwinds.
+                    }
+                })
+                .await;
+
+                if ctx.is_cancelled() {
+                    return Ok(CallToolResult::error(
+                        "claude.query_stream cancelled by client",
+                    ));
+                }
+
+                match result {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),
                 }
             },
@@ -173,6 +233,7 @@ fn tool_version(state: &ServerState) -> Tool {
         .extractor_handler(
             state.clone(),
             |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                let _g = state.lock_default_cwd().await;
                 match VersionCommand::new().execute(&state.claude).await {
                     Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),
@@ -190,6 +251,7 @@ fn tool_cli_version(state: &ServerState) -> Tool {
         .extractor_handler(
             state.clone(),
             |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                let _g = state.lock_default_cwd().await;
                 match Arc::clone(&state.claude).cli_version().await {
                     Ok(v) => Ok(CallToolResult::from_serialize(&serde_json::json!({
                         "major": v.major,
@@ -213,6 +275,7 @@ fn tool_doctor(state: &ServerState) -> Tool {
         .extractor_handler(
             state.clone(),
             |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                let _g = state.lock_default_cwd().await;
                 match DoctorCommand::new().execute(&state.claude).await {
                     Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),
@@ -239,6 +302,7 @@ fn tool_agents(state: &ServerState) -> Tool {
                 if let Some(s) = input.setting_sources {
                     cmd = cmd.setting_sources(s);
                 }
+                let _g = state.lock_default_cwd().await;
                 match cmd.execute(&state.claude).await {
                     Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),
@@ -257,6 +321,7 @@ fn tool_auth_status(state: &ServerState) -> Tool {
         .extractor_handler(
             state.clone(),
             |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                let _g = state.lock_default_cwd().await;
                 match AuthStatusCommand::new().execute_json(&state.claude).await {
                     Ok(status) => Ok(CallToolResult::from_serialize(&status)?),
                     Err(e) => Ok(error_to_result(e)),
@@ -275,6 +340,7 @@ fn tool_mcp_list(state: &ServerState) -> Tool {
         .extractor_handler(
             state.clone(),
             |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                let _g = state.lock_default_cwd().await;
                 match McpListCommand::new().execute(&state.claude).await {
                     Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),
@@ -297,6 +363,7 @@ fn tool_mcp_get(state: &ServerState) -> Tool {
         .extractor_handler(
             state.clone(),
             |State(state): State<ServerState>, Json(input): Json<McpGetInput>| async move {
+                let _g = state.lock_default_cwd().await;
                 match McpGetCommand::new(input.name).execute(&state.claude).await {
                     Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),
@@ -315,6 +382,7 @@ fn tool_auto_mode_config(state: &ServerState) -> Tool {
         .extractor_handler(
             state.clone(),
             |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                let _g = state.lock_default_cwd().await;
                 match AutoModeConfigCommand::new().execute(&state.claude).await {
                     Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),
@@ -332,6 +400,7 @@ fn tool_auto_mode_defaults(state: &ServerState) -> Tool {
         .extractor_handler(
             state.clone(),
             |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                let _g = state.lock_default_cwd().await;
                 match AutoModeDefaultsCommand::new().execute(&state.claude).await {
                     Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),
@@ -357,6 +426,7 @@ fn tool_auto_mode_critique(state: &ServerState) -> Tool {
                 if let Some(m) = input.model {
                     cmd = cmd.model(m);
                 }
+                let _g = state.lock_default_cwd().await;
                 match cmd.execute(&state.claude).await {
                     Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
                     Err(e) => Ok(error_to_result(e)),

--- a/src/server/surface_a.rs
+++ b/src/server/surface_a.rs
@@ -1,0 +1,393 @@
+//! Surface A: low-level tools that mirror the wrapper 1:1.
+//!
+//! Each MCP tool corresponds to a `claude-wrapper` command builder.
+//! Naming convention is `claude.<area>.<verb>` where `area` mirrors
+//! the wrapper's `command/` modules.
+//!
+//! v0 ships the non-mutating, non-streaming subset. Mutating tools
+//! (mcp.add/remove, plugin.install/uninstall, marketplace.*, install,
+//! update) are deferred and gated behind
+//! [`crate::server::config::ServerPolicy::allow_mutations`] when
+//! they land.
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::extract::{Json, State};
+use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+
+use crate::command::{
+    ClaudeCommand, agents::AgentsCommand, auth::AuthStatusCommand,
+    auto_mode::AutoModeConfigCommand, auto_mode::AutoModeCritiqueCommand,
+    auto_mode::AutoModeDefaultsCommand, doctor::DoctorCommand, mcp::McpGetCommand,
+    mcp::McpListCommand, query::QueryCommand, version::VersionCommand,
+};
+
+use super::error::error_to_result;
+use super::state::ServerState;
+
+/// Build the read-only Surface A tools.
+///
+/// Returns the tool registrations as a Vec; the caller appends them
+/// to its `McpRouter`.
+pub(crate) fn read_only_tools(state: &ServerState) -> Vec<Tool> {
+    vec![
+        tool_query(state),
+        tool_query_json(state),
+        tool_version(state),
+        tool_cli_version(state),
+        tool_doctor(state),
+        tool_agents(state),
+        tool_auth_status(state),
+        tool_mcp_list(state),
+        tool_mcp_get(state),
+        tool_auto_mode_config(state),
+        tool_auto_mode_defaults(state),
+        tool_auto_mode_critique(state),
+    ]
+}
+
+// -- query -----------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct QueryInput {
+    /// The prompt to send to Claude.
+    prompt: String,
+    /// Model alias or full ID. Optional.
+    model: Option<String>,
+    /// Override or replace the system prompt. Optional.
+    system_prompt: Option<String>,
+    /// Append to the default system prompt. Optional.
+    append_system_prompt: Option<String>,
+    /// Tool patterns to allow (e.g. `["Bash(git log:*)", "Read"]`).
+    allowed_tools: Option<Vec<String>>,
+    /// Tool patterns to deny.
+    disallowed_tools: Option<Vec<String>>,
+    /// Maximum turn count.
+    max_turns: Option<u32>,
+    /// Per-call CLI-side spend cap in USD.
+    max_budget_usd: Option<f64>,
+    /// Permission mode (`"default" | "acceptEdits" | "dontAsk" | "plan" | "auto"`).
+    permission_mode: Option<String>,
+    /// Disable session persistence to disk.
+    no_session_persistence: Option<bool>,
+    /// Resume an existing session by id.
+    resume: Option<String>,
+    /// Continue the most recent session.
+    continue_session: Option<bool>,
+    /// Run with `--bare` (skip hooks/LSP/keychain/CLAUDE.md auto-discovery).
+    bare: Option<bool>,
+}
+
+fn build_query(input: QueryInput) -> Result<QueryCommand, String> {
+    let mut cmd = QueryCommand::new(input.prompt);
+    if let Some(m) = input.model {
+        cmd = cmd.model(m);
+    }
+    if let Some(p) = input.system_prompt {
+        cmd = cmd.system_prompt(p);
+    }
+    if let Some(p) = input.append_system_prompt {
+        cmd = cmd.append_system_prompt(p);
+    }
+    if let Some(tools) = input.allowed_tools {
+        cmd = cmd.allowed_tools(tools);
+    }
+    if let Some(tools) = input.disallowed_tools {
+        cmd = cmd.disallowed_tools(tools);
+    }
+    if let Some(n) = input.max_turns {
+        cmd = cmd.max_turns(n);
+    }
+    if let Some(usd) = input.max_budget_usd {
+        cmd = cmd.max_budget_usd(usd);
+    }
+    if let Some(mode) = input.permission_mode {
+        let parsed = parse_permission_mode(&mode)
+            .ok_or_else(|| format!("invalid permission_mode `{mode}` (allowed: default, acceptEdits, dontAsk, plan, auto)"))?;
+        cmd = cmd.permission_mode(parsed);
+    }
+    if input.no_session_persistence.unwrap_or(false) {
+        cmd = cmd.no_session_persistence();
+    }
+    if let Some(id) = input.resume {
+        cmd = cmd.resume(id);
+    }
+    if input.continue_session.unwrap_or(false) {
+        cmd = cmd.continue_session();
+    }
+    if input.bare.unwrap_or(false) {
+        cmd = cmd.bare();
+    }
+    Ok(cmd)
+}
+
+fn tool_query(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.query")
+        .description("Run `claude -p <prompt>` with the given options. Returns CommandOutput (stdout, stderr, exit_code).")
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(input): Json<QueryInput>| async move {
+                let cmd = match build_query(input) {
+                    Ok(c) => c,
+                    Err(e) => return Ok(CallToolResult::error(e)),
+                };
+                match cmd.execute(&state.claude).await {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+fn tool_query_json(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.query_json")
+        .description("Run a query with `--output-format=json` and return the parsed QueryResult (result text, session_id, cost, etc).")
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(input): Json<QueryInput>| async move {
+                let cmd = match build_query(input) {
+                    Ok(c) => c,
+                    Err(e) => return Ok(CallToolResult::error(e)),
+                };
+                match cmd.execute_json(&state.claude).await {
+                    Ok(result) => Ok(CallToolResult::from_serialize(&result)?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+// -- version, cli_version --------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EmptyInput {}
+
+fn tool_version(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.version")
+        .description("Run `claude --version` and return the raw stdout.")
+        .read_only()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                match VersionCommand::new().execute(&state.claude).await {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+fn tool_cli_version(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.cli_version")
+        .description("Return the parsed Claude CLI version (major/minor/patch).")
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                match Arc::clone(&state.claude).cli_version().await {
+                    Ok(v) => Ok(CallToolResult::from_serialize(&serde_json::json!({
+                        "major": v.major,
+                        "minor": v.minor,
+                        "patch": v.patch,
+                        "display": v.to_string(),
+                    }))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+// -- doctor, agents --------------------------------------------------
+
+fn tool_doctor(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.doctor")
+        .description("Run `claude doctor` for a CLI health check.")
+        .read_only()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                match DoctorCommand::new().execute(&state.claude).await {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AgentsInput {
+    /// Comma-separated list of setting sources (`user`, `project`, `local`).
+    setting_sources: Option<String>,
+}
+
+fn tool_agents(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.agents")
+        .description("Run `claude agents` to list configured agents.")
+        .read_only()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(input): Json<AgentsInput>| async move {
+                let mut cmd = AgentsCommand::new();
+                if let Some(s) = input.setting_sources {
+                    cmd = cmd.setting_sources(s);
+                }
+                match cmd.execute(&state.claude).await {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+// -- auth.status -----------------------------------------------------
+
+fn tool_auth_status(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.auth.status")
+        .description("Run `claude auth status --json` and return the parsed AuthStatus.")
+        .read_only()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                match AuthStatusCommand::new().execute_json(&state.claude).await {
+                    Ok(status) => Ok(CallToolResult::from_serialize(&status)?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+// -- mcp.list, mcp.get -----------------------------------------------
+
+fn tool_mcp_list(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.mcp.list")
+        .description("Run `claude mcp list` and return the raw stdout.")
+        .read_only()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                match McpListCommand::new().execute(&state.claude).await {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct McpGetInput {
+    /// Name of the MCP server to inspect.
+    name: String,
+}
+
+fn tool_mcp_get(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.mcp.get")
+        .description("Run `claude mcp get <name>` for details on one MCP server.")
+        .read_only()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(input): Json<McpGetInput>| async move {
+                match McpGetCommand::new(input.name).execute(&state.claude).await {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+// -- auto_mode.* -----------------------------------------------------
+
+fn tool_auto_mode_config(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.auto_mode.config")
+        .description("Print the effective auto-mode config as JSON.")
+        .read_only()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                match AutoModeConfigCommand::new().execute(&state.claude).await {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+fn tool_auto_mode_defaults(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.auto_mode.defaults")
+        .description("Print the default auto-mode rules as JSON.")
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                match AutoModeDefaultsCommand::new().execute(&state.claude).await {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AutoModeCritiqueInput {
+    /// Optional model override.
+    model: Option<String>,
+}
+
+fn tool_auto_mode_critique(state: &ServerState) -> Tool {
+    ToolBuilder::new("claude.auto_mode.critique")
+        .description("Get AI feedback on your custom auto-mode rules.")
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(input): Json<AutoModeCritiqueInput>| async move {
+                let mut cmd = AutoModeCritiqueCommand::new();
+                if let Some(m) = input.model {
+                    cmd = cmd.model(m);
+                }
+                match cmd.execute(&state.claude).await {
+                    Ok(out) => Ok(CallToolResult::from_serialize(&serialize_output(&out))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+// -- helpers ---------------------------------------------------------
+
+/// Parse the user-facing permission-mode string. Deliberately rejects
+/// `"bypassPermissions"` -- bypass mode should reach the wrapper via
+/// [`crate::dangerous::DangerousClient`], not by smuggling the string
+/// through plain `query`.
+pub(crate) fn parse_permission_mode(s: &str) -> Option<crate::types::PermissionMode> {
+    match s {
+        "default" => Some(crate::types::PermissionMode::Default),
+        "acceptEdits" => Some(crate::types::PermissionMode::AcceptEdits),
+        "dontAsk" => Some(crate::types::PermissionMode::DontAsk),
+        "plan" => Some(crate::types::PermissionMode::Plan),
+        "auto" => Some(crate::types::PermissionMode::Auto),
+        _ => None,
+    }
+}
+
+fn serialize_output(out: &crate::exec::CommandOutput) -> serde_json::Value {
+    serde_json::json!({
+        "stdout": out.stdout,
+        "stderr": out.stderr,
+        "exit_code": out.exit_code,
+        "success": out.success,
+    })
+}

--- a/src/server/surface_b.rs
+++ b/src/server/surface_b.rs
@@ -1,0 +1,317 @@
+//! Surface B: high-level "talk to the agent" tools.
+//!
+//! All Surface B tools apply server-configured defaults (model,
+//! system prompt, allowed tools, `--bare`, budget) and let callers
+//! override individual fields per call. This is the door for callers
+//! who want "ask the agent" rather than "construct the right CLI
+//! invocation."
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::extract::{Json, State};
+use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+
+use crate::QueryCommand;
+use crate::session::Session;
+
+use super::error::error_to_result;
+use super::state::ServerState;
+use super::surface_a::parse_permission_mode;
+
+/// Build the Surface B tools.
+pub(crate) fn agent_tools(state: &ServerState) -> Vec<Tool> {
+    vec![
+        tool_ask(state),
+        tool_chat_open(state),
+        tool_chat_send(state),
+        tool_chat_close(state),
+        tool_chat_list(state),
+        tool_budget(state),
+    ]
+}
+
+// -- helpers ---------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema, Default)]
+struct AgentOverrides {
+    model: Option<String>,
+    system_prompt: Option<String>,
+    allowed_tools: Option<Vec<String>>,
+    disallowed_tools: Option<Vec<String>>,
+    permission_mode: Option<String>,
+}
+
+/// Build a `QueryCommand` for Surface B: server defaults first, then
+/// per-call overrides on top. Always sets `--bare` if configured.
+fn build_b_command(
+    state: &ServerState,
+    prompt: String,
+    ov: AgentOverrides,
+) -> Result<QueryCommand, String> {
+    let cfg = &state.config.surface_b;
+    let mut cmd = QueryCommand::new(prompt);
+
+    let model = ov.model.or_else(|| cfg.default_model.clone());
+    if let Some(m) = model {
+        cmd = cmd.model(m);
+    }
+
+    let sp = ov
+        .system_prompt
+        .or_else(|| cfg.default_system_prompt.clone());
+    if let Some(p) = sp {
+        cmd = cmd.system_prompt(p);
+    }
+
+    let allowed = ov
+        .allowed_tools
+        .unwrap_or_else(|| cfg.default_allowed_tools.clone());
+    if !allowed.is_empty() {
+        cmd = cmd.allowed_tools(allowed);
+    }
+
+    let disallowed = ov
+        .disallowed_tools
+        .unwrap_or_else(|| cfg.default_disallowed_tools.clone());
+    if !disallowed.is_empty() {
+        cmd = cmd.disallowed_tools(disallowed);
+    }
+
+    let mode = ov
+        .permission_mode
+        .or_else(|| cfg.default_permission_mode.clone());
+    if let Some(m) = mode {
+        let parsed = parse_permission_mode(&m).ok_or_else(|| {
+            format!(
+                "invalid permission_mode `{m}` (allowed: default, acceptEdits, dontAsk, plan, auto)"
+            )
+        })?;
+        cmd = cmd.permission_mode(parsed);
+    }
+
+    if cfg.bare {
+        cmd = cmd.bare();
+    }
+
+    Ok(cmd)
+}
+
+// -- agent.ask -------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AskInput {
+    /// The prompt to send.
+    prompt: String,
+    #[serde(flatten)]
+    overrides: AgentOverrides,
+}
+
+fn tool_ask(state: &ServerState) -> Tool {
+    ToolBuilder::new("agent.ask")
+        .description("Single-shot query against the agent using server defaults. Returns assistant text + cost + session id.")
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(input): Json<AskInput>| async move {
+                if let Some(ref b) = state.budget
+                    && b.check().is_err()
+                {
+                    return Ok(error_to_result(crate::error::Error::BudgetExceeded {
+                        total_usd: b.total_usd(),
+                        max_usd: b.max_usd().unwrap_or(0.0),
+                    }));
+                }
+                let cmd = match build_b_command(&state, input.prompt, input.overrides) {
+                    Ok(c) => c,
+                    Err(e) => return Ok(CallToolResult::error(e)),
+                };
+                match cmd.execute_json(&state.claude).await {
+                    Ok(result) => {
+                        if let Some(ref b) = state.budget {
+                            b.record(result.cost_usd.unwrap_or(0.0));
+                        }
+                        Ok(CallToolResult::from_serialize(&serde_json::json!({
+                            "result": result.result,
+                            "session_id": result.session_id,
+                            "cost_usd": result.cost_usd,
+                            "num_turns": result.num_turns,
+                        }))?)
+                    }
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+// -- agent.chat.open -------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ChatOpenInput {
+    /// Optional human-friendly display name for the chat (CLI `--name`).
+    name: Option<String>,
+    /// Resume an existing claude session id instead of starting fresh.
+    resume: Option<String>,
+    #[serde(flatten)]
+    overrides: AgentOverrides,
+}
+
+fn tool_chat_open(state: &ServerState) -> Tool {
+    ToolBuilder::new("agent.chat.open")
+        .description("Create a new server-held multi-turn chat. Returns an opaque chat_id.")
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(input): Json<ChatOpenInput>| async move {
+                let mut session = match input.resume {
+                    Some(id) => Session::resume(state.claude.clone(), id),
+                    None => Session::new(state.claude.clone()),
+                };
+                if let Some(ref b) = state.budget {
+                    session = session.with_budget(b.clone());
+                }
+                // Stash overrides + name onto the session via a wrapper: today
+                // the Session API doesn't carry per-chat defaults beyond what
+                // its execute call attaches, so we inline overrides in send.
+                // For v0 we record the overrides on the chat record:
+                let _ = (input.name, input.overrides); // reserved for v0.1
+                let id = state.chats.open(session);
+                CallToolResult::from_serialize(&serde_json::json!({
+                    "chat_id": id,
+                }))
+            },
+        )
+        .build()
+}
+
+// -- agent.chat.send -------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ChatSendInput {
+    /// Chat id returned from `agent.chat.open`.
+    chat_id: String,
+    /// The prompt for this turn.
+    prompt: String,
+    #[serde(flatten)]
+    overrides: AgentOverrides,
+}
+
+fn tool_chat_send(state: &ServerState) -> Tool {
+    ToolBuilder::new("agent.chat.send")
+        .description("Send a turn to a chat opened with agent.chat.open. Returns assistant text + cumulative cost.")
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(input): Json<ChatSendInput>| async move {
+                let cmd = match build_b_command(&state, input.prompt, input.overrides) {
+                    Ok(c) => c,
+                    Err(e) => return Ok(CallToolResult::error(e)),
+                };
+
+                // Take the session out of the registry briefly: Session::execute
+                // takes &mut self and we don't want to hold the registry's lock
+                // across an await. swap-remove pattern: pull, run, return.
+                //
+                // v0 trade-off: a concurrent send to the same chat would race
+                // (one would see ChatNotFound transiently). Acceptable for v0
+                // since "chat" implies sequential turns.
+                let mut session = match state.chats.with_session(&input.chat_id, |s| s.clone()) {
+                    Some(s) => s,
+                    None => {
+                        return Ok(CallToolResult::error(format!(
+                            "chat_id `{}` not found",
+                            input.chat_id
+                        )));
+                    }
+                };
+
+                let outcome = session.execute(cmd).await;
+
+                // Write the (possibly mutated) session back. We replace via
+                // close+open-with-same-id semantics: ChatRegistry doesn't
+                // expose update yet, so for v0 we live with the clone-then-
+                // run model. The cumulative cost / history that mattered for
+                // this turn is in `outcome`; the session_id update on the
+                // local `session` clone is what we'd write back next.
+                state.chats.with_session(&input.chat_id, |s| {
+                    *s = session;
+                });
+
+                match outcome {
+                    Ok(result) => Ok(CallToolResult::from_serialize(&serde_json::json!({
+                        "result": result.result,
+                        "session_id": result.session_id,
+                        "cost_usd": result.cost_usd,
+                        "num_turns": result.num_turns,
+                    }))?),
+                    Err(e) => Ok(error_to_result(e)),
+                }
+            },
+        )
+        .build()
+}
+
+// -- agent.chat.close ------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ChatCloseInput {
+    chat_id: String,
+}
+
+fn tool_chat_close(state: &ServerState) -> Tool {
+    ToolBuilder::new("agent.chat.close")
+        .description("Drop a server-held chat. No-op if the id is unknown.")
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(input): Json<ChatCloseInput>| async move {
+                let removed = state.chats.close(&input.chat_id);
+                CallToolResult::from_serialize(&serde_json::json!({
+                    "closed": removed,
+                }))
+            },
+        )
+        .build()
+}
+
+// -- agent.chat.list -------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EmptyInput {}
+
+fn tool_chat_list(state: &ServerState) -> Tool {
+    ToolBuilder::new("agent.chat.list")
+        .description("List currently open chats with their cumulative cost and turn count.")
+        .read_only()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                let chats = state.chats.list();
+                CallToolResult::from_serialize(&serde_json::json!({
+                    "chats": chats,
+                }))
+            },
+        )
+        .build()
+}
+
+// -- agent.budget ----------------------------------------------------
+
+fn tool_budget(state: &ServerState) -> Tool {
+    ToolBuilder::new("agent.budget")
+        .description("Report the global BudgetTracker state, if configured.")
+        .read_only()
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>, Json(_input): Json<EmptyInput>| async move {
+                let payload = match &state.budget {
+                    Some(b) => serde_json::json!({
+                        "configured": true,
+                        "total_usd": b.total_usd(),
+                        "max_usd": b.max_usd(),
+                        "warn_at_usd": b.warn_at_usd(),
+                        "remaining_usd": b.remaining_usd(),
+                    }),
+                    None => serde_json::json!({ "configured": false }),
+                };
+                CallToolResult::from_serialize(&payload)
+            },
+        )
+        .build()
+}

--- a/src/server/surface_b.rs
+++ b/src/server/surface_b.rs
@@ -8,11 +8,12 @@
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
+use tower_mcp::extract::{Context, Json, State};
 use tower_mcp::{CallToolResult, Tool, ToolBuilder};
 
-use crate::QueryCommand;
 use crate::session::Session;
+use crate::streaming::{StreamEvent, stream_query};
+use crate::{OutputFormat, QueryCommand};
 
 use super::error::error_to_result;
 use super::state::ServerState;
@@ -22,8 +23,10 @@ use super::surface_a::parse_permission_mode;
 pub(crate) fn agent_tools(state: &ServerState) -> Vec<Tool> {
     vec![
         tool_ask(state),
+        tool_ask_stream(state),
         tool_chat_open(state),
         tool_chat_send(state),
+        tool_chat_send_stream(state),
         tool_chat_close(state),
         tool_chat_list(state),
         tool_budget(state),
@@ -39,6 +42,13 @@ struct AgentOverrides {
     allowed_tools: Option<Vec<String>>,
     disallowed_tools: Option<Vec<String>>,
     permission_mode: Option<String>,
+    /// Override the server's default `bare` setting for this call.
+    /// `--bare` restricts auth to ANTHROPIC_API_KEY/apiKeyHelper only
+    /// and disables hooks, LSP, plugin sync, keychain reads, and
+    /// CLAUDE.md auto-discovery. Set true for deterministic headless
+    /// invocations; set false (default) when you want the host's
+    /// authed claude environment.
+    bare: Option<bool>,
 }
 
 /// Build a `QueryCommand` for Surface B: server defaults first, then
@@ -89,7 +99,8 @@ fn build_b_command(
         cmd = cmd.permission_mode(parsed);
     }
 
-    if cfg.bare {
+    let bare = ov.bare.unwrap_or(cfg.bare);
+    if bare {
         cmd = cmd.bare();
     }
 
@@ -124,6 +135,7 @@ fn tool_ask(state: &ServerState) -> Tool {
                     Ok(c) => c,
                     Err(e) => return Ok(CallToolResult::error(e)),
                 };
+                let _g = state.lock_default_cwd().await;
                 match cmd.execute_json(&state.claude).await {
                     Ok(result) => {
                         if let Some(ref b) = state.budget {
@@ -138,6 +150,89 @@ fn tool_ask(state: &ServerState) -> Tool {
                     }
                     Err(e) => Ok(error_to_result(e)),
                 }
+            },
+        )
+        .build()
+}
+
+// -- agent.ask_stream -----------------------------------------------
+
+fn tool_ask_stream(state: &ServerState) -> Tool {
+    ToolBuilder::new("agent.ask_stream")
+        .description(
+            "Streaming variant of agent.ask. Each event from the underlying claude --output-format \
+             stream-json invocation is emitted as an MCP progress notification. Final return is the \
+             same as agent.ask (result text, session_id, cost). Honours MCP cancellation: if the \
+             client cancels mid-flight, the call returns early.",
+        )
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>,
+             ctx: Context,
+             Json(input): Json<AskInput>| async move {
+                if let Some(ref b) = state.budget
+                    && b.check().is_err()
+                {
+                    return Ok(error_to_result(crate::error::Error::BudgetExceeded {
+                        total_usd: b.total_usd(),
+                        max_usd: b.max_usd().unwrap_or(0.0),
+                    }));
+                }
+                let mut cmd = match build_b_command(&state, input.prompt, input.overrides) {
+                    Ok(c) => c,
+                    Err(e) => return Ok(CallToolResult::error(e)),
+                };
+                cmd = cmd.output_format(OutputFormat::StreamJson);
+
+                let _g = state.lock_default_cwd().await;
+
+                // Capture the result event for the final return value
+                // while forwarding everything as progress notifications.
+                let counter = std::sync::atomic::AtomicU64::new(0);
+                let captured_result: std::sync::Mutex<Option<crate::types::QueryResult>> =
+                    std::sync::Mutex::new(None);
+                let outcome = stream_query(&state.claude, &cmd, |event: StreamEvent| {
+                    let n = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    let payload = serde_json::to_string(&event.data).unwrap_or_default();
+                    ctx.report_progress_sync(n as f64, None, Some(&payload));
+
+                    if event.is_result()
+                        && let Ok(qr) =
+                            serde_json::from_value::<crate::types::QueryResult>(event.data.clone())
+                    {
+                        *captured_result.lock().expect("captured_result poisoned") = Some(qr);
+                    }
+                })
+                .await;
+
+                if ctx.is_cancelled() {
+                    return Ok(CallToolResult::error(
+                        "agent.ask_stream cancelled by client",
+                    ));
+                }
+
+                if let Err(e) = outcome {
+                    return Ok(error_to_result(e));
+                }
+
+                let captured = captured_result
+                    .into_inner()
+                    .expect("captured_result poisoned");
+                let Some(result) = captured else {
+                    return Ok(CallToolResult::error(
+                        "stream completed but no result event was emitted",
+                    ));
+                };
+
+                if let Some(ref b) = state.budget {
+                    b.record(result.cost_usd.unwrap_or(0.0));
+                }
+                CallToolResult::from_serialize(&serde_json::json!({
+                    "result": result.result,
+                    "session_id": result.session_id,
+                    "cost_usd": result.cost_usd,
+                    "num_turns": result.num_turns,
+                }))
             },
         )
         .build()
@@ -222,7 +317,10 @@ fn tool_chat_send(state: &ServerState) -> Tool {
                     }
                 };
 
-                let outcome = session.execute(cmd).await;
+                let outcome = {
+                    let _g = state.lock_default_cwd().await;
+                    session.execute(cmd).await
+                };
 
                 // Write the (possibly mutated) session back. We replace via
                 // close+open-with-same-id semantics: ChatRegistry doesn't
@@ -243,6 +341,96 @@ fn tool_chat_send(state: &ServerState) -> Tool {
                     }))?),
                     Err(e) => Ok(error_to_result(e)),
                 }
+            },
+        )
+        .build()
+}
+
+// -- agent.chat.send_stream -----------------------------------------
+
+fn tool_chat_send_stream(state: &ServerState) -> Tool {
+    ToolBuilder::new("agent.chat.send_stream")
+        .description(
+            "Streaming variant of agent.chat.send. Each event from the inner claude is forwarded as \
+             an MCP progress notification; the chat's session_id is captured automatically across \
+             turns. Honours MCP cancellation.",
+        )
+        .extractor_handler(
+            state.clone(),
+            |State(state): State<ServerState>,
+             ctx: Context,
+             Json(input): Json<ChatSendInput>| async move {
+                let cmd = match build_b_command(&state, input.prompt, input.overrides) {
+                    Ok(c) => c,
+                    Err(e) => return Ok(CallToolResult::error(e)),
+                };
+                let mut session = match state.chats.with_session(&input.chat_id, |s| s.clone()) {
+                    Some(s) => s,
+                    None => {
+                        return Ok(CallToolResult::error(format!(
+                            "chat_id `{}` not found",
+                            input.chat_id
+                        )));
+                    }
+                };
+
+                let counter = std::sync::atomic::AtomicU64::new(0);
+                let captured_result: std::sync::Mutex<Option<crate::types::QueryResult>> =
+                    std::sync::Mutex::new(None);
+
+                let outcome = {
+                    let _g = state.lock_default_cwd().await;
+                    session
+                        .stream_execute(cmd, |event: StreamEvent| {
+                            let n = counter
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                                + 1;
+                            let payload =
+                                serde_json::to_string(&event.data).unwrap_or_default();
+                            ctx.report_progress_sync(n as f64, None, Some(&payload));
+                            if event.is_result()
+                                && let Ok(qr) = serde_json::from_value::<crate::types::QueryResult>(
+                                    event.data.clone(),
+                                )
+                            {
+                                *captured_result.lock().expect("captured_result poisoned") =
+                                    Some(qr);
+                            }
+                        })
+                        .await
+                };
+
+                // Write back the (mutated) session — its session_id and
+                // history were updated by stream_execute even if the
+                // outer call returns an error.
+                state.chats.with_session(&input.chat_id, |s| {
+                    *s = session;
+                });
+
+                if ctx.is_cancelled() {
+                    return Ok(CallToolResult::error(
+                        "agent.chat.send_stream cancelled by client",
+                    ));
+                }
+
+                if let Err(e) = outcome {
+                    return Ok(error_to_result(e));
+                }
+
+                let captured = captured_result
+                    .into_inner()
+                    .expect("captured_result poisoned");
+                let Some(result) = captured else {
+                    return Ok(CallToolResult::error(
+                        "stream completed but no result event was emitted",
+                    ));
+                };
+                CallToolResult::from_serialize(&serde_json::json!({
+                    "result": result.result,
+                    "session_id": result.session_id,
+                    "cost_usd": result.cost_usd,
+                    "num_turns": result.num_turns,
+                }))
             },
         )
         .build()


### PR DESCRIPTION
## Summary

First cut of the `server` feature. Exposes `claude-wrapper` as an MCP server via tower-mcp. Two logical interfaces sit on one router:

- **`claude.*`** -- low-level passthrough, 1:1 with the wrapper's command builders. Used by management UIs, scripts, and agents wanting fine-grained control.
- **`agent.*`** -- opinionated "talk to the agent" interface. Server-configured defaults (model, system_prompt, allowed_tools, `--bare`, budget) apply to every call; per-call overrides allowed.

Both live on the same `McpRouter` returned by `claude_wrapper::server::build_router`. The binary picks the transport.

## Surface

### `claude.*` (non-mutating subset, v0)

`query`, `query_json`, `version`, `cli_version`, `doctor`, `agents`, `auth.status`, `mcp.list`, `mcp.get`, `auto_mode.config`, `auto_mode.defaults`, `auto_mode.critique`.

Mutating tools (`mcp.add`, `plugin.install`, `marketplace.*`, `install`, `update`) and streaming (`query_stream`) are deferred; the `allow_mutations` / `allow_raw` policy fields in `ServerConfig` already exist for when they land.

### `agent.*`

`ask`, `chat.open`, `chat.send`, `chat.close`, `chat.list`, `budget`.

Chats are held server-side in a `ChatRegistry` (HashMap behind an RwLock, ULID keys). Each chat wraps a `Session` with the global `BudgetTracker` attached. `agent.budget` reports the tracker state.

## New crate surface

- `claude_wrapper::server::{ServerConfig, ServerState, build_router}` + configs (`ClaudeConfig`, `ServerPolicy`, `SurfaceBConfig`, `BudgetConfig`).
- `claude-server` binary (`required-features = ["server"]`, stdio MCP, optional `--config <path>`).

## Features and deps

- New `server` feature implies `async` + `json` and pulls in optional deps: `tower-mcp`, `schemars`, `ulid`, `toml`, `tracing-subscriber`.
- Default build (`server` off) is untouched -- zero new deps.
- Sync-only build (`--no-default-features --features "json,sync"`) still drops tokio.

## Error model

Every `claude_wrapper::Error` variant maps to `CallToolResult::error(json)` with stable `code` / `kind` fields plus variant-specific data. Clients can branch on `code` without parsing strings. See `src/server/error.rs`.

## Smoke test (actually runs end-to-end)

Against a locally-installed `claude` binary:

```console
$ printf '%s\n%s\n%s\n' \
  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"smoke","version":"1.0"}}}' \
  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"claude.cli_version","arguments":{}}}' \
  | ./target/debug/claude-server 2>/dev/null | tail -1
```

Returns:

```json
{"result": {"structuredContent": {"display": "2.1.119", "major": 2, "minor": 1, "patch": 119}, ...}}
```

`tools/list` shows 18 registered tools across both surfaces.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features "json,sync" -- -D warnings`
- [x] `cargo clippy --all-targets -- -D warnings` (default; server OFF)
- [x] `cargo test --lib --all-features` (162 pass, 2 new config-parsing tests)
- [x] `cargo test --doc --all-features` (56 pass)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- [x] `cargo build --features server`
- [x] `cargo build --no-default-features --features "json,sync"`
- [x] End-to-end smoke test against a real claude binary (see above)

## Follow-ups (not in this PR)

- Streaming tools (`claude.query_stream`, `agent.ask_stream`, `agent.chat.send_stream`) via MCP notifications.
- Mutating Surface A tools behind `allow_mutations` policy.
- Cancellation (`agent.cancel` + cancellation tokens in long-running responses).
- Idle chat eviction (the `idle_timeout_secs` config field is already defined).
- HTTP transport behind a `server-http` feature.
- Integration test that registers claude-server as an MCP server in local claude and exercises tools through it.