### PR TITLE
chore: release v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/claude-wrapper/CHANGELOG.md
+++ b/crates/claude-wrapper/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.9.0...v0.10.0) - 2026-05-20
+
+### Added
+
+- settings -- read on-disk settings layers ([#612](https://github.com/joshrotenberg/claude-wrapper/pull/612))
+- commands -- read custom slash command files ([#613](https://github.com/joshrotenberg/claude-wrapper/pull/613))
+- *(history)* paginate list tools + fix aiTitle field name ([#610](https://github.com/joshrotenberg/claude-wrapper/pull/610))
+- *(duplex)* permission_mode + dangerously_skip_permissions builders ([#614](https://github.com/joshrotenberg/claude-wrapper/pull/614))
+- skills -- read-side ~/.claude/skills/<stem>/SKILL.md ([#611](https://github.com/joshrotenberg/claude-wrapper/pull/611))
+- *(history)* expand SessionSummary with preview, cost, tokens ([#609](https://github.com/joshrotenberg/claude-wrapper/pull/609))
+- jobs -- read-side background-job state introspection ([#606](https://github.com/joshrotenberg/claude-wrapper/pull/606))
+- ProjectPurgeCommand for `claude project purge` ([#604](https://github.com/joshrotenberg/claude-wrapper/pull/604))
+- auth login modes + sso fix + auto_mode docstring ([#605](https://github.com/joshrotenberg/claude-wrapper/pull/605))
+- plugin lifecycle parity with claude 2.1.143 ([#603](https://github.com/joshrotenberg/claude-wrapper/pull/603))
+- declare tested-against CLI range + runtime drift warning ([#596](https://github.com/joshrotenberg/claude-wrapper/pull/596))
+- --agent / --agents typed builders on DuplexOptions ([#595](https://github.com/joshrotenberg/claude-wrapper/pull/595))
+- worktrees -- read-side git worktree introspection ([#594](https://github.com/joshrotenberg/claude-wrapper/pull/594))
+- AgentsRoot write / write_new / delete ([#592](https://github.com/joshrotenberg/claude-wrapper/pull/592))
+- typed auth errors -- classify CLI failures at exec time ([#591](https://github.com/joshrotenberg/claude-wrapper/pull/591))
+- auth strategy detection from environment ([#590](https://github.com/joshrotenberg/claude-wrapper/pull/590))
+- typed worktree builder + slash command helpers ([#589](https://github.com/joshrotenberg/claude-wrapper/pull/589))
+- artifacts module -- read agent definitions ([#588](https://github.com/joshrotenberg/claude-wrapper/pull/588))
+- *(history)* claude_wrapper::history JSONL session parser ([#587](https://github.com/joshrotenberg/claude-wrapper/pull/587))
+- *(duplex)* DuplexOptions::resume + continue_session ([#586](https://github.com/joshrotenberg/claude-wrapper/pull/586))
+
+### Other
+
+- *(agents)* claude agents is now a TUI; AgentsCommand can't list ([#593](https://github.com/joshrotenberg/claude-wrapper/pull/593))
+- *(workspace)* move claude-wrapper crate into crates/ ([#581](https://github.com/joshrotenberg/claude-wrapper/pull/581))
+
 ## [0.9.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.8.0...v0.9.0) - 2026-05-08
 
 ### Added

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Scope:Managed in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/types.rs:222
  variant Scope:Managed in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/types.rs:222
  variant Error:History in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/error.rs:96
  variant Error:Artifacts in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/error.rs:106
  variant Error:Worktrees in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/error.rs:116
  variant Error:Auth in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/error.rs:133
  variant Error:History in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/error.rs:96
  variant Error:Artifacts in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/error.rs:106
  variant Error:Worktrees in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/error.rs:116
  variant Error:Auth in /tmp/.tmp2BTdj1/claude-wrapper/crates/claude-wrapper/src/error.rs:133
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.9.0...v0.10.0) - 2026-05-20

### Added

- settings -- read on-disk settings layers ([#612](https://github.com/joshrotenberg/claude-wrapper/pull/612))
- commands -- read custom slash command files ([#613](https://github.com/joshrotenberg/claude-wrapper/pull/613))
- *(history)* paginate list tools + fix aiTitle field name ([#610](https://github.com/joshrotenberg/claude-wrapper/pull/610))
- *(duplex)* permission_mode + dangerously_skip_permissions builders ([#614](https://github.com/joshrotenberg/claude-wrapper/pull/614))
- skills -- read-side ~/.claude/skills/<stem>/SKILL.md ([#611](https://github.com/joshrotenberg/claude-wrapper/pull/611))
- *(history)* expand SessionSummary with preview, cost, tokens ([#609](https://github.com/joshrotenberg/claude-wrapper/pull/609))
- jobs -- read-side background-job state introspection ([#606](https://github.com/joshrotenberg/claude-wrapper/pull/606))
- ProjectPurgeCommand for `claude project purge` ([#604](https://github.com/joshrotenberg/claude-wrapper/pull/604))
- auth login modes + sso fix + auto_mode docstring ([#605](https://github.com/joshrotenberg/claude-wrapper/pull/605))
- plugin lifecycle parity with claude 2.1.143 ([#603](https://github.com/joshrotenberg/claude-wrapper/pull/603))
- declare tested-against CLI range + runtime drift warning ([#596](https://github.com/joshrotenberg/claude-wrapper/pull/596))
- --agent / --agents typed builders on DuplexOptions ([#595](https://github.com/joshrotenberg/claude-wrapper/pull/595))
- worktrees -- read-side git worktree introspection ([#594](https://github.com/joshrotenberg/claude-wrapper/pull/594))
- AgentsRoot write / write_new / delete ([#592](https://github.com/joshrotenberg/claude-wrapper/pull/592))
- typed auth errors -- classify CLI failures at exec time ([#591](https://github.com/joshrotenberg/claude-wrapper/pull/591))
- auth strategy detection from environment ([#590](https://github.com/joshrotenberg/claude-wrapper/pull/590))
- typed worktree builder + slash command helpers ([#589](https://github.com/joshrotenberg/claude-wrapper/pull/589))
- artifacts module -- read agent definitions ([#588](https://github.com/joshrotenberg/claude-wrapper/pull/588))
- *(history)* claude_wrapper::history JSONL session parser ([#587](https://github.com/joshrotenberg/claude-wrapper/pull/587))
- *(duplex)* DuplexOptions::resume + continue_session ([#586](https://github.com/joshrotenberg/claude-wrapper/pull/586))

### Other

- *(agents)* claude agents is now a TUI; AgentsCommand can't list ([#593](https://github.com/joshrotenberg/claude-wrapper/pull/593))
- *(workspace)* move claude-wrapper crate into crates/ ([#581](https://github.com/joshrotenberg/claude-wrapper/pull/581))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).