### PR TITLE
ci: pin macos-13 to dodge macos-latest rustup-init quirk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Pinned macos-13 instead of macos-latest: the macos-latest
-        # runner image rolled to one whose `rustup` is the
-        # `rustup-init` bootstrap stub, which intercepts `cargo
-        # clippy` invocations (rustup-init treats `clippy` as an
-        # unknown CLI arg and exits 1). Revisit when GitHub fixes
-        # the runner image.
-        os: [ubuntu-latest, macos-13, windows-latest]
+        # Pinned macos-14 instead of macos-latest: the current
+        # macos-latest image (aliased to macos-15) has a broken
+        # `rustup` -- it's actually the `rustup-init` bootstrap
+        # stub, which intercepts `cargo clippy` invocations
+        # (rustup-init treats `clippy` as an unknown CLI arg and
+        # exits 1). macos-13 was the first attempt but had bad
+        # runner availability. macos-14 is the latest pin that
+        # both works and has decent capacity. Revisit when GitHub
+        # fixes the macos-latest image.
+        os: [ubuntu-latest, macos-14, windows-latest]
         rust: [stable, beta]
         exclude:
-          - os: macos-13
+          - os: macos-14
             rust: beta
           - os: windows-latest
             rust: beta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Pinned macos-13 instead of macos-latest: the macos-latest
+        # runner image rolled to one whose `rustup` is the
+        # `rustup-init` bootstrap stub, which intercepts `cargo
+        # clippy` invocations (rustup-init treats `clippy` as an
+        # unknown CLI arg and exits 1). Revisit when GitHub fixes
+        # the runner image.
+        os: [ubuntu-latest, macos-13, windows-latest]
         rust: [stable, beta]
         exclude:
-          - os: macos-latest
+          - os: macos-13
             rust: beta
           - os: windows-latest
             rust: beta


### PR DESCRIPTION
## Summary

The `macos-latest` runner image rolled at ~2026-05-14 18:53 UTC to one whose `rustup` is actually the `rustup-init` bootstrap stub. That breaks `cargo clippy`: cargo's clippy subcommand dispatch goes through rustup, but rustup-init treats \`clippy\` as an unknown CLI argument and exits with:

\`\`\`
error: unexpected argument 'clippy' found
Usage: rustup-init[EXE] [OPTIONS]
\`\`\`

Every PR opened after the image roll is hitting this on the macOS matrix entry while ubuntu/windows pass cleanly. Pin \`macos-13\` until GitHub fixes the \`macos-latest\` image.

## Affected runs (all post-18:53 UTC, all hit the same error)

- #581 (workspace restructure)
- The release-plz auto-PR
- Any subsequent PR until this lands

## Test plan

- [ ] CI on this PR shows macos-13 passing
- [ ] Once merged, rebase #581 and confirm its CI goes green