### PR TITLE
feat(examples): add minimal HTTP claude-as-a-service example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +88,8 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "claude-wrapper"
 version = "0.8.0"
 dependencies = [
+ "anyhow",
+ "axum",
  "serde",
  "serde_json",
  "tempfile",
@@ -69,6 +129,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +203,86 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "id-arena"
@@ -160,10 +342,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -204,6 +398,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -268,6 +468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +529,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +560,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -358,6 +593,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -421,11 +662,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ wait-timeout = { version = "0.2", optional = true }
 which = "8"
 
 [dev-dependencies]
+anyhow = "1"
+axum = "0.8"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
@@ -50,6 +53,10 @@ required-features = ["async", "json"]
 
 [[example]]
 name = "duplex_chat"
+required-features = ["async", "json"]
+
+[[example]]
+name = "duplex_http_service"
 required-features = ["async", "json"]
 
 [[example]]

--- a/examples/duplex_http_service.rs
+++ b/examples/duplex_http_service.rs
@@ -1,0 +1,158 @@
+//! Minimal HTTP "claude as a service": one `DuplexSession` behind two routes.
+//!
+//! Spawns a single [`DuplexSession`] on startup and serves it over HTTP via
+//! `axum`. Concurrent requests serialize through a `tokio::sync::Mutex` so
+//! they never overlap inside the wrapper (which would otherwise return
+//! [`Error::DuplexTurnInFlight`](claude_wrapper::Error::DuplexTurnInFlight)
+//! and surface as a 500). Cumulative cost and turn count are tracked by hand
+//! in shared state.
+//!
+//! Routes:
+//!
+//! - `POST /chat` -- body `{"prompt": "..."}`, returns
+//!   `{"text": "...", "session_id": "...", "turn_cost_usd": 0.0}`.
+//! - `GET /health` -- returns
+//!   `{"alive": true, "cumulative_cost_usd": 0.0, "turns": 0}`.
+//!
+//! Ctrl+C closes the session cleanly before shutting the server down.
+//!
+//! ```sh
+//! cargo run --example duplex_http_service
+//!
+//! # in another terminal
+//! curl -X POST http://127.0.0.1:3000/chat \
+//!   -H 'content-type: application/json' \
+//!   -d '{"prompt":"What is 2+2? Reply with just the number."}'
+//! # => {"text":"4","session_id":"...","turn_cost_usd":0.0001}
+//!
+//! curl http://127.0.0.1:3000/health
+//! # => {"alive":true,"cumulative_cost_usd":0.0001,"turns":1}
+//! ```
+//!
+//! ## Intentional simplicity
+//!
+//! This is the canonical "DuplexSession over HTTP" reference: one session,
+//! no pool, no auth. It also rolls its own bookkeeping by hand so it can
+//! double as a before/after demo for the wrapper types that tighten this
+//! shape:
+//!
+//! - The `cumulative_cost_usd` / `turns` mutexes collapse into
+//!   [`Conversation`](claude_wrapper::conversation::Conversation), which
+//!   already tracks both. Replacing `Arc<Mutex<DuplexSession>>` with
+//!   `Arc<Mutex<Conversation>>` removes ~10 lines of state plumbing.
+//! - The hardcoded `alive: true` is a placeholder for a future
+//!   `session.is_alive()` health primitive (tracked in
+//!   <https://github.com/joshrotenberg/claude-wrapper/issues/572>).
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use claude_wrapper::Claude;
+use claude_wrapper::duplex::{DuplexOptions, DuplexSession};
+
+#[derive(Clone)]
+struct AppState {
+    session: Arc<Mutex<DuplexSession>>,
+    cumulative_cost_usd: Arc<Mutex<f64>>,
+    turns: Arc<Mutex<u32>>,
+}
+
+#[derive(Deserialize)]
+struct ChatRequest {
+    prompt: String,
+}
+
+#[derive(Serialize)]
+struct ChatResponse {
+    text: String,
+    session_id: Option<String>,
+    turn_cost_usd: f64,
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    // TODO: replace with `session.is_alive()` once
+    // https://github.com/joshrotenberg/claude-wrapper/issues/572 lands.
+    alive: bool,
+    cumulative_cost_usd: f64,
+    turns: u32,
+}
+
+async fn chat(
+    State(state): State<AppState>,
+    Json(body): Json<ChatRequest>,
+) -> Result<Json<ChatResponse>, (StatusCode, String)> {
+    let session = state.session.lock().await;
+    let turn = session
+        .send(body.prompt)
+        .await
+        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+
+    let turn_cost = turn.total_cost_usd().unwrap_or(0.0);
+    *state.cumulative_cost_usd.lock().await += turn_cost;
+    *state.turns.lock().await += 1;
+
+    Ok(Json(ChatResponse {
+        text: turn.result_text().unwrap_or("").to_string(),
+        session_id: turn.session_id().map(String::from),
+        turn_cost_usd: turn_cost,
+    }))
+}
+
+async fn health(State(state): State<AppState>) -> impl IntoResponse {
+    Json(HealthResponse {
+        alive: true,
+        cumulative_cost_usd: *state.cumulative_cost_usd.lock().await,
+        turns: *state.turns.lock().await,
+    })
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let claude = Claude::builder().build()?;
+    let session = DuplexSession::spawn(&claude, DuplexOptions::default().model("haiku")).await?;
+
+    let state = AppState {
+        session: Arc::new(Mutex::new(session)),
+        cumulative_cost_usd: Arc::new(Mutex::new(0.0)),
+        turns: Arc::new(Mutex::new(0)),
+    };
+
+    let app = Router::new()
+        .route("/chat", post(chat))
+        .route("/health", get(health))
+        .with_state(state.clone());
+
+    let addr = "127.0.0.1:3000";
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    println!("listening on http://{addr}");
+    println!("  POST /chat   -- body: {{\"prompt\":\"...\"}}");
+    println!("  GET  /health -- cumulative cost + turn count");
+    println!("(Ctrl+C to shut down)");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    println!("closing duplex session...");
+    let session = Arc::try_unwrap(state.session)
+        .map_err(|_| anyhow::anyhow!("session still has outstanding references"))?
+        .into_inner();
+    session.close().await?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to install Ctrl+C handler");
+}


### PR DESCRIPTION
## Summary

Adds `examples/duplex_http_service.rs` -- a minimal HTTP service that holds a single `DuplexSession` and exposes it over `POST /chat` and `GET /health`. The canonical "how do I turn DuplexSession into a tiny service" reference: one session, no pool, no auth.

- `POST /chat` -- `{"prompt": "..."}` -> `{"text", "session_id", "turn_cost_usd"}`
- `GET /health` -- `{"alive", "cumulative_cost_usd", "turns"}`
- Single `DuplexSession` behind a `tokio::sync::Mutex` so concurrent requests serialize cleanly (avoids `Error::DuplexTurnInFlight` surfacing as a 500).
- Manual cumulative cost / turn count bookkeeping in app state -- intentionally hand-rolled so the example doubles as a before/after demo for the `Conversation` wrapper.
- Graceful shutdown on Ctrl+C calls `session.close()` before the listener drains.

Inline TODOs flag the two follow-up cleanup paths:

- `alive: true` is hardcoded; replace with `session.is_alive()` once #572 lands.
- The `cumulative_cost_usd` / `turns` mutexes collapse into `Conversation`.

`axum 0.8` and `anyhow` are added as dev-dependencies (axum is the obvious idiomatic choice for two routes + JSON; tokio dev-dep already includes the runtime features it needs).

Closes #573.

## Test plan

- [x] `cargo build --example duplex_http_service --all-features` -- clean
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --no-default-features` (example is feature-gated, sync-only build still passes)
- [x] `cargo test --lib --all-features` (201 passed)
- [x] `cargo test --doc --all-features` (66 passed)
- [ ] Manual: `cargo run --example duplex_http_service` -> `curl POST /chat` returns "4" + `session_id`; second `/chat` reuses `session_id`; `/health` shows incremented `turns` / `cumulative_cost_usd`