### PR TITLE
docs: reposition DuplexSession as the recommended multi-turn primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI assistants working on this repo.
 
 ## What this is
 
-`claude-wrapper` is a type-safe Rust wrapper around the Claude Code CLI. Each subcommand is a builder that produces a typed result. Execution is via tokio (default) or `std::thread` (with the `sync` feature). Built in: multi-turn `Session` with streaming, cumulative cost + optional `BudgetTracker` hard-stops, typed tool-permission patterns (`ToolPattern`), retry policy, and an `McpConfigBuilder` for programmatic `.mcp.json` generation.
+`claude-wrapper` is a type-safe Rust wrapper around the Claude Code CLI. Each subcommand is a builder that produces a typed result. Execution is via tokio (default) or `std::thread` (with the `sync` feature). Built in: long-lived `DuplexSession` for hosts (one child held open across turns; mid-turn interrupts, permission handlers, broadcast subscribers), transient `Session` for short-lived processes (subprocess-per-turn with `--resume`, cumulative cost + history, optional `BudgetTracker` hard-stops, streaming), typed tool-permission patterns (`ToolPattern`), retry policy, and an `McpConfigBuilder` for programmatic `.mcp.json` generation.
 
 This is the only crate in the repo.
 
@@ -79,7 +79,8 @@ Key modules:
 - `src/command/plugin.rs`, `marketplace.rs`, `auth.rs`, `doctor.rs`, `agents.rs`, `version.rs`, `raw.rs` -- other subcommands
 - `src/exec.rs` -- process spawning (tokio for async, `std::process` + `wait-timeout` for sync), concurrent pipe drain, timeout cleanup
 - `src/streaming.rs` -- `stream_query` / `stream_query_sync` for NDJSON streaming
-- `src/session.rs` -- `Session` for multi-turn conversations (async-only; holds `Arc<Claude>`, auto-threads session_id, tracks history/cost, supports streaming, optional `BudgetTracker` attachment)
+- `src/session.rs` -- `Session` for multi-turn conversations from short-lived processes (async-only; subprocess per turn; holds `Arc<Claude>`, auto-threads session_id, tracks history/cost, supports streaming, optional `BudgetTracker` attachment)
+- `src/duplex.rs` -- `DuplexSession` for long-running hosts (async + json; one `claude` subprocess held open in stream-json mode across many turns; supports `subscribe`, `interrupt`, and an async `PermissionHandler` for mid-turn permission decisions)
 - `src/budget.rs` -- `BudgetTracker` with fire-once warn/exceeded callbacks and `Error::BudgetExceeded` hard-stop
 - `src/tool_pattern.rs` -- `ToolPattern` for typed `--allowed-tools` / `--disallowed-tools` patterns (`tool`, `tool_with_args`, `all`, `mcp` constructors; `parse()` validation; loose `From<&str>` for back-compat)
 - `src/mcp_config.rs` -- `McpConfigBuilder` for generating `.mcp.json` files
@@ -108,9 +109,47 @@ The `Session` module and every `async fn execute` / `async fn execute_json` are 
 - Prefer editing existing files over creating new ones
 - When adding code behind a feature gate, verify every build configuration compiles (see Build and test)
 
-## Session API notes
+## Multi-turn API notes
 
-`Session` is the preferred multi-turn interface. Key points:
+The crate ships two multi-turn primitives. Recommend `DuplexSession`
+for long-running hosts (the featureful default for agentic / UI
+work), and `Session` for short-lived processes that just need
+conversation continuity over a series of one-off subprocess calls.
+
+### `DuplexSession` (recommended for long-running hosts)
+
+Holds one `claude` subprocess open in stream-json duplex mode for
+the lifetime of the conversation. Async-only, gated on `feature =
+"async"` + `feature = "json"`. Key points:
+
+- `DuplexSession::spawn(claude, opts)` -- starts the child and the
+  background task that owns it.
+- `send(prompt) -> TurnResult` -- one turn at a time; `send` while
+  another turn is pending returns `Error::DuplexTurnInFlight`.
+- `subscribe() -> broadcast::Receiver<InboundEvent>` -- typed event
+  stream (`SystemInit`, `Assistant`, `StreamEvent`, `User`,
+  `Other`). Multiple receivers are supported. Slow consumers see
+  `RecvError::Lagged` rather than blocking.
+- `interrupt() -> Result<()>` -- writes a clean
+  `control_request {subtype: "interrupt"}`. The in-flight turn
+  closes shortly after with a truncated `TurnResult`.
+- `respond_to_permission(request_id, decision)` -- answers a
+  permission prompt that was deferred from the handler.
+- `close(self)` -- drops the outbound channel, closes stdin, and
+  reaps the child. Drop without close also tears down (via
+  `kill_on_drop` on the `Command`).
+- Not `Clone`. Wrap in `Arc<DuplexSession>` if you need to call
+  `&self` methods (`send`, `subscribe`, `interrupt`,
+  `respond_to_permission`) from multiple tasks. `close(self)`
+  requires exclusive ownership.
+- TurnResult does not track cumulative cost or history across
+  turns -- the events vec is per-turn. Hosts that want that can
+  accumulate themselves; we may add a typed wrapper later.
+
+### `Session` (for short-lived processes)
+
+Holds host-side state across a series of transient `claude -p`
+subprocess calls. Key points:
 
 - Holds `Arc<Claude>` -- `Send + Sync`, can move between tasks, store in long-lived actor state
 - `Session::new(arc)` starts fresh; `Session::resume(arc, id)` reattaches to an existing id

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Features:
 
 - Full coverage of `claude -p` via `QueryCommand`
 - Async (tokio) and blocking (`std::thread` + `wait-timeout`) APIs behind feature flags
-- Multi-turn `Session` with auto-resume, streaming, cumulative cost, and optional `BudgetTracker` hard-stops
+- Long-lived `DuplexSession` for hosts (IDE backends, daemons, agent servers, chat UIs): one `claude` subprocess held open across turns, mid-turn interrupts, mid-turn permission decisions, broadcast event subscribers
+- Transient `Session` for short-lived processes (CLIs, build scripts, batch jobs): subprocess-per-turn with `--resume` continuity, cumulative cost + history, optional `BudgetTracker` hard-stops, streaming
 - NDJSON streaming events (`stream_query` / `stream_query_sync`)
 - Typed tool-permission patterns (`ToolPattern`)
 - MCP server management: list, get, add, add-json, remove, add-from-desktop, serve, reset-project-choices
@@ -199,11 +200,65 @@ let cmd = QueryCommand::new("review").allowed_tools(["Read", "Bash(git log:*)"])
 `ToolPattern::parse(s)` validates shape (balanced parens, no comma,
 non-empty name) and returns a typed `PatternError` on malformed input.
 
-## Session management
+## Multi-turn conversations
 
-For multi-turn conversations, wrap the client in an `Arc` and use
-`Session`. It threads `session_id` across turns, tracks cumulative cost
-+ history, and supports streaming.
+Two shapes for multi-turn work, each suited to a different process
+model. Pick `DuplexSession` if you can keep a `claude` subprocess
+open for the lifetime of the conversation (IDE backends, daemons,
+agent servers, chat UIs). Pick `Session` if your process is
+short-lived and conversation continuity is the main thing you need
+(CLIs, build scripts, batch jobs, lambdas).
+
+| | `DuplexSession` | `Session` |
+|---|---|---|
+| Process model | one child held open across turns | new subprocess per turn, `--resume` continuity |
+| Mid-turn interrupt | yes (`interrupt()`) | no (only `child.kill()` via SIGKILL) |
+| Mid-turn permission prompts | yes (`PermissionHandler`) | no |
+| Broadcast event subscribers | yes (`subscribe()`) | no (per-turn streaming via `stream_query`) |
+| Built-in cost / history tracking | no (TurnResult is per-turn) | yes (`total_cost_usd`, `history`, `BudgetTracker`) |
+| Right for | long-running hosts | short-lived processes |
+
+### `DuplexSession` (recommended for long-running hosts)
+
+Holds one `claude` subprocess open in stream-json duplex mode for
+the duration of a conversation. User messages go in over stdin,
+NDJSON events come back over stdout. Subscribe to the event stream
+for token-by-token UI updates, answer permission prompts via an
+async callback, and cancel a turn cleanly with `interrupt()`.
+
+```rust
+use claude_wrapper::Claude;
+use claude_wrapper::duplex::{DuplexOptions, DuplexSession, InboundEvent};
+
+let claude = Claude::builder().build()?;
+let session = DuplexSession::spawn(
+    &claude,
+    DuplexOptions::default().model("haiku"),
+).await?;
+
+let mut events = session.subscribe();
+let turn = session.send("what's 2 + 2?").await?;
+
+while let Ok(event) = events.try_recv() {
+    if let InboundEvent::Assistant(_) = event {
+        // partial or complete assistant message
+    }
+}
+
+println!("answer: {}", turn.result_text().unwrap_or(""));
+session.close().await?;
+```
+
+See the [`duplex` module docs](https://docs.rs/claude-wrapper/latest/claude_wrapper/duplex/index.html)
+for `interrupt()`, `respond_to_permission()`, and the full surface.
+
+### `Session` (for short-lived processes)
+
+Spawns a transient subprocess per turn and threads `session_id`
+across them via `--resume`. Tracks history, cumulative cost, and
+integrates with `BudgetTracker` for hard-stop ceilings. The right
+fit when each turn can stand on its own and the host process
+isn't long-lived.
 
 ```rust
 use std::sync::Arc;
@@ -229,11 +284,11 @@ let mut resumed = Session::resume(claude, "sess-abc123");
 let next = resumed.send("pick up where we left off").await?;
 ```
 
-`Session` is `Send + Sync`, holds `Arc<Claude>`, and can move between
-tasks or sit in long-lived actor state. Streaming turns use
-`Session::stream` / `Session::stream_execute` and capture the session
-id from the first event that carries one -- persisted even if the
-stream errors partway through.
+`Session` is `Send + Sync`, holds `Arc<Claude>`, and can move
+between tasks or sit in long-lived actor state. Streaming turns
+use `Session::stream` / `Session::stream_execute` and capture the
+session id from the first event that carries one -- persisted even
+if the stream errors partway through.
 
 `Session` is currently async-only. Sync callers compose equivalent
 state using `execute_sync` / `execute_json_sync` and `BudgetTracker`.

--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -8,19 +8,20 @@
 //!
 //! # When to use
 //!
-//! Most consumers of this crate should keep using [`QueryCommand`] and
-//! [`Session`] -- one subprocess per turn, continuity via `--resume`.
-//! That is the right shape for short-lived processes (CLIs, build
-//! scripts, batch jobs, lambdas) which have no long-running runtime
-//! to host a session.
+//! [`DuplexSession`] is the recommended primitive for long-running
+//! hosts that drive multi-turn conversations: agent servers, IDE
+//! backends, daemons, chat UIs. Holding the child open across turns
+//! amortizes init cost and unlocks capabilities that are awkward or
+//! impossible from a transient subprocess: mid-turn permission
+//! decisions ([`PermissionHandler`]), clean
+//! [interrupts](DuplexSession::interrupt), and a typed
+//! [event subscriber stream](DuplexSession::subscribe) that fans out
+//! events to multiple consumers.
 //!
-//! [`DuplexSession`] is for the inverse case: an agent server, IDE
-//! backend, daemon, or chat UI where holding a `claude` subprocess
-//! open across turns amortizes init cost and unlocks capabilities
-//! that are awkward or impossible from a transient subprocess
-//! (mid-turn permission decisions, hook flow, clean interrupts).
-//! Those capabilities ship in subsequent PRs; this PR is the
-//! minimum happy path.
+//! For short-lived processes (CLIs, build scripts, batch jobs,
+//! lambdas) where each turn can stand on its own, prefer
+//! [`QueryCommand`] for one-off calls or [`Session`] for transient
+//! multi-turn with cumulative cost / history tracking.
 //!
 //! [`QueryCommand`]: crate::QueryCommand
 //! [`Session`]: crate::session::Session

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,12 +101,48 @@
 //! # }
 //! ```
 //!
-//! # Session management
+//! # Multi-turn conversations
 //!
-//! For multi-turn conversations use [`session::Session`]. It threads the
-//! CLI `session_id` across turns, tracks cumulative cost + history, and
-//! supports streaming. See the [session module docs](session) for the
-//! full API.
+//! Two shapes for multi-turn work, each suited to a different
+//! process model. [`DuplexSession`] is the recommended choice for
+//! long-running hosts; [`Session`] is the right fit for short-lived
+//! processes.
+//!
+//! | | [`DuplexSession`] | [`Session`] |
+//! |---|---|---|
+//! | Process model | one child held open across turns | new subprocess per turn, `--resume` continuity |
+//! | Mid-turn interrupt | yes ([`DuplexSession::interrupt`](duplex::DuplexSession::interrupt)) | no (only `child.kill()` via SIGKILL) |
+//! | Mid-turn permission prompts | yes ([`PermissionHandler`]) | no |
+//! | Broadcast event subscribers | yes ([`DuplexSession::subscribe`](duplex::DuplexSession::subscribe)) | no (per-turn `stream_query`) |
+//! | Built-in cost / history tracking | no ([`TurnResult`] is per-turn) | yes ([`Session::total_cost_usd`], [`Session::history`], [`BudgetTracker`]) |
+//! | Right for | long-running hosts (IDE backends, daemons, agent servers, chat UIs) | short-lived processes (CLIs, build scripts, batch jobs, lambdas) |
+//!
+//! ## `DuplexSession` (recommended for long-running hosts)
+//!
+//! ```no_run
+//! # #[cfg(all(feature = "async", feature = "json"))] {
+//! use claude_wrapper::Claude;
+//! use claude_wrapper::duplex::{DuplexOptions, DuplexSession};
+//!
+//! # async fn example() -> claude_wrapper::Result<()> {
+//! let claude = Claude::builder().build()?;
+//! let session = DuplexSession::spawn(
+//!     &claude,
+//!     DuplexOptions::default().model("haiku"),
+//! ).await?;
+//!
+//! let turn = session.send("what's 2 + 2?").await?;
+//! println!("answer: {}", turn.result_text().unwrap_or(""));
+//!
+//! session.close().await?;
+//! # Ok(()) }
+//! # }
+//! ```
+//!
+//! See the [duplex module docs](duplex) for the full API including
+//! `subscribe`, `interrupt`, and `respond_to_permission`.
+//!
+//! ## `Session` (for short-lived processes)
 //!
 //! ```no_run
 //! # #[cfg(all(feature = "async", feature = "json"))] {
@@ -123,6 +159,8 @@
 //! # Ok(()) }
 //! # }
 //! ```
+//!
+//! See the [session module docs](session) for the full API.
 //!
 //! # Budget tracking
 //!

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,8 +1,22 @@
-//! Multi-turn session management.
+//! Multi-turn session management for short-lived processes.
 //!
 //! A [`Session`] threads Claude's `session_id` across turns automatically,
 //! so callers never need to scrape it out of a result event or pass
 //! `--resume` by hand.
+//!
+//! # When to use
+//!
+//! [`Session`] is the right fit when each turn can stand on its own
+//! and the host process is short-lived: CLIs, build scripts, batch
+//! jobs, lambdas. Each turn spawns a fresh `claude` subprocess and
+//! resumes the conversation via `--resume <session_id>`.
+//!
+//! For long-running hosts (IDE backends, daemons, agent servers,
+//! chat UIs) where holding a `claude` subprocess open across many
+//! turns is cheap, prefer [`DuplexSession`](crate::duplex::DuplexSession).
+//! It supports mid-turn interrupts, mid-turn permission decisions, and
+//! a broadcast event stream that [`Session`] cannot offer because of
+//! the transient subprocess model.
 //!
 //! # Ownership
 //!


### PR DESCRIPTION
## Summary

Now that the four-PR \`DuplexSession\` rollout (#562, #564, #565, #566) and the live integration test pass (#568) have all landed, this updates the docs so users encounter the right primitive for their use case.

The crate has two multi-turn shapes:

- **\`DuplexSession\`** -- recommended for long-running hosts. One \`claude\` subprocess held open across turns, mid-turn interrupt, mid-turn permission decisions, broadcast event subscribers. Right for IDE backends, daemons, agent servers, chat UIs.
- **\`Session\`** -- for short-lived processes. Subprocess-per-turn with \`--resume\` continuity, cumulative cost + history, optional \`BudgetTracker\` hard-stops. Right for CLIs, build scripts, batch jobs, lambdas where holding a child open across the run isn't appropriate.

Both stay supported. The docs change just makes the choice obvious.

## Files touched

- \`README.md\` -- features list now distinguishes both primitives; replaced the single \"Session management\" section with a \"Multi-turn conversations\" section that opens with a comparison table, then a \`DuplexSession\` example, then the existing \`Session\` example.
- \`src/lib.rs\` -- same comparison table and side-by-side examples in the crate-level docs, with intra-doc links throughout.
- \`src/session.rs\` -- added a \"When to use\" sub-section at the top of the module docs pointing users to \`DuplexSession\` when the host process can keep a child open.
- \`src/duplex.rs\` -- tightened the \"When to use\" framing so it leads with \`DuplexSession\` as the recommended option for hosts; removed a stale \"this PR is the minimum happy path\" line.
- \`AGENTS.md\` -- added a \`src/duplex.rs\` architecture bullet, rewrote \"Session API notes\" as \"Multi-turn API notes\" covering both primitives, refreshed the top-of-file blurb.

No code or behavior changes.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --lib --all-features\` (194 pass)
- [x] \`cargo test --doc --all-features\` (64 pass, includes the new \`DuplexSession\` example in lib.rs)
- [x] \`cargo build\` (default features)
- [x] \`cargo build --all-features\`
- [x] \`cargo build --no-default-features --features \"json,sync\"\`
- [x] \`cargo clippy --all-targets --no-default-features --features \"json,sync\" -- -D warnings\`
- [x] \`cargo doc --all-features --no-deps\` -- 0 warnings, 0 errors (resolved 4 \`rustdoc::redundant_explicit_links\` along the way)