### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.7.0...v0.8.0) - 2026-04-29
+
+### Added
+
+- add Xhigh variant to Effort enum ([#559](https://github.com/joshrotenberg/claude-wrapper/pull/559))
+
+### Other
+
+- bump tokio from 1.51.0 to 1.52.1 in the tokio-ecosystem group ([#558](https://github.com/joshrotenberg/claude-wrapper/pull/558))
+- update changelog ([#556](https://github.com/joshrotenberg/claude-wrapper/pull/556))
+
 ## [0.7.0] - 2026-04-24
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Effort::Max 3 -> 4 in /tmp/.tmpsjtckJ/claude-wrapper/src/types.rs:194
  variant Effort::Max 3 -> 4 in /tmp/.tmpsjtckJ/claude-wrapper/src/types.rs:194

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Effort:Xhigh in /tmp/.tmpsjtckJ/claude-wrapper/src/types.rs:192
  variant Effort:Xhigh in /tmp/.tmpsjtckJ/claude-wrapper/src/types.rs:192
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.7.0...v0.8.0) - 2026-04-29

### Added

- add Xhigh variant to Effort enum ([#559](https://github.com/joshrotenberg/claude-wrapper/pull/559))

### Other

- bump tokio from 1.51.0 to 1.52.1 in the tokio-ecosystem group ([#558](https://github.com/joshrotenberg/claude-wrapper/pull/558))
- update changelog ([#556](https://github.com/joshrotenberg/claude-wrapper/pull/556))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).