### PR TITLE
feat: add Xhigh variant to Effort enum

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -188,6 +188,8 @@ pub enum Effort {
     Medium,
     /// High effort.
     High,
+    /// Extra-high effort.
+    Xhigh,
     /// Maximum effort, most thorough.
     Max,
 }
@@ -198,6 +200,7 @@ impl Effort {
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
+            Self::Xhigh => "xhigh",
             Self::Max => "max",
         }
     }


### PR DESCRIPTION
Latest version of `claude` now has a `xhigh` effort option:

```
$ claude --help | grep effort
  --effort <level>                                  Effort level for the current session (low, medium, high, xhigh, max)
```
