### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.8.0...v0.9.0) - 2026-05-08
+
+### Added
+
+- *(examples)* add minimal HTTP claude-as-a-service example ([#576](https://github.com/joshrotenberg/claude-wrapper/pull/576))
+- add health/watchdog primitives to DuplexSession ([#575](https://github.com/joshrotenberg/claude-wrapper/pull/575))
+- add Conversation wrapper for DuplexSession bookkeeping ([#574](https://github.com/joshrotenberg/claude-wrapper/pull/574))
+- add DuplexSession::interrupt for clean mid-turn cancel ([#566](https://github.com/joshrotenberg/claude-wrapper/pull/566))
+- add mid-turn permission handling to DuplexSession ([#565](https://github.com/joshrotenberg/claude-wrapper/pull/565))
+- add DuplexSession::subscribe with classified InboundEvent stream ([#564](https://github.com/joshrotenberg/claude-wrapper/pull/564))
+- add DuplexSession for long-lived stream-json conversations ([#562](https://github.com/joshrotenberg/claude-wrapper/pull/562))
+
+### Other
+
+- *(examples)* add DuplexSession examples for chat and interrupt ([#570](https://github.com/joshrotenberg/claude-wrapper/pull/570))
+- reposition DuplexSession as the recommended multi-turn primitive ([#569](https://github.com/joshrotenberg/claude-wrapper/pull/569))
+- *(duplex)* expand live integration coverage and tighten assertions ([#568](https://github.com/joshrotenberg/claude-wrapper/pull/568))
+- update changelog ([#560](https://github.com/joshrotenberg/claude-wrapper/pull/560))
+
 ## [0.8.0] - 2026-05-04
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:DuplexClosed in /tmp/.tmpVtUult/claude-wrapper/src/error.rs:69
  variant Error:DuplexTurnInFlight in /tmp/.tmpVtUult/claude-wrapper/src/error.rs:76
  variant Error:DuplexControlFailed in /tmp/.tmpVtUult/claude-wrapper/src/error.rs:84
  variant Error:DuplexClosed in /tmp/.tmpVtUult/claude-wrapper/src/error.rs:69
  variant Error:DuplexTurnInFlight in /tmp/.tmpVtUult/claude-wrapper/src/error.rs:76
  variant Error:DuplexControlFailed in /tmp/.tmpVtUult/claude-wrapper/src/error.rs:84
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.8.0...v0.9.0) - 2026-05-08

### Added

- *(examples)* add minimal HTTP claude-as-a-service example ([#576](https://github.com/joshrotenberg/claude-wrapper/pull/576))
- add health/watchdog primitives to DuplexSession ([#575](https://github.com/joshrotenberg/claude-wrapper/pull/575))
- add Conversation wrapper for DuplexSession bookkeeping ([#574](https://github.com/joshrotenberg/claude-wrapper/pull/574))
- add DuplexSession::interrupt for clean mid-turn cancel ([#566](https://github.com/joshrotenberg/claude-wrapper/pull/566))
- add mid-turn permission handling to DuplexSession ([#565](https://github.com/joshrotenberg/claude-wrapper/pull/565))
- add DuplexSession::subscribe with classified InboundEvent stream ([#564](https://github.com/joshrotenberg/claude-wrapper/pull/564))
- add DuplexSession for long-lived stream-json conversations ([#562](https://github.com/joshrotenberg/claude-wrapper/pull/562))

### Other

- *(examples)* add DuplexSession examples for chat and interrupt ([#570](https://github.com/joshrotenberg/claude-wrapper/pull/570))
- reposition DuplexSession as the recommended multi-turn primitive ([#569](https://github.com/joshrotenberg/claude-wrapper/pull/569))
- *(duplex)* expand live integration coverage and tighten assertions ([#568](https://github.com/joshrotenberg/claude-wrapper/pull/568))
- update changelog ([#560](https://github.com/joshrotenberg/claude-wrapper/pull/560))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).