### PR TITLE
docs(examples): add DuplexSession examples for chat and interrupt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,14 @@ name = "agent_worker"
 required-features = ["async", "json"]
 
 [[example]]
+name = "duplex_chat"
+required-features = ["async", "json"]
+
+[[example]]
+name = "duplex_interrupt"
+required-features = ["async", "json"]
+
+[[example]]
 name = "health_check"
 required-features = ["async"]
 

--- a/examples/duplex_chat.rs
+++ b/examples/duplex_chat.rs
@@ -1,0 +1,76 @@
+//! Interactive multi-turn chat using `DuplexSession`.
+//!
+//! Spawns one `claude` subprocess and holds it open across turns.
+//! A background task subscribes to the event stream and prints
+//! event tags live so you can see the duplex protocol in action
+//! while the model is working.
+//!
+//! Type a message and press Enter. Empty line ends the chat;
+//! Ctrl+D / EOF also closes cleanly.
+//!
+//! ```sh
+//! cargo run --example duplex_chat
+//! ```
+
+use std::io::Write;
+
+use claude_wrapper::Claude;
+use claude_wrapper::duplex::{DuplexOptions, DuplexSession, InboundEvent};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+#[tokio::main]
+async fn main() -> claude_wrapper::Result<()> {
+    let claude = Claude::builder().build()?;
+    let session = DuplexSession::spawn(&claude, DuplexOptions::default().model("haiku")).await?;
+
+    // Background task: print event tags as they arrive. The receiver
+    // owns its end of the broadcast channel, so the task runs
+    // independently of the main REPL loop. When the session closes,
+    // events_tx is dropped, recv() returns Err, and the task exits.
+    let mut rx = session.subscribe();
+    let printer = tokio::spawn(async move {
+        while let Ok(event) = rx.recv().await {
+            let tag = match event {
+                InboundEvent::SystemInit { ref session_id } => {
+                    eprintln!("[init] session_id={session_id}");
+                    continue;
+                }
+                InboundEvent::Assistant(_) => "[assistant]",
+                InboundEvent::StreamEvent(_) => "[stream]",
+                InboundEvent::User(_) => "[user]",
+                InboundEvent::Other(_) => "[other]",
+            };
+            eprintln!("{tag}");
+        }
+    });
+
+    let stdin = tokio::io::stdin();
+    let mut lines = BufReader::new(stdin).lines();
+
+    println!("DuplexSession chat (empty line to exit)");
+    print!("> ");
+    std::io::stdout().flush().ok();
+
+    while let Some(line) = lines.next_line().await.ok().flatten() {
+        if line.trim().is_empty() {
+            break;
+        }
+
+        let turn = session.send(line).await?;
+
+        if let Some(text) = turn.result_text() {
+            println!("\n{text}\n");
+        }
+        if let Some(cost) = turn.total_cost_usd() {
+            eprintln!("(turn cost: ${cost:.4})");
+        }
+
+        print!("> ");
+        std::io::stdout().flush().ok();
+    }
+
+    println!("\nclosing session...");
+    session.close().await?;
+    let _ = printer.await;
+    Ok(())
+}

--- a/examples/duplex_interrupt.rs
+++ b/examples/duplex_interrupt.rs
@@ -1,0 +1,59 @@
+//! Cancel a long-running turn with `DuplexSession::interrupt`.
+//!
+//! Spawns a duplex session, kicks off a turn that asks for a long
+//! response, then sends an interrupt 500ms later. Both futures are
+//! driven concurrently via `tokio::join!`: the `send` future
+//! resolves with a truncated `TurnResult`, and the `interrupt`
+//! future resolves with `Ok(())` once the CLI acknowledges.
+//!
+//! ```sh
+//! cargo run --example duplex_interrupt
+//! ```
+//!
+//! Interrupt is the long-lived host's clean alternative to
+//! SIGKILL'ing the child: the conversation stays alive, you can
+//! follow up with another `send`, and the truncated turn comes
+//! back with diagnostic fields you can show to the user.
+
+use std::time::Duration;
+
+use claude_wrapper::Claude;
+use claude_wrapper::duplex::{DuplexOptions, DuplexSession};
+
+#[tokio::main]
+async fn main() -> claude_wrapper::Result<()> {
+    let claude = Claude::builder().build()?;
+    let session = DuplexSession::spawn(&claude, DuplexOptions::default().model("haiku")).await?;
+
+    let send_fut = session.send(
+        "Write a long, detailed essay about the history of programming \
+         languages, covering at least 20 distinct languages chronologically.",
+    );
+    let interrupt_fut = async {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        eprintln!("sending interrupt...");
+        session.interrupt().await
+    };
+
+    let (turn_result, interrupt_result) = tokio::join!(send_fut, interrupt_fut);
+
+    let turn = turn_result?;
+    interrupt_result?;
+
+    println!("interrupted turn closed");
+    if let Some(reason) = turn.result.get("terminal_reason").and_then(|v| v.as_str()) {
+        println!("  terminal_reason: {reason}");
+    }
+    if let Some(subtype) = turn.result.get("subtype").and_then(|v| v.as_str()) {
+        println!("  subtype: {subtype}");
+    }
+    if let Some(is_err) = turn.result.get("is_error").and_then(|v| v.as_bool()) {
+        println!("  is_error: {is_err}");
+    }
+    if let Some(cost) = turn.total_cost_usd() {
+        println!("  cost: ${cost:.4}");
+    }
+
+    session.close().await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Two focused examples covering the distinctive \`DuplexSession\` features. Smoke-tested live against claude 2.1.123.

## What's new

### \`examples/duplex_chat.rs\` -- interactive multi-turn chat REPL

Spawns one \`claude\` subprocess and holds it open across turns. A background task subscribes to the event stream and prints event tags (\`[init]\`, \`[assistant]\`, \`[stream]\`, \`[user]\`, \`[other]\`) live so users can see the duplex protocol in action while the model is working. Empty line ends the chat; Ctrl+D / EOF also closes cleanly.

Demonstrates: \`spawn\`, \`send\`, \`subscribe\`, multi-turn over one child, \`close\`.

```sh
$ echo \"What is 2+2?\" | cargo run --example duplex_chat
DuplexSession chat (empty line to exit)
> [init] session_id=6391afd9-...
[other]
[assistant]
[assistant]

2 + 2 = 4.

(turn cost: \$0.0706)
> 
closing session...
```

### \`examples/duplex_interrupt.rs\` -- concurrent send + interrupt

Sends a long-essay prompt and interrupts 500ms later via \`tokio::join!\`. The \`send\` future resolves with a truncated \`TurnResult\` showing \`terminal_reason: \"aborted_streaming\"\`, \`subtype: \"error_during_execution\"\`, and \`is_error: true\`. The \`interrupt\` future resolves with \`Ok(())\` once the CLI acknowledges.

Demonstrates: \`interrupt\` as the long-lived host's clean alternative to SIGKILL'ing the child. The conversation stays alive after an interrupt; you can follow up with another \`send\`.

```sh
$ cargo run --example duplex_interrupt
sending interrupt...
interrupted turn closed
  terminal_reason: aborted_streaming
  subtype: error_during_execution
  is_error: true
  cost: \$0.0000
```

## Other changes

- \`Cargo.toml\`: registered both examples with \`required-features = [\"async\", \"json\"]\` so they're skipped on sync-only builds.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --lib --all-features\` (194 pass)
- [x] \`cargo test --doc --all-features\` (64 pass)
- [x] \`cargo build --examples --all-features\` (both new examples compile)
- [x] \`cargo build --no-default-features --features \"json,sync\"\` (sync-only still builds; examples are skipped per their required-features)
- [x] \`cargo run --example duplex_interrupt\` against claude 2.1.123 (interrupt acknowledged, truncated turn returned)
- [x] \`cargo run --example duplex_chat\` with piped input against claude 2.1.123 (turn completed, subscriber events printed)