### PR TITLE
feat(server): claude-server -- MCP server layer over claude-wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ CLAUDE.md
 .worktrees/
 NAME_IDEAS.md
 /tmp/
+
+# claude-server spike: local dev wiring + design notes
+.mcp.json
+.claude-server-dev.toml
+mcp-spec.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -109,8 +110,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -147,6 +150,21 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -205,8 +223,10 @@ name = "claude-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "clap",
  "claude-wrapper",
+ "http-body-util",
  "schemars",
  "serde",
  "serde_json",
@@ -214,6 +234,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tower",
  "tower-mcp",
  "tracing",
  "tracing-subscriber",
@@ -240,6 +261,41 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -373,6 +429,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,7 +458,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -517,6 +595,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,9 +778,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -753,6 +887,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -884,6 +1024,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,7 +1105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1015,6 +1166,43 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1085,18 +1273,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3922ea4ba2fe8df4fa000c2277534dff77551e4db08b5c3a01ba25accf7ae6ca"
 dependencies = [
  "async-trait",
+ "axum",
  "base64",
  "futures",
+ "http",
+ "http-body-util",
+ "hyper",
  "pin-project-lite",
  "regex",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-mcp-types",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1180,6 +1374,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,10 +1414,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -1234,6 +1467,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1398,6 +1676,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,9 +1268,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3922ea4ba2fe8df4fa000c2277534dff77551e4db08b5c3a01ba25accf7ae6ca"
+checksum = "fe5843c187089d0c21cdca5fab23aa8afb5ec538eac7105352f4298de888eca2"
 dependencies = [
  "async-trait",
  "axum",
@@ -1284,6 +1284,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tower",
@@ -1295,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "tower-mcp-types"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4ca9cfdeeec75a22461f14cf0e3848ce2fb92a6e9e2082d2d142757e842a44"
+checksum = "0b7cc9f6b3e250de8dbb655bb310f438a69f299e69e4b050acd826f95bb5b40a"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
  "tokio",
  "toml",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,12 +1375,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,80 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -67,6 +137,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +161,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "claude-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "claude-wrapper",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "toml",
+ "tower-mcp",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "claude-wrapper"
 version = "0.9.0"
 dependencies = [
@@ -99,6 +234,18 @@ dependencies = [
  "wait-timeout",
  "which",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -138,12 +285,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -151,6 +314,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -164,8 +361,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -303,10 +505,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -342,6 +556,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,10 +594,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -455,6 +693,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +759,31 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
 
 [[package]]
 name = "scopeguard"
@@ -516,6 +828,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +863,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +881,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -582,6 +923,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -634,6 +981,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +1018,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +1077,39 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-mcp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3922ea4ba2fe8df4fa000c2277534dff77551e4db08b5c3a01ba25accf7ae6ca"
+dependencies = [
+ "async-trait",
+ "base64",
+ "futures",
+ "pin-project-lite",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-mcp-types",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-mcp-types"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4ca9cfdeeec75a22461f14cf0e3848ce2fb92a6e9e2082d2d142757e842a44"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "tower-service"
@@ -719,6 +1147,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -732,6 +1190,18 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"
@@ -823,6 +1293,18 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 resolver = "3"
 members = [
     "crates/claude-wrapper",
+    "crates/claude-server",
 ]

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -41,7 +41,9 @@ metrics = []
 # feature must be on AND `policy.allow_mutations = true` at
 # runtime. Compile-time gate strips the code entirely;
 # runtime gate hides the tools from `tools/list`.
-mutations = []
+# Implies `core` because mutations.rs reuses `core::strip_ansi` for
+# command-output JSON envelopes -- the two surfaces share helpers.
+mutations = ["core"]
 
 # Read-only access to historical sessions on disk
 # (`~/.claude/projects/<slug>/<session_id>.jsonl`). Tools:

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -63,6 +63,16 @@ artifacts = []
 # to inspect the worktrees they've spawned.
 worktrees = []
 
+# Read-only access to background-job state on disk
+# (`~/.claude/jobs/<short-id>/state.json` + `timeline.jsonl`).
+# Tools: claude_job_list, claude_job_get. Resources: claude://jobs,
+# claude://jobs/{short_id}. Built on claude_wrapper::jobs; no new
+# deps. Lets coordinator agents reason about background work
+# launched via `claude agents` (which writes the same on-disk
+# state). Read-only by design -- the dispatch protocol is
+# undocumented.
+jobs = []
+
 # Sync (blocking) variants of agent-turn tools: chat_send_sync,
 # chat_send_stream_sync, claude_query_sync. On by default for
 # ergonomic builds. `default-features = false` drops them entirely
@@ -73,7 +83,7 @@ sync-agent-turns = []
 # Convenience profile: the kitchen sink for Finestra-class
 # deployments that want the full surface including mutations
 # and historical session reads.
-full = ["chat", "core", "metrics", "sync-agent-turns", "mutations", "history", "artifacts", "worktrees"]
+full = ["chat", "core", "metrics", "sync-agent-turns", "mutations", "history", "artifacts", "worktrees", "jobs"]
 
 [dependencies]
 claude-wrapper = { path = "../claude-wrapper", default-features = false, features = ["async", "json"] }

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -43,6 +43,13 @@ metrics = []
 # runtime gate hides the tools from `tools/list`.
 mutations = []
 
+# Read-only access to historical sessions on disk
+# (`~/.claude/projects/<slug>/<session_id>.jsonl`). Tools:
+# claude_project_list, claude_session_list, claude_session_get.
+# Resources: claude://projects, claude://sessions/{id}. Built on
+# claude_wrapper::history; no new deps.
+history = []
+
 # Sync (blocking) variants of agent-turn tools: chat_send_sync,
 # chat_send_stream_sync, claude_query_sync. On by default for
 # ergonomic builds. `default-features = false` drops them entirely
@@ -51,8 +58,9 @@ mutations = []
 sync-agent-turns = []
 
 # Convenience profile: the kitchen sink for Finestra-class
-# deployments that want the full surface including mutations.
-full = ["chat", "core", "metrics", "sync-agent-turns", "mutations"]
+# deployments that want the full surface including mutations
+# and historical session reads.
+full = ["chat", "core", "metrics", "sync-agent-turns", "mutations", "history"]
 
 [dependencies]
 claude-wrapper = { path = "../claude-wrapper", default-features = false, features = ["async", "json"] }

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -10,13 +10,49 @@ description = "MCP server layer over claude-wrapper"
 publish = false
 
 [features]
-default = ["sync-agent-turns"]
+# Default surface: 1:1 CLI passthrough + duplex chat sidecar +
+# process metrics + sync agent-turn variants. Tuned for the
+# common "MCP server over claude" use case. Larger surfaces
+# (mutations, artifacts, history, worktrees) are opt-in so
+# consumers who only want chat don't pay for them.
+default = ["chat", "core", "metrics", "sync-agent-turns"]
+
+# 1:1 mirror of `claude` CLI: query (async + sync), version,
+# cli_version, agents, auth_status, mcp_list/get,
+# plugin_list/validate, marketplace_list, auto_mode_*, doctor.
+# Plus the turn registry data layer (TurnRegistry) which the async
+# claude_query needs.
+core = []
+
+# Long-lived duplex chat surface: chat_open / send / list /
+# history / interrupt / budget / close / compact, the turn_*
+# control tools (turn_get / wait / cancel / list), and the
+# claude://chats[/{id}] resources. Built on DuplexSession +
+# Conversation in claude-wrapper.
+chat = []
+
+# Process counters + metrics_summary tool + claude://metrics
+# resource. Cheap; lets coordinator agents introspect spend.
+metrics = []
+
+# Mutating CLI passthrough: mcp_add / add_json / remove,
+# plugin_install / uninstall / enable / disable / update,
+# marketplace_add / remove / update. Double-gated: this Cargo
+# feature must be on AND `policy.allow_mutations = true` at
+# runtime. Compile-time gate strips the code entirely;
+# runtime gate hides the tools from `tools/list`.
+mutations = []
+
 # Sync (blocking) variants of agent-turn tools: chat_send_sync,
 # chat_send_stream_sync, claude_query_sync. On by default for
 # ergonomic builds. `default-features = false` drops them entirely
 # so the model literally can't discover blocking variants -- the
 # "agent sits waiting" failure mode becomes structurally impossible.
 sync-agent-turns = []
+
+# Convenience profile: the kitchen sink for Finestra-class
+# deployments that want the full surface including mutations.
+full = ["chat", "core", "metrics", "sync-agent-turns", "mutations"]
 
 [dependencies]
 claude-wrapper = { path = "../claude-wrapper", default-features = false, features = ["async", "json"] }

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -9,6 +9,15 @@ repository = "https://github.com/joshrotenberg/claude-wrapper"
 description = "MCP server layer over claude-wrapper"
 publish = false
 
+[features]
+default = ["sync-agent-turns"]
+# Sync (blocking) variants of agent-turn tools: chat_send_sync,
+# chat_send_stream_sync, claude_query_sync. On by default for
+# ergonomic builds. `default-features = false` drops them entirely
+# so the model literally can't discover blocking variants -- the
+# "agent sits waiting" failure mode becomes structurally impossible.
+sync-agent-turns = []
+
 [dependencies]
 claude-wrapper = { path = "../claude-wrapper", default-features = false, features = ["async", "json"] }
 tokio = { version = "1", features = ["process", "time", "io-util", "macros", "rt-multi-thread", "sync"] }

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -23,7 +23,6 @@ claude-wrapper = { path = "../claude-wrapper", default-features = false, feature
 tokio = { version = "1", features = ["process", "time", "io-util", "macros", "rt-multi-thread", "sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower-mcp = { version = "0.10", features = ["http"] }

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -82,10 +82,20 @@ jobs = []
 # "agent sits waiting" failure mode becomes structurally impossible.
 sync-agent-turns = []
 
+# Build the polished `claude-server` binary. Pulls in clap and
+# anyhow which aren't needed by library embedders. Implied by
+# `full` so `cargo install claude-server --features full` does
+# the right thing.
+bin = ["dep:clap", "dep:anyhow"]
+
+# Enable structured JSON tracing output via `--log-format json`.
+# Implied by `bin`; library embedders wire their own logging.
+tracing-json = ["tracing-subscriber/json"]
+
 # Convenience profile: the kitchen sink for Finestra-class
 # deployments that want the full surface including mutations
-# and historical session reads.
-full = ["chat", "core", "metrics", "sync-agent-turns", "mutations", "history", "artifacts", "worktrees", "jobs"]
+# and historical session reads. Includes the polished binary.
+full = ["bin", "chat", "core", "metrics", "sync-agent-turns", "mutations", "history", "artifacts", "worktrees", "jobs", "tracing-json"]
 
 [dependencies]
 claude-wrapper = { path = "../claude-wrapper", default-features = false, features = ["async", "json"] }
@@ -99,6 +109,18 @@ axum = "0.8"
 tower = "0.5"
 schemars = "1"
 toml = "0.9"
+
+# Bin-only deps; pulled in by the `bin` feature.
+clap = { version = "4", features = ["derive"], optional = true }
+anyhow = { version = "1", optional = true }
+
+# The polished bin. Requires the `bin` feature (which pulls clap +
+# anyhow) and `full` (which turns on every surface). Library
+# consumers who only want the lib don't pay for clap.
+[[bin]]
+name = "claude-server"
+path = "src/bin/claude-server.rs"
+required-features = ["bin", "full"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -50,6 +50,13 @@ mutations = []
 # claude_wrapper::history; no new deps.
 history = []
 
+# Read-only access to user-level agent definitions on disk
+# (`~/.claude/agents/<name>.md`). Tools: agent_list, agent_get.
+# Resources: claude://agents, claude://agents/{name}. Built on
+# claude_wrapper::artifacts; no new deps. Mutations (write/delete)
+# come in a follow-up under the existing `mutations` feature.
+artifacts = []
+
 # Sync (blocking) variants of agent-turn tools: chat_send_sync,
 # chat_send_stream_sync, claude_query_sync. On by default for
 # ergonomic builds. `default-features = false` drops them entirely
@@ -60,7 +67,7 @@ sync-agent-turns = []
 # Convenience profile: the kitchen sink for Finestra-class
 # deployments that want the full surface including mutations
 # and historical session reads.
-full = ["chat", "core", "metrics", "sync-agent-turns", "mutations", "history"]
+full = ["chat", "core", "metrics", "sync-agent-turns", "mutations", "history", "artifacts"]
 
 [dependencies]
 claude-wrapper = { path = "../claude-wrapper", default-features = false, features = ["async", "json"] }

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -57,6 +57,12 @@ history = []
 # come in a follow-up under the existing `mutations` feature.
 artifacts = []
 
+# Read-only git worktree introspection. Tools: worktree_list.
+# Resources: claude://worktrees. Built on claude_wrapper::worktrees;
+# no new deps. Useful for hosts orchestrating chat_open(worktree=true)
+# to inspect the worktrees they've spawned.
+worktrees = []
+
 # Sync (blocking) variants of agent-turn tools: chat_send_sync,
 # chat_send_stream_sync, claude_query_sync. On by default for
 # ergonomic builds. `default-features = false` drops them entirely
@@ -67,7 +73,7 @@ sync-agent-turns = []
 # Convenience profile: the kitchen sink for Finestra-class
 # deployments that want the full surface including mutations
 # and historical session reads.
-full = ["chat", "core", "metrics", "sync-agent-turns", "mutations", "history", "artifacts"]
+full = ["chat", "core", "metrics", "sync-agent-turns", "mutations", "history", "artifacts", "worktrees"]
 
 [dependencies]
 claude-wrapper = { path = "../claude-wrapper", default-features = false, features = ["async", "json"] }

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "claude-server"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.90.0"
+authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/joshrotenberg/claude-wrapper"
+description = "MCP server layer over claude-wrapper"
+publish = false
+
+[dependencies]
+claude-wrapper = { path = "../claude-wrapper", default-features = false, features = ["async", "json"] }
+tokio = { version = "1", features = ["process", "time", "io-util", "macros", "rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tower-mcp = "0.10"
+schemars = "1"
+toml = "0.9"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }
+tower-mcp = { version = "0.10", features = ["testing"] }
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"
+
+# The canonical "raw, no-frills MCP server CLI". Lives in examples/
+# because the library is the product and the binary is just one
+# demonstration of how to wire it. `cargo run --example server`.
+[[example]]
+name = "server"
+path = "examples/server.rs"

--- a/crates/claude-server/Cargo.toml
+++ b/crates/claude-server/Cargo.toml
@@ -26,14 +26,18 @@ serde_json = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tower-mcp = "0.10"
+tower-mcp = { version = "0.10", features = ["http"] }
+axum = "0.8"
+tower = "0.5"
 schemars = "1"
 toml = "0.9"
 
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }
-tower-mcp = { version = "0.10", features = ["testing"] }
+tower-mcp = { version = "0.10", features = ["testing", "http"] }
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 

--- a/crates/claude-server/examples/embed_chat.rs
+++ b/crates/claude-server/examples/embed_chat.rs
@@ -1,0 +1,99 @@
+//! Embedded-mode demo: chat lifecycle via direct library calls.
+//!
+//! No socket. No transport. No subprocess of `claude-server`. Just
+//! `build_router(...)` + an in-process JSON-RPC dispatcher
+//! (`TestClient`) calling tools directly.
+//!
+//! This is the shape consuming Rust apps would adopt to embed
+//! claude-server -- a CLI subcommand backend, an Elixir NIF
+//! sidecar, an agent runtime that wants the chat machinery
+//! without standing up another process.
+//!
+//! Note: this DOES spawn a real `claude` subprocess (the duplex
+//! child held open by the chat). It runs against your real
+//! `~/.claude/` config and bills your account. We pin haiku to
+//! keep cost negligible (this run typically costs <$0.05).
+//!
+//! Run with: `cargo run --example embed_chat`
+
+use claude_server::{ServerConfig, build_router};
+use tower_mcp::TestClient;
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Step 1: build the router. This is the only library API call
+    // that matters -- everything below is just standard MCP
+    // dispatching.
+    let router = build_router(ServerConfig::default())?;
+
+    // Step 2: in-process dispatcher. No JSON-RPC over stdio /
+    // HTTP -- the request goes straight into the router's tower
+    // Service.
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // Step 3: open a chat. async-by-default returns immediately
+    // with a chat_id we use for subsequent calls.
+    println!("opening chat...");
+    let open = client
+        .call_tool(
+            "chat_open",
+            serde_json::json!({
+                "model": "haiku",
+                "max_cost_usd": 0.5,
+                "system_prompt": "You're being driven by an embedded Rust example. Be brief.",
+            }),
+        )
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text())?;
+    let chat_id = body["chat_id"].as_str().expect("chat_id").to_string();
+    println!("chat_id: {chat_id}");
+
+    // Step 4: fire a turn (async). chat_send returns a turn_id
+    // immediately; the turn runs in the background.
+    println!("firing turn (async)...");
+    let fire = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id,
+                "prompt": "In one sentence, what's the deal with embedded MCP servers?",
+            }),
+        )
+        .await;
+    let fire_body: serde_json::Value = serde_json::from_str(&fire.all_text())?;
+    let turn_id = fire_body["turn_id"].as_str().expect("turn_id").to_string();
+    println!("turn_id: {turn_id}");
+
+    // Step 5: block until the turn settles (or timeout).
+    println!("waiting for turn to settle...");
+    let waited = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id, "timeout_secs": 60.0}),
+        )
+        .await;
+    let wbody: serde_json::Value = serde_json::from_str(&waited.all_text())?;
+    println!("status: {}", wbody["status"].as_str().unwrap_or("unknown"));
+    if let Some(text) = wbody["result"]["result"].as_str() {
+        println!("\nassistant: {text}\n");
+    }
+    if let Some(cost) = wbody["result"]["turn_cost_usd"].as_f64() {
+        println!("turn cost: ${cost:.4}");
+    }
+
+    // Step 6: peek at process metrics. We've fired one turn; the
+    // counters should reflect it.
+    let metrics = client
+        .call_tool("metrics_summary", serde_json::json!({}))
+        .await;
+    println!("\nmetrics: {}", metrics.all_text());
+
+    // Step 7: clean up.
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+    println!("\nchat closed.");
+
+    Ok(())
+}

--- a/crates/claude-server/examples/embed_parallel_projects.rs
+++ b/crates/claude-server/examples/embed_parallel_projects.rs
@@ -1,0 +1,131 @@
+//! Embedded demo: one server, two chats, two projects, in parallel.
+//!
+//! Demonstrates the "talk to another project" pattern with
+//! `chat_open(working_dir: ...)`. A single `claude-server` (here
+//! embedded directly, no transport) hosts two chats in different
+//! project roots simultaneously. The chats share nothing -- each
+//! gets its own duplex `claude` subprocess in its own working
+//! directory -- but they're coordinated through one library
+//! instance.
+//!
+//! Use case: a CLI / agent runtime that operates across multiple
+//! project trees from a single entrypoint without standing up a
+//! separate claude-server per project.
+//!
+//! Run with: `cargo run --example embed_parallel_projects`
+//!
+//! Spawns two real `claude` subprocesses (haiku, ~$0.05 each).
+
+use claude_server::{ServerConfig, build_router};
+use tower_mcp::TestClient;
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let router = build_router(ServerConfig::default())?;
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // Two project roots: this repo + the parent directory.
+    // Substitute any two directories you care about.
+    let cwd = std::env::current_dir()?;
+    let parent = cwd.parent().unwrap_or(&cwd).to_path_buf();
+
+    println!("opening chat A in {}", cwd.display());
+    let chat_a = open_chat(&mut client, &cwd, "haiku").await?;
+    println!("opening chat B in {}", parent.display());
+    let chat_b = open_chat(&mut client, &parent, "haiku").await?;
+
+    // Fire two turns back-to-back. async-by-default means both
+    // return turn_ids immediately and run in parallel -- different
+    // chats don't serialize.
+    println!("\nfiring two turns in parallel...");
+    let fire_a = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_a,
+                "prompt": "What's your current working directory? Reply in one short sentence.",
+            }),
+        )
+        .await;
+    let fire_b = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_b,
+                "prompt": "What's your current working directory? Reply in one short sentence.",
+            }),
+        )
+        .await;
+    let turn_a = serde_json::from_str::<serde_json::Value>(&fire_a.all_text())?["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let turn_b = serde_json::from_str::<serde_json::Value>(&fire_b.all_text())?["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Both chats run in parallel on the server side -- different
+    // duplex subprocesses, no shared state. Waits are sequential
+    // here for demo simplicity (TestClient::call_tool needs &mut),
+    // but the actual work is concurrent: by the time we get to
+    // wait B, it's either already done or about to be.
+    println!("waiting for both turns to settle...");
+    let settled_a = wait_for(&mut client, &turn_a).await?;
+    let settled_b = wait_for(&mut client, &turn_b).await?;
+
+    println!(
+        "\nchat A ({}):\n  {}",
+        cwd.display(),
+        settled_a["result"]["result"].as_str().unwrap_or("")
+    );
+    println!(
+        "\nchat B ({}):\n  {}",
+        parent.display(),
+        settled_b["result"]["result"].as_str().unwrap_or("")
+    );
+
+    // Clean up.
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_a}))
+        .await;
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_b}))
+        .await;
+
+    Ok(())
+}
+
+async fn open_chat(
+    client: &mut TestClient,
+    working_dir: &std::path::Path,
+    model: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let result = client
+        .call_tool(
+            "chat_open",
+            serde_json::json!({
+                "model": model,
+                "working_dir": working_dir,
+                "max_cost_usd": 0.5,
+                "system_prompt": "You're being driven by an embedded Rust example. Be brief.",
+            }),
+        )
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&result.all_text())?;
+    Ok(body["chat_id"].as_str().expect("chat_id").to_string())
+}
+
+async fn wait_for(
+    client: &mut TestClient,
+    turn_id: &str,
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let result = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id, "timeout_secs": 60.0}),
+        )
+        .await;
+    Ok(serde_json::from_str(&result.all_text())?)
+}

--- a/crates/claude-server/examples/server.rs
+++ b/crates/claude-server/examples/server.rs
@@ -15,8 +15,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use claude_server::{
-    ServerConfig, build_router, build_router_with_notification_sender, notification_channel,
-    registered_tools,
+    ServerConfig, build_router_with_notification_sender, notification_channel, registered_tools,
 };
 use tower::Layer;
 use tower_mcp::HttpTransport;
@@ -78,14 +77,16 @@ async fn main() -> Result<()> {
             transport.run().await.context("stdio transport")?;
         }
         Cmd::ServeHttp { bind, bearer } => {
-            // HttpTransport currently creates its own notification
-            // channel and overrides the router's, so chat workers that
-            // fire `claude://chats/{id}` updates against state's channel
-            // won't reach HTTP subscribers today. Stdio works; HTTP
-            // subscription support needs an upstream tower-mcp change
-            // to accept an external sender.
-            let router = build_router(cfg).context("build_router")?;
-            let mut app = HttpTransport::new(router)
+            // Notification-aware construction, mirroring stdio. Chat
+            // workers fire `claude://chats/{id}` resource updates
+            // through `notif_tx`; the HTTP transport drains `notif_rx`
+            // and fans the items out to every live SSE session.
+            // Requires tower-mcp >= 0.10.1
+            // (HttpTransport::with_notifications).
+            let (notif_tx, notif_rx) = notification_channel(256);
+            let router = build_router_with_notification_sender(cfg, notif_tx)
+                .context("build_router_with_notification_sender")?;
+            let mut app = HttpTransport::with_notifications(router, notif_rx)
                 .layer(McpTracingLayer::new())
                 .into_router();
             if let Some(token) = bearer {

--- a/crates/claude-server/examples/server.rs
+++ b/crates/claude-server/examples/server.rs
@@ -1,162 +1,39 @@
-//! The canonical "raw, no-frills MCP server CLI" for claude-server.
+//! Truly-minimal `claude-server` integration recipe.
 //!
-//! This example exists to demonstrate the library API in its
-//! simplest deployable shape. The library does all the work; the
-//! example is just `clap + tokio + one library call + a transport`.
-//! Copy this file into your own crate and adapt as needed.
+//! ~50 lines. Build the router, hand it to a stdio transport, run.
+//! No subcommands, no flags, no polish. Copy this into your own
+//! crate as a starting point when you want to embed.
 //!
-//! Run with `cargo run --example server -- serve` (or `tools` /
-//! `help`).
+//! For the polished CLI with subcommands (`tools`, `doctor`,
+//! `config`, `install-mcp-config`, `serve-http`), bind safety, log
+//! controls, and runtime surface gates, see the `claude-server`
+//! binary (`src/bin/claude-server.rs`) instead -- this example is
+//! the foundation it grew from.
+//!
+//! Run with: `cargo run --example server --features full`
 
-use std::net::SocketAddr;
-use std::path::PathBuf;
-
-use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
-
-use claude_server::{
-    ServerConfig, build_router_with_notification_sender, notification_channel, registered_tools,
-};
+use claude_server::{ServerConfig, build_router_with_notification_sender, notification_channel};
 use tower::Layer;
-use tower_mcp::HttpTransport;
 use tower_mcp::middleware::McpTracingLayer;
 use tower_mcp::transport::stdio::GenericStdioTransport;
 
-/// Raw MCP server CLI for `claude-server`. Wires the library router
-/// to a transport. Reach for this when you want a working binary;
-/// reach for [`claude_server::build_router`] directly when you want
-/// to embed.
-#[derive(Debug, Parser)]
-#[command(name = "claude-server", version, about)]
-struct Cli {
-    /// Path to a TOML ServerConfig. Defaults are used if omitted.
-    #[arg(long, short = 'c', global = true)]
-    config: Option<PathBuf>,
-
-    #[command(subcommand)]
-    command: Option<Cmd>,
-}
-
-#[derive(Debug, Subcommand)]
-enum Cmd {
-    /// Serve over stdio (default).
-    Serve,
-    /// Serve over HTTP via axum. Localhost-only by default.
-    ServeHttp {
-        /// Bind address. Defaults to 127.0.0.1:7800. Be intentional
-        /// before binding to anything other than localhost.
-        #[arg(long, default_value = "127.0.0.1:7800")]
-        bind: SocketAddr,
-        /// Optional bearer token. When set, every request must
-        /// include `Authorization: Bearer <token>` or it gets a 401.
-        #[arg(long)]
-        bearer: Option<String>,
-    },
-    /// Print the registered tool surface as JSON and exit.
-    Tools,
-}
-
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
-async fn main() -> Result<()> {
-    init_tracing();
-
-    let cli = Cli::parse();
-    let cfg = load_config(cli.config).await?;
-
-    match cli.command.unwrap_or(Cmd::Serve) {
-        Cmd::Serve => {
-            // Notification-aware construction: we own the channel, share
-            // its sender with both the library (so chat workers fire
-            // claude://chats/{id} resource updates) and the router; the
-            // receiver feeds the stdio transport.
-            let (notif_tx, notif_rx) = notification_channel(256);
-            let router = build_router_with_notification_sender(cfg, notif_tx)
-                .context("build_router_with_notification_sender")?;
-            let service = McpTracingLayer::new().layer(router);
-            let mut transport = GenericStdioTransport::with_notifications(service, notif_rx);
-            transport.run().await.context("stdio transport")?;
-        }
-        Cmd::ServeHttp { bind, bearer } => {
-            // Notification-aware construction, mirroring stdio. Chat
-            // workers fire `claude://chats/{id}` resource updates
-            // through `notif_tx`; the HTTP transport drains `notif_rx`
-            // and fans the items out to every live SSE session.
-            // Requires tower-mcp >= 0.10.1
-            // (HttpTransport::with_notifications).
-            let (notif_tx, notif_rx) = notification_channel(256);
-            let router = build_router_with_notification_sender(cfg, notif_tx)
-                .context("build_router_with_notification_sender")?;
-            let mut app = HttpTransport::with_notifications(router, notif_rx)
-                .layer(McpTracingLayer::new())
-                .into_router();
-            if let Some(token) = bearer {
-                use axum::middleware;
-                app = app.layer(middleware::from_fn(move |req, next| {
-                    let token = token.clone();
-                    bearer_guard(req, next, token)
-                }));
-                tracing::info!("bearer auth enabled");
-            }
-            let listener = tokio::net::TcpListener::bind(bind)
-                .await
-                .with_context(|| format!("binding {bind}"))?;
-            tracing::info!(%bind, "claude-server listening on http");
-            axum::serve(listener, app).await.context("axum::serve")?;
-        }
-        Cmd::Tools => {
-            let tools = registered_tools(cfg).context("registered_tools")?;
-            let body: Vec<_> = tools
-                .into_iter()
-                .map(|t| {
-                    serde_json::json!({
-                        "name": t.name,
-                        "description": t.description,
-                    })
-                })
-                .collect();
-            println!("{}", serde_json::to_string_pretty(&body)?);
-        }
-    }
-    Ok(())
-}
-
-async fn load_config(path: Option<PathBuf>) -> Result<ServerConfig> {
-    let Some(p) = path else {
-        return Ok(ServerConfig::default());
-    };
-    let text = tokio::fs::read_to_string(&p)
-        .await
-        .with_context(|| format!("reading {}", p.display()))?;
-    toml::from_str(&text).with_context(|| format!("parsing {}", p.display()))
-}
-
-fn init_tracing() {
-    use tracing_subscriber::{EnvFilter, fmt};
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new("info,claude_server=info,tower_mcp=info"));
-    let _ = fmt()
-        .with_env_filter(filter)
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // tracing → stderr so stdout stays clean for MCP framing
+    tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_target(false)
         .with_ansi(false)
-        .try_init();
-}
+        .try_init()
+        .ok();
 
-/// Reject any request whose `Authorization: Bearer <token>` doesn't
-/// match the configured token. Constant-time string compare would be
-/// nicer but we're not handling untrusted input at scale here.
-async fn bearer_guard(
-    req: axum::extract::Request,
-    next: axum::middleware::Next,
-    expected: String,
-) -> Result<axum::response::Response, axum::http::StatusCode> {
-    let header = req
-        .headers()
-        .get(axum::http::header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.strip_prefix("Bearer "));
-    match header {
-        Some(t) if t == expected => Ok(next.run(req).await),
-        _ => Err(axum::http::StatusCode::UNAUTHORIZED),
-    }
+    // Notification-aware construction: chat workers fire
+    // `claude://chats/{id}` resource updates through `notif_tx`;
+    // the stdio transport drains `notif_rx`.
+    let (notif_tx, notif_rx) = notification_channel(256);
+    let router = build_router_with_notification_sender(ServerConfig::default(), notif_tx)?;
+    let service = McpTracingLayer::new().layer(router);
+    let mut transport = GenericStdioTransport::with_notifications(service, notif_rx);
+    transport.run().await?;
+    Ok(())
 }

--- a/crates/claude-server/examples/server.rs
+++ b/crates/claude-server/examples/server.rs
@@ -14,9 +14,14 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
-use claude_server::{ServerConfig, build_router, registered_tools};
+use claude_server::{
+    ServerConfig, build_router, build_router_with_notification_sender, notification_channel,
+    registered_tools,
+};
+use tower::Layer;
+use tower_mcp::HttpTransport;
 use tower_mcp::middleware::McpTracingLayer;
-use tower_mcp::{HttpTransport, StdioTransport};
+use tower_mcp::transport::stdio::GenericStdioTransport;
 
 /// Raw MCP server CLI for `claude-server`. Wires the library router
 /// to a transport. Reach for this when you want a working binary;
@@ -61,11 +66,24 @@ async fn main() -> Result<()> {
 
     match cli.command.unwrap_or(Cmd::Serve) {
         Cmd::Serve => {
-            let router = build_router(cfg).context("build_router")?;
-            let mut transport = StdioTransport::new(router).layer(McpTracingLayer::new());
+            // Notification-aware construction: we own the channel, share
+            // its sender with both the library (so chat workers fire
+            // claude://chats/{id} resource updates) and the router; the
+            // receiver feeds the stdio transport.
+            let (notif_tx, notif_rx) = notification_channel(256);
+            let router = build_router_with_notification_sender(cfg, notif_tx)
+                .context("build_router_with_notification_sender")?;
+            let service = McpTracingLayer::new().layer(router);
+            let mut transport = GenericStdioTransport::with_notifications(service, notif_rx);
             transport.run().await.context("stdio transport")?;
         }
         Cmd::ServeHttp { bind, bearer } => {
+            // HttpTransport currently creates its own notification
+            // channel and overrides the router's, so chat workers that
+            // fire `claude://chats/{id}` updates against state's channel
+            // won't reach HTTP subscribers today. Stdio works; HTTP
+            // subscription support needs an upstream tower-mcp change
+            // to accept an external sender.
             let router = build_router(cfg).context("build_router")?;
             let mut app = HttpTransport::new(router)
                 .layer(McpTracingLayer::new())

--- a/crates/claude-server/examples/server.rs
+++ b/crates/claude-server/examples/server.rs
@@ -8,13 +8,14 @@
 //! Run with `cargo run --example server -- serve` (or `tools` /
 //! `help`).
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use claude_server::{ServerConfig, build_router, registered_tools};
-use tower_mcp::StdioTransport;
+use tower_mcp::{HttpTransport, StdioTransport};
 
 /// Raw MCP server CLI for `claude-server`. Wires the library router
 /// to a transport. Reach for this when you want a working binary;
@@ -35,6 +36,17 @@ struct Cli {
 enum Cmd {
     /// Serve over stdio (default).
     Serve,
+    /// Serve over HTTP via axum. Localhost-only by default.
+    ServeHttp {
+        /// Bind address. Defaults to 127.0.0.1:7800. Be intentional
+        /// before binding to anything other than localhost.
+        #[arg(long, default_value = "127.0.0.1:7800")]
+        bind: SocketAddr,
+        /// Optional bearer token. When set, every request must
+        /// include `Authorization: Bearer <token>` or it gets a 401.
+        #[arg(long)]
+        bearer: Option<String>,
+    },
     /// Print the registered tool surface as JSON and exit.
     Tools,
 }
@@ -51,6 +63,23 @@ async fn main() -> Result<()> {
             let router = build_router(cfg).context("build_router")?;
             let mut transport = StdioTransport::new(router);
             transport.run().await.context("stdio transport")?;
+        }
+        Cmd::ServeHttp { bind, bearer } => {
+            let router = build_router(cfg).context("build_router")?;
+            let mut app = HttpTransport::new(router).into_router();
+            if let Some(token) = bearer {
+                use axum::middleware;
+                app = app.layer(middleware::from_fn(move |req, next| {
+                    let token = token.clone();
+                    bearer_guard(req, next, token)
+                }));
+                tracing::info!("bearer auth enabled");
+            }
+            let listener = tokio::net::TcpListener::bind(bind)
+                .await
+                .with_context(|| format!("binding {bind}"))?;
+            tracing::info!(%bind, "claude-server listening on http");
+            axum::serve(listener, app).await.context("axum::serve")?;
         }
         Cmd::Tools => {
             let tools = registered_tools(cfg).context("registered_tools")?;
@@ -89,4 +118,23 @@ fn init_tracing() {
         .with_target(false)
         .with_ansi(false)
         .try_init();
+}
+
+/// Reject any request whose `Authorization: Bearer <token>` doesn't
+/// match the configured token. Constant-time string compare would be
+/// nicer but we're not handling untrusted input at scale here.
+async fn bearer_guard(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+    expected: String,
+) -> Result<axum::response::Response, axum::http::StatusCode> {
+    let header = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "));
+    match header {
+        Some(t) if t == expected => Ok(next.run(req).await),
+        _ => Err(axum::http::StatusCode::UNAUTHORIZED),
+    }
 }

--- a/crates/claude-server/examples/server.rs
+++ b/crates/claude-server/examples/server.rs
@@ -1,0 +1,92 @@
+//! The canonical "raw, no-frills MCP server CLI" for claude-server.
+//!
+//! This example exists to demonstrate the library API in its
+//! simplest deployable shape. The library does all the work; the
+//! example is just `clap + tokio + one library call + a transport`.
+//! Copy this file into your own crate and adapt as needed.
+//!
+//! Run with `cargo run --example server -- serve` (or `tools` /
+//! `help`).
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+
+use claude_server::{ServerConfig, build_router, registered_tools};
+use tower_mcp::StdioTransport;
+
+/// Raw MCP server CLI for `claude-server`. Wires the library router
+/// to a transport. Reach for this when you want a working binary;
+/// reach for [`claude_server::build_router`] directly when you want
+/// to embed.
+#[derive(Debug, Parser)]
+#[command(name = "claude-server", version, about)]
+struct Cli {
+    /// Path to a TOML ServerConfig. Defaults are used if omitted.
+    #[arg(long, short = 'c', global = true)]
+    config: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: Option<Cmd>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Cmd {
+    /// Serve over stdio (default).
+    Serve,
+    /// Print the registered tool surface as JSON and exit.
+    Tools,
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() -> Result<()> {
+    init_tracing();
+
+    let cli = Cli::parse();
+    let cfg = load_config(cli.config).await?;
+
+    match cli.command.unwrap_or(Cmd::Serve) {
+        Cmd::Serve => {
+            let router = build_router(cfg).context("build_router")?;
+            let mut transport = StdioTransport::new(router);
+            transport.run().await.context("stdio transport")?;
+        }
+        Cmd::Tools => {
+            let tools = registered_tools(cfg).context("registered_tools")?;
+            let body: Vec<_> = tools
+                .into_iter()
+                .map(|t| {
+                    serde_json::json!({
+                        "name": t.name,
+                        "description": t.description,
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&body)?);
+        }
+    }
+    Ok(())
+}
+
+async fn load_config(path: Option<PathBuf>) -> Result<ServerConfig> {
+    let Some(p) = path else {
+        return Ok(ServerConfig::default());
+    };
+    let text = tokio::fs::read_to_string(&p)
+        .await
+        .with_context(|| format!("reading {}", p.display()))?;
+    toml::from_str(&text).with_context(|| format!("parsing {}", p.display()))
+}
+
+fn init_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt};
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,claude_server=info"));
+    let _ = fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .with_ansi(false)
+        .try_init();
+}

--- a/crates/claude-server/examples/server.rs
+++ b/crates/claude-server/examples/server.rs
@@ -15,6 +15,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use claude_server::{ServerConfig, build_router, registered_tools};
+use tower_mcp::middleware::McpTracingLayer;
 use tower_mcp::{HttpTransport, StdioTransport};
 
 /// Raw MCP server CLI for `claude-server`. Wires the library router
@@ -61,12 +62,14 @@ async fn main() -> Result<()> {
     match cli.command.unwrap_or(Cmd::Serve) {
         Cmd::Serve => {
             let router = build_router(cfg).context("build_router")?;
-            let mut transport = StdioTransport::new(router);
+            let mut transport = StdioTransport::new(router).layer(McpTracingLayer::new());
             transport.run().await.context("stdio transport")?;
         }
         Cmd::ServeHttp { bind, bearer } => {
             let router = build_router(cfg).context("build_router")?;
-            let mut app = HttpTransport::new(router).into_router();
+            let mut app = HttpTransport::new(router)
+                .layer(McpTracingLayer::new())
+                .into_router();
             if let Some(token) = bearer {
                 use axum::middleware;
                 app = app.layer(middleware::from_fn(move |req, next| {
@@ -111,7 +114,7 @@ async fn load_config(path: Option<PathBuf>) -> Result<ServerConfig> {
 fn init_tracing() {
     use tracing_subscriber::{EnvFilter, fmt};
     let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new("info,claude_server=info"));
+        .unwrap_or_else(|_| EnvFilter::new("info,claude_server=info,tower_mcp=info"));
     let _ = fmt()
         .with_env_filter(filter)
         .with_writer(std::io::stderr)

--- a/crates/claude-server/src/artifacts.rs
+++ b/crates/claude-server/src/artifacts.rs
@@ -173,9 +173,7 @@ fn agents_root(state: &ServerState) -> claude_wrapper::error::Result<AgentsRoot>
     }
 }
 
-fn internal(e: impl std::fmt::Display) -> tower_mcp::Error {
-    tower_mcp::Error::internal(e.to_string())
-}
+use crate::errors::from_wrapper as internal;
 
 fn agent_summary_to_json(a: &claude_wrapper::artifacts::AgentSummary) -> serde_json::Value {
     json!({

--- a/crates/claude-server/src/artifacts.rs
+++ b/crates/claude-server/src/artifacts.rs
@@ -1,23 +1,28 @@
-//! Read-only access to Claude Code's user-level **agent** definitions
-//! (`~/.claude/agents/<stem>.md`), exposed as MCP tools and
-//! resources. Backed by [`claude_wrapper::artifacts::AgentsRoot`].
+//! User-level **agent** definitions (`~/.claude/agents/<stem>.md`)
+//! exposed as MCP tools and resources. Backed by
+//! [`claude_wrapper::artifacts::AgentsRoot`].
 //!
-//! Tools:
+//! Read tools (always-on under the `artifacts` feature):
 //! - `agent_list` -- enumerate every `*.md` agent at the configured
 //!   root. Returns summary metadata only.
 //! - `agent_get { file_stem }` -- one agent's full record including
 //!   the prompt body and any unknown frontmatter keys.
+//!
+//! Mutating tools (gated by `artifacts` + `mutations` Cargo features
+//! AND `policy.allow_mutations` at runtime):
+//! - `agent_write { file_stem, name?, description?, tools[], model?, body, extra{}, if_not_exists? }`
+//!   -- create or overwrite (upsert by default; `if_not_exists: true`
+//!   makes it create-only).
+//! - `agent_delete { file_stem }` -- remove the file.
 //!
 //! Resources:
 //! - `claude://agents` -- same shape as `agent_list`.
 //!
 //! Resource templates:
 //! - `claude://agents/{file_stem}` -- one agent's full record.
-//!
-//! Mutations (write / delete) live elsewhere -- they are double-gated
-//! by the `mutations` Cargo feature plus `policy.allow_mutations`
-//! and are not yet implemented.
 
+#[cfg(feature = "mutations")]
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 use schemars::JsonSchema;
@@ -29,13 +34,22 @@ use tower_mcp::{
     CallToolResult, Resource, ResourceBuilder, ResourceTemplateBuilder, Tool, ToolBuilder,
 };
 
+#[cfg(feature = "mutations")]
+use claude_wrapper::artifacts::AgentWriteInput;
 use claude_wrapper::artifacts::AgentsRoot;
 
 use crate::state::ServerState;
 
-/// Build the artifacts-feature tool list.
+/// Build the artifacts-feature tool list (read-only).
 pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
     vec![tool_agent_list(state), tool_agent_get(state)]
+}
+
+/// Build the artifacts-feature mutating tool list. Caller is
+/// responsible for runtime gating on `policy.allow_mutations`.
+#[cfg(feature = "mutations")]
+pub(crate) fn mutating_tools(state: &ServerState) -> Vec<Tool> {
+    vec![tool_agent_write(state), tool_agent_delete(state)]
 }
 
 /// Build the artifacts-feature resource list.
@@ -107,6 +121,111 @@ fn tool_agent_get(state: &ServerState) -> Tool {
                 let root = agents_root(&state).map_err(internal)?;
                 let agent = root.get(&input.file_stem).map_err(internal)?;
                 Ok(CallToolResult::json(agent_to_json(&agent)))
+            }
+        })
+        .build()
+}
+
+// -- tool_agent_write (mutating) ------------------------------------
+
+#[cfg(feature = "mutations")]
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AgentWriteInputJson {
+    /// Filename stem (the basename of `<stem>.md` under the agents
+    /// root). Must not be empty, `.`, `..`, or contain `/`, `\`, or
+    /// NUL bytes.
+    file_stem: String,
+    /// Frontmatter `name`. Defaults to `file_stem` if absent.
+    #[serde(default)]
+    name: Option<String>,
+    /// Frontmatter `description`. Omitted when None.
+    #[serde(default)]
+    description: Option<String>,
+    /// Frontmatter `tools` as a list; rendered comma-joined. Empty
+    /// list omits the key entirely.
+    #[serde(default)]
+    tools: Vec<String>,
+    /// Frontmatter `model`. Omitted when None.
+    #[serde(default)]
+    model: Option<String>,
+    /// Body of the agent prompt. Trimmed of surrounding whitespace
+    /// before write.
+    body: String,
+    /// Additional frontmatter key/value pairs preserved verbatim.
+    #[serde(default)]
+    extra: BTreeMap<String, String>,
+    /// When true, fail if the agent already exists. Default false
+    /// (upsert: create or overwrite).
+    #[serde(default)]
+    if_not_exists: bool,
+}
+
+#[cfg(feature = "mutations")]
+fn tool_agent_write(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("agent_write")
+        .description(
+            "Create or overwrite an agent at `<file_stem>.md` under the \
+             configured agents root. Atomic write (tempfile + rename). \
+             Pass `if_not_exists: true` for create-only semantics. \
+             Required by both `mutations` Cargo feature and runtime \
+             `policy.allow_mutations`. Path-traversal validated.",
+        )
+        .handler(move |input: AgentWriteInputJson| {
+            let state = state.clone();
+            async move {
+                let root = agents_root(&state).map_err(internal)?;
+                let stem = input.file_stem.clone();
+                let payload = AgentWriteInput {
+                    name: input.name,
+                    description: input.description,
+                    tools: input.tools,
+                    model: input.model,
+                    body: input.body,
+                    extra: input.extra,
+                };
+                if input.if_not_exists {
+                    root.write_new(&stem, payload).map_err(internal)?;
+                } else {
+                    root.write(&stem, payload).map_err(internal)?;
+                }
+                Ok(CallToolResult::json(json!({
+                    "file_stem": stem,
+                    "status": "written",
+                })))
+            }
+        })
+        .build()
+}
+
+// -- tool_agent_delete (mutating) -----------------------------------
+
+#[cfg(feature = "mutations")]
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AgentDeleteInput {
+    /// Filename stem to remove (`<stem>.md` under the agents root).
+    file_stem: String,
+}
+
+#[cfg(feature = "mutations")]
+fn tool_agent_delete(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("agent_delete")
+        .description(
+            "Remove the `<file_stem>.md` agent. Errors if the file \
+             doesn't exist. Required by both `mutations` Cargo feature \
+             and runtime `policy.allow_mutations`. Path-traversal \
+             validated.",
+        )
+        .handler(move |input: AgentDeleteInput| {
+            let state = state.clone();
+            async move {
+                let root = agents_root(&state).map_err(internal)?;
+                root.delete(&input.file_stem).map_err(internal)?;
+                Ok(CallToolResult::json(json!({
+                    "file_stem": input.file_stem,
+                    "status": "deleted",
+                })))
             }
         })
         .build()

--- a/crates/claude-server/src/artifacts.rs
+++ b/crates/claude-server/src/artifacts.rs
@@ -1,0 +1,203 @@
+//! Read-only access to Claude Code's user-level **agent** definitions
+//! (`~/.claude/agents/<stem>.md`), exposed as MCP tools and
+//! resources. Backed by [`claude_wrapper::artifacts::AgentsRoot`].
+//!
+//! Tools:
+//! - `agent_list` -- enumerate every `*.md` agent at the configured
+//!   root. Returns summary metadata only.
+//! - `agent_get { file_stem }` -- one agent's full record including
+//!   the prompt body and any unknown frontmatter keys.
+//!
+//! Resources:
+//! - `claude://agents` -- same shape as `agent_list`.
+//!
+//! Resource templates:
+//! - `claude://agents/{file_stem}` -- one agent's full record.
+//!
+//! Mutations (write / delete) live elsewhere -- they are double-gated
+//! by the `mutations` Cargo feature plus `policy.allow_mutations`
+//! and are not yet implemented.
+
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use tower_mcp::protocol::ReadResourceResult;
+use tower_mcp::resource::ResourceTemplate;
+use tower_mcp::{
+    CallToolResult, Resource, ResourceBuilder, ResourceTemplateBuilder, Tool, ToolBuilder,
+};
+
+use claude_wrapper::artifacts::AgentsRoot;
+
+use crate::state::ServerState;
+
+/// Build the artifacts-feature tool list.
+pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
+    vec![tool_agent_list(state), tool_agent_get(state)]
+}
+
+/// Build the artifacts-feature resource list.
+pub(crate) fn resources(state: &ServerState) -> Vec<Resource> {
+    vec![resource_agents(state)]
+}
+
+/// Build the artifacts-feature resource templates.
+pub(crate) fn templates(state: &ServerState) -> Vec<ResourceTemplate> {
+    vec![template_agent_detail(state)]
+}
+
+// -- tool_agent_list -------------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct NoArgs {}
+
+fn tool_agent_list(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("agent_list")
+        .description(
+            "Enumerate user-level agents under `~/.claude/agents/<stem>.md`. \
+             Each entry: `file_stem` (canonical lookup handle), `name` \
+             (frontmatter or stem fallback), `description`, `tools` \
+             (parsed comma-list), `model`, `file_path`, `size_bytes`. \
+             Read-only.",
+        )
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let state = state.clone();
+            async move {
+                let root = agents_root(&state).map_err(internal)?;
+                let agents = root.list().map_err(internal)?;
+                Ok(CallToolResult::json(json!({
+                    "agents": agents
+                        .iter()
+                        .map(agent_summary_to_json)
+                        .collect::<Vec<_>>(),
+                })))
+            }
+        })
+        .build()
+}
+
+// -- tool_agent_get --------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AgentGetInput {
+    /// Filename stem (the basename of `<stem>.md` under the agents
+    /// root). This is the canonical handle, not the frontmatter
+    /// `name` -- those can diverge.
+    file_stem: String,
+}
+
+fn tool_agent_get(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("agent_get")
+        .description(
+            "Read one agent's full record by `file_stem`. Returns the \
+             frontmatter metadata plus the prompt body and any unknown \
+             frontmatter keys (in `extra`). Errors if no agent with \
+             that stem exists under the configured agents root. \
+             Read-only.",
+        )
+        .read_only()
+        .handler(move |input: AgentGetInput| {
+            let state = state.clone();
+            async move {
+                let root = agents_root(&state).map_err(internal)?;
+                let agent = root.get(&input.file_stem).map_err(internal)?;
+                Ok(CallToolResult::json(agent_to_json(&agent)))
+            }
+        })
+        .build()
+}
+
+// -- resource: claude://agents --------------------------------------
+
+fn resource_agents(state: &ServerState) -> Resource {
+    let state = state.clone();
+    ResourceBuilder::new("claude://agents")
+        .name("Claude agents")
+        .description(
+            "Live view of every user-level agent at the configured \
+             agents root. Same shape as the agent_list tool.",
+        )
+        .mime_type("application/json")
+        .handler(move || {
+            let state = state.clone();
+            async move {
+                let root = agents_root(&state).map_err(internal)?;
+                let agents = root.list().map_err(internal)?;
+                let body = json!({
+                    "agents": agents
+                        .iter()
+                        .map(agent_summary_to_json)
+                        .collect::<Vec<_>>(),
+                });
+                let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+                Ok(ReadResourceResult::text("claude://agents", text))
+            }
+        })
+        .build()
+}
+
+// -- template: claude://agents/{file_stem} --------------------------
+
+fn template_agent_detail(state: &ServerState) -> ResourceTemplate {
+    let state = state.clone();
+    ResourceTemplateBuilder::new("claude://agents/{file_stem}")
+        .name("Agent detail")
+        .description(
+            "Full agent record keyed by file stem. Same shape as the \
+             agent_get tool.",
+        )
+        .mime_type("application/json")
+        .handler(move |uri: String, vars: HashMap<String, String>| {
+            let state = state.clone();
+            async move {
+                let stem = vars.get("file_stem").cloned().unwrap_or_default();
+                let root = agents_root(&state).map_err(internal)?;
+                let agent = root.get(&stem).map_err(internal)?;
+                let text = serde_json::to_string_pretty(&agent_to_json(&agent)).unwrap_or_default();
+                Ok(ReadResourceResult::text(uri, text))
+            }
+        })
+}
+
+// -- helpers --------------------------------------------------------
+
+fn agents_root(state: &ServerState) -> claude_wrapper::error::Result<AgentsRoot> {
+    match state.config.agents_root.as_ref() {
+        Some(path) => Ok(AgentsRoot::at(path.clone())),
+        None => AgentsRoot::home(),
+    }
+}
+
+fn internal(e: impl std::fmt::Display) -> tower_mcp::Error {
+    tower_mcp::Error::internal(e.to_string())
+}
+
+fn agent_summary_to_json(a: &claude_wrapper::artifacts::AgentSummary) -> serde_json::Value {
+    json!({
+        "file_stem": a.file_stem,
+        "name": a.name,
+        "description": a.description,
+        "tools": a.tools,
+        "model": a.model,
+        "file_path": a.file_path,
+        "size_bytes": a.size_bytes,
+    })
+}
+
+fn agent_to_json(a: &claude_wrapper::artifacts::Agent) -> serde_json::Value {
+    json!({
+        "file_stem": a.file_stem,
+        "name": a.name,
+        "description": a.description,
+        "tools": a.tools,
+        "model": a.model,
+        "file_path": a.file_path,
+        "body": a.body,
+        "extra": a.extra,
+    })
+}

--- a/crates/claude-server/src/bin/claude-server.rs
+++ b/crates/claude-server/src/bin/claude-server.rs
@@ -1,0 +1,491 @@
+//! Polished `claude-server` MCP binary.
+//!
+//! The library (`claude_server`) is the product; this binary is the
+//! sharp default front door. Run it bare with `claude-server serve`
+//! for stdio MCP, `claude-server serve-http` for HTTP, or one of the
+//! diagnostic subcommands (`tools`, `doctor`, `config`,
+//! `install-mcp-config`) to inspect / wire up the server.
+//!
+//! For the truly-minimal copy-paste integration recipe, see
+//! `examples/server.rs` -- the bare bones from which this binary
+//! grew.
+//!
+//! All surfaces are compiled in by default (the `[[bin]]` section in
+//! `Cargo.toml` requires `features = ["full"]`). Use the
+//! `[surfaces]` block in `ServerConfig` to disable individual
+//! surfaces at runtime without recompiling.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+
+use claude_server::{
+    ServerConfig, build_router_with_notification_sender, notification_channel, registered_tools,
+};
+use tower::Layer;
+use tower_mcp::HttpTransport;
+use tower_mcp::middleware::McpTracingLayer;
+use tower_mcp::transport::stdio::GenericStdioTransport;
+
+/// Polished MCP server CLI for `claude-server`.
+#[derive(Debug, Parser)]
+#[command(name = "claude-server", version, about, long_about = None)]
+struct Cli {
+    /// Path to a TOML ServerConfig. Defaults are used if omitted.
+    #[arg(long, short = 'c', global = true)]
+    config: Option<PathBuf>,
+
+    /// Log level for the embedded tracing-subscriber. Overrides the
+    /// `RUST_LOG` env var. Accepts `error`, `warn`, `info`, `debug`,
+    /// `trace`, or a full env-filter expression like
+    /// `info,claude_server=debug`.
+    #[arg(long, global = true)]
+    log_level: Option<String>,
+
+    /// Log output format. `text` is the default human-readable
+    /// shape; `json` emits structured JSON one event per line,
+    /// suitable for log shippers.
+    #[arg(long, global = true, value_enum, default_value_t = LogFormat::Text)]
+    log_format: LogFormat,
+
+    #[command(subcommand)]
+    command: Option<Cmd>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum LogFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Subcommand)]
+enum Cmd {
+    /// Serve over stdio (default).
+    Serve,
+    /// Serve over HTTP via axum. Localhost-only by default.
+    ServeHttp {
+        /// Bind address. Defaults to 127.0.0.1:7800.
+        #[arg(long, default_value = "127.0.0.1:7800")]
+        bind: SocketAddr,
+        /// Optional bearer token. When set, every request must
+        /// include `Authorization: Bearer <token>` or it gets a 401.
+        #[arg(long)]
+        bearer: Option<String>,
+        /// Allow binding to non-loopback addresses. Required to
+        /// bind anything other than `127.0.0.1` / `::1`.
+        /// Refuses by default so an accidental `--bind 0.0.0.0`
+        /// doesn't quietly expose the server publicly.
+        #[arg(long)]
+        allow_public: bool,
+    },
+    /// Print the registered tool surface as JSON and exit.
+    Tools,
+    /// Run a pre-flight check: is `claude` on PATH, what CLI
+    /// version, what auth strategy, what tested-against range
+    /// status, are the configured roots present.
+    Doctor,
+    /// Print the effective ServerConfig (post-load, post-defaults)
+    /// as JSON. Useful for "why is this not picking up my setting".
+    Config,
+    /// Emit an MCP client config snippet pointing at this binary.
+    /// Stdout by default; pass `--write` to write to the target's
+    /// canonical path.
+    InstallMcpConfig {
+        /// Which MCP client to target.
+        #[arg(long, value_enum, default_value_t = McpTarget::Stdout)]
+        target: McpTarget,
+        /// Override the server name registered in the client (the
+        /// key the client uses to refer to this server). Defaults to
+        /// `claude-server`.
+        #[arg(long, default_value = "claude-server")]
+        name: String,
+        /// Override the path to the binary embedded in the snippet.
+        /// Defaults to the absolute path of the currently-running
+        /// `claude-server` executable.
+        #[arg(long)]
+        binary: Option<PathBuf>,
+        /// Write the snippet to the target's canonical config path
+        /// (with a confirmation prompt if the file already exists)
+        /// instead of printing to stdout. Currently honored for
+        /// `claude-desktop`; other targets print and let the user
+        /// pipe.
+        #[arg(long)]
+        write: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum McpTarget {
+    /// Print a generic stdio MCP config blob to stdout. Caller
+    /// pipes / pastes into whatever client they want.
+    Stdout,
+    /// Claude Desktop. Canonical path on macOS:
+    /// `~/Library/Application Support/Claude/claude_desktop_config.json`.
+    ClaudeDesktop,
+    /// Claude Code CLI -- emit a `claude mcp add-json` command
+    /// the user can run to register this server with their CLI.
+    ClaudeCode,
+    /// VS Code MCP -- emit the user-settings snippet. Note: the
+    /// VS Code MCP path is project-local most of the time; user
+    /// pastes wherever appropriate.
+    Vscode,
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    init_tracing(cli.log_level.as_deref(), cli.log_format);
+
+    let cfg = load_config(cli.config.clone()).await?;
+
+    match cli.command.unwrap_or(Cmd::Serve) {
+        Cmd::Serve => serve_stdio(cfg).await,
+        Cmd::ServeHttp {
+            bind,
+            bearer,
+            allow_public,
+        } => serve_http(cfg, bind, bearer, allow_public).await,
+        Cmd::Tools => cmd_tools(cfg),
+        Cmd::Doctor => cmd_doctor(cfg).await,
+        Cmd::Config => cmd_config(cfg),
+        Cmd::InstallMcpConfig {
+            target,
+            name,
+            binary,
+            write,
+        } => cmd_install_mcp_config(target, name, binary, write),
+    }
+}
+
+// -- serve over stdio ----------------------------------------------
+
+async fn serve_stdio(cfg: ServerConfig) -> Result<()> {
+    let (notif_tx, notif_rx) = notification_channel(256);
+    let router = build_router_with_notification_sender(cfg, notif_tx)
+        .context("build_router_with_notification_sender")?;
+    let service = McpTracingLayer::new().layer(router);
+    let mut transport = GenericStdioTransport::with_notifications(service, notif_rx);
+    transport.run().await.context("stdio transport")
+}
+
+// -- serve over HTTP -----------------------------------------------
+
+async fn serve_http(
+    cfg: ServerConfig,
+    bind: SocketAddr,
+    bearer: Option<String>,
+    allow_public: bool,
+) -> Result<()> {
+    if !bind.ip().is_loopback() && !allow_public {
+        anyhow::bail!(
+            "refusing to bind {bind}: address is not loopback. \
+             Pass `--allow-public` if you really mean to expose this \
+             server beyond localhost. Note: an unauthenticated MCP \
+             endpoint can drive `claude` arbitrarily; consider \
+             `--bearer <token>` as well."
+        );
+    }
+    if !bind.ip().is_loopback() {
+        tracing::warn!(
+            %bind,
+            bearer_set = bearer.is_some(),
+            "binding to non-loopback address; ensure your firewall is appropriate"
+        );
+    }
+
+    let (notif_tx, notif_rx) = notification_channel(256);
+    let router = build_router_with_notification_sender(cfg, notif_tx)
+        .context("build_router_with_notification_sender")?;
+    let mut app = HttpTransport::with_notifications(router, notif_rx)
+        .layer(McpTracingLayer::new())
+        .into_router();
+    if let Some(token) = bearer {
+        use axum::middleware;
+        app = app.layer(middleware::from_fn(move |req, next| {
+            let token = token.clone();
+            bearer_guard(req, next, token)
+        }));
+        tracing::info!("bearer auth enabled");
+    }
+    let listener = tokio::net::TcpListener::bind(bind)
+        .await
+        .with_context(|| format!("binding {bind}"))?;
+    tracing::info!(%bind, "claude-server listening on http");
+    axum::serve(listener, app).await.context("axum::serve")
+}
+
+// -- tools subcommand ----------------------------------------------
+
+fn cmd_tools(cfg: ServerConfig) -> Result<()> {
+    let tools = registered_tools(cfg).context("registered_tools")?;
+    let body: Vec<_> = tools
+        .into_iter()
+        .map(|t| {
+            serde_json::json!({
+                "name": t.name,
+                "description": t.description,
+            })
+        })
+        .collect();
+    println!("{}", serde_json::to_string_pretty(&body)?);
+    Ok(())
+}
+
+// -- doctor subcommand ---------------------------------------------
+
+async fn cmd_doctor(cfg: ServerConfig) -> Result<()> {
+    use claude_wrapper::{Claude, auth};
+
+    println!("claude-server doctor");
+    println!("====================");
+
+    // 1. claude binary on PATH
+    let claude_builder_result = Claude::builder()
+        .binary(
+            cfg.claude
+                .binary
+                .clone()
+                .unwrap_or_else(|| PathBuf::from("claude")),
+        )
+        .build();
+    match &claude_builder_result {
+        Ok(_) => println!("[ok ]   `claude` binary found"),
+        Err(e) => println!("[FAIL]  `claude` binary: {e}"),
+    }
+
+    // 2. live CLI version + tested-range status
+    if let Ok(claude) = Claude::builder()
+        .tested_cli_version_range(
+            claude_wrapper::CliVersion {
+                major: 2,
+                minor: 1,
+                patch: 0,
+            },
+            claude_wrapper::CliVersion {
+                major: 2,
+                minor: 1,
+                patch: 143,
+            },
+        )
+        .build()
+    {
+        match claude.cli_version().await {
+            Ok(v) => println!("[ok ]   CLI version: {v}"),
+            Err(e) => println!("[warn]  CLI version fetch failed: {e}"),
+        }
+        match claude.cli_version_status().await {
+            Ok(status) => match status {
+                claude_wrapper::CliVersionStatus::Tested => {
+                    println!("[ok ]   tested-against range: tested");
+                }
+                claude_wrapper::CliVersionStatus::NewerUntested { found, tested_max } => {
+                    println!(
+                        "[warn]  tested-against range: newer than tested (found {found}, tested max {tested_max})"
+                    );
+                }
+                claude_wrapper::CliVersionStatus::OlderThanMinimum { found, minimum } => {
+                    println!(
+                        "[FAIL]  tested-against range: below declared minimum (found {found}, minimum {minimum})"
+                    );
+                }
+            },
+            Err(e) => println!("[warn]  range classification failed: {e}"),
+        }
+    }
+
+    // 3. auth strategy (env-derived)
+    let auth_summary = auth::detect();
+    println!("[info]  auth strategy: {}", auth_summary.strategy.as_str());
+
+    // 4. configured roots (only relevant when feature is on)
+    if let Some(p) = cfg.history_root.as_ref() {
+        println!(
+            "[{}]  history_root: {}",
+            if p.exists() { "ok " } else { "warn" },
+            p.display()
+        );
+    }
+    if let Some(p) = cfg.agents_root.as_ref() {
+        println!(
+            "[{}]  agents_root: {}",
+            if p.exists() { "ok " } else { "warn" },
+            p.display()
+        );
+    }
+    if let Some(p) = cfg.jobs_root.as_ref() {
+        println!(
+            "[{}]  jobs_root: {}",
+            if p.exists() { "ok " } else { "warn" },
+            p.display()
+        );
+    }
+    if let Some(p) = cfg.worktrees_root.as_ref() {
+        println!(
+            "[{}]  worktrees_root: {}",
+            if p.exists() { "ok " } else { "warn" },
+            p.display()
+        );
+    }
+
+    // 5. surface counts
+    let tools = registered_tools(cfg).context("registered_tools for doctor")?;
+    println!("[info]  registered tools: {}", tools.len());
+
+    Ok(())
+}
+
+// -- config subcommand ---------------------------------------------
+
+fn cmd_config(cfg: ServerConfig) -> Result<()> {
+    let json = serde_json::to_string_pretty(&cfg).context("serialize ServerConfig")?;
+    println!("{json}");
+    Ok(())
+}
+
+// -- install-mcp-config subcommand ---------------------------------
+
+fn cmd_install_mcp_config(
+    target: McpTarget,
+    name: String,
+    binary: Option<PathBuf>,
+    write: bool,
+) -> Result<()> {
+    let binary_path = match binary {
+        Some(p) => p,
+        None => std::env::current_exe().context("resolving current executable path")?,
+    };
+    let binary_str = binary_path.to_string_lossy().to_string();
+
+    match target {
+        McpTarget::Stdout => {
+            let blob = serde_json::json!({
+                name.as_str(): {
+                    "command": binary_str,
+                    "args": ["serve"]
+                }
+            });
+            println!("{}", serde_json::to_string_pretty(&blob)?);
+        }
+        McpTarget::ClaudeDesktop => {
+            let blob = serde_json::json!({
+                "mcpServers": {
+                    name.as_str(): {
+                        "command": binary_str,
+                        "args": ["serve"]
+                    }
+                }
+            });
+            if write {
+                let path =
+                    claude_desktop_config_path().context("resolving Claude Desktop config path")?;
+                anyhow::bail!(
+                    "--write would overwrite {} -- merging into existing \
+                     config is not implemented yet. Print to stdout and \
+                     edit manually instead.",
+                    path.display()
+                );
+            }
+            println!(
+                "// Paste the `mcpServers` entry below into Claude Desktop's config:\n\
+                 // macOS:   ~/Library/Application Support/Claude/claude_desktop_config.json\n\
+                 // Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
+            );
+            println!("{}", serde_json::to_string_pretty(&blob)?);
+        }
+        McpTarget::ClaudeCode => {
+            let json_blob = serde_json::json!({
+                "command": binary_str,
+                "args": ["serve"]
+            });
+            let json_str = serde_json::to_string(&json_blob)?;
+            println!(
+                "# Run this to register {name} with your `claude` CLI:\n\
+                 claude mcp add-json {name} '{json_str}'"
+            );
+        }
+        McpTarget::Vscode => {
+            let blob = serde_json::json!({
+                "servers": {
+                    name.as_str(): {
+                        "type": "stdio",
+                        "command": binary_str,
+                        "args": ["serve"]
+                    }
+                }
+            });
+            println!(
+                "// Paste the entry below into your VS Code MCP config\n\
+                 // (project: .vscode/mcp.json; user: settings.json under `mcp`):"
+            );
+            println!("{}", serde_json::to_string_pretty(&blob)?);
+        }
+    }
+    Ok(())
+}
+
+fn claude_desktop_config_path() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .context("HOME not set")?;
+    #[cfg(target_os = "macos")]
+    let p = home
+        .join("Library")
+        .join("Application Support")
+        .join("Claude")
+        .join("claude_desktop_config.json");
+    #[cfg(not(target_os = "macos"))]
+    let p = home
+        .join(".config")
+        .join("Claude")
+        .join("claude_desktop_config.json");
+    Ok(p)
+}
+
+// -- helpers --------------------------------------------------------
+
+async fn load_config(path: Option<PathBuf>) -> Result<ServerConfig> {
+    let Some(p) = path else {
+        return Ok(ServerConfig::default());
+    };
+    let text = tokio::fs::read_to_string(&p)
+        .await
+        .with_context(|| format!("reading {}", p.display()))?;
+    toml::from_str(&text).with_context(|| format!("parsing {}", p.display()))
+}
+
+fn init_tracing(level_override: Option<&str>, format: LogFormat) {
+    use tracing_subscriber::{EnvFilter, fmt};
+    let filter = if let Some(spec) = level_override {
+        EnvFilter::try_new(spec).unwrap_or_else(|_| EnvFilter::new("info"))
+    } else {
+        EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new("info,claude_server=info,tower_mcp=info"))
+    };
+    let builder = fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .with_ansi(false);
+    let _ = match format {
+        LogFormat::Text => builder.try_init(),
+        LogFormat::Json => builder.json().try_init(),
+    };
+}
+
+async fn bearer_guard(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+    expected: String,
+) -> Result<axum::response::Response, axum::http::StatusCode> {
+    let header = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "));
+    match header {
+        Some(t) if t == expected => Ok(next.run(req).await),
+        _ => Err(axum::http::StatusCode::UNAUTHORIZED),
+    }
+}

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -654,6 +654,4 @@ fn tool_chat_close(state: &ServerState) -> Tool {
 
 // -- helpers --------------------------------------------------------
 
-fn super_internal(e: impl std::fmt::Display) -> tower_mcp::Error {
-    tower_mcp::Error::internal(e.to_string())
-}
+use crate::errors::from_wrapper as super_internal;

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -87,6 +87,13 @@ struct ChatOpenInput {
     /// land in a side worktree instead of the current working tree.
     #[serde(default)]
     worktree_name: Option<String>,
+    /// Per-chat working directory override. The spawned `claude`
+    /// subprocess starts in this directory instead of the
+    /// server-default `ServerConfig::claude::working_dir`.
+    /// Lets a single server host chats against multiple project
+    /// roots simultaneously.
+    #[serde(default)]
+    working_dir: Option<std::path::PathBuf>,
 }
 
 fn tool_chat_open(state: &ServerState) -> Tool {
@@ -120,7 +127,13 @@ fn tool_chat_open(state: &ServerState) -> Tool {
                     }
                 }
 
-                let session = DuplexSession::spawn(&state.claude, opts)
+                // Per-chat working_dir override clones the Claude
+                // client; without override we use the server-default.
+                let claude = match input.working_dir {
+                    Some(dir) => std::sync::Arc::new(state.claude.with_working_dir(dir)),
+                    None => state.claude.clone(),
+                };
+                let session = DuplexSession::spawn(&claude, opts)
                     .await
                     .map_err(super_internal)?;
                 let mut conv = Conversation::new(session);

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -106,6 +106,23 @@ struct ChatOpenInput {
     /// `resume` at the CLI level; passing both lets the CLI decide.
     #[serde(default)]
     continue_session: Option<bool>,
+    /// Pin this chat to a named subagent (`claude --agent <name>`).
+    /// Resolved by the CLI from inline `agents_json` definitions
+    /// first, then user-level `~/.claude/agents/<name>.md` files.
+    /// Caveat: as of Claude Code 2.1.143, the CLI silently ignores
+    /// an unknown name and falls back to default. Validate against
+    /// `agent_list` / `agent_get` (artifacts feature) if you want
+    /// hard "must exist" semantics.
+    #[serde(default)]
+    agent: Option<String>,
+    /// Inline subagent definitions for this chat
+    /// (`claude --agents <json>`). JSON object keyed by agent name,
+    /// each value carrying at least `description` and `prompt`.
+    /// Inline definitions override on-disk
+    /// `~/.claude/agents/*.md` of the same name. Pair with
+    /// `agent` to select which one to use as the chat's persona.
+    #[serde(default)]
+    agents_json: Option<String>,
 }
 
 fn tool_chat_open(state: &ServerState) -> Tool {
@@ -140,6 +157,12 @@ fn tool_chat_open(state: &ServerState) -> Tool {
                     input.worktree_name.is_some() || input.worktree.unwrap_or(false);
                 if want_worktree {
                     opts = opts.worktree(input.worktree_name.as_deref());
+                }
+                if let Some(json) = input.agents_json {
+                    opts = opts.agents_json(json);
+                }
+                if let Some(name) = input.agent {
+                    opts = opts.agent(name);
                 }
 
                 // Per-chat working_dir override clones the Claude

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -66,6 +66,16 @@ struct ChatOpenInput {
     /// (no callback wired through MCP today).
     #[serde(default)]
     warn_at_usd: Option<f64>,
+    /// Run this chat in a fresh git worktree (`claude --worktree`).
+    /// `true` uses a default-named worktree; pass `worktree_name`
+    /// to choose a name explicitly.
+    #[serde(default)]
+    worktree: Option<bool>,
+    /// Name for the fresh worktree (implies `worktree = true`).
+    /// Useful for "agent runs in isolation" -- the chat's writes
+    /// land in a side worktree instead of the current working tree.
+    #[serde(default)]
+    worktree_name: Option<String>,
 }
 
 fn tool_chat_open(state: &ServerState) -> Tool {
@@ -88,6 +98,15 @@ fn tool_chat_open(state: &ServerState) -> Tool {
                 }
                 if let Some(s) = input.append_system_prompt {
                     opts = opts.append_system_prompt(s);
+                }
+                // worktree_name implies worktree-enabled.
+                let want_worktree =
+                    input.worktree_name.is_some() || input.worktree.unwrap_or(false);
+                if want_worktree {
+                    opts = opts.arg("--worktree");
+                    if let Some(name) = input.worktree_name {
+                        opts = opts.arg(name);
+                    }
                 }
 
                 let session = DuplexSession::spawn(&state.claude, opts)

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -139,10 +139,7 @@ fn tool_chat_open(state: &ServerState) -> Tool {
                 let want_worktree =
                     input.worktree_name.is_some() || input.worktree.unwrap_or(false);
                 if want_worktree {
-                    opts = opts.arg("--worktree");
-                    if let Some(name) = input.worktree_name {
-                        opts = opts.arg(name);
-                    }
+                    opts = opts.worktree(input.worktree_name.as_deref());
                 }
 
                 // Per-chat working_dir override clones the Claude

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -23,6 +23,7 @@ use serde_json::json;
 #[cfg(feature = "sync-agent-turns")]
 use tower_mcp::extract::{Context, Json, State};
 use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+use tracing::Instrument;
 
 use claude_wrapper::budget::BudgetTracker;
 use claude_wrapper::conversation::Conversation;
@@ -172,43 +173,71 @@ fn tool_chat_send(state: &ServerState) -> Tool {
                 }
                 let handle = state.turns.register(Some(input.chat_id.clone())).await;
                 let turn_id = handle.turn_id.clone();
+                let span = tracing::info_span!(
+                    "chat_send",
+                    turn_id = %turn_id,
+                    chat_id = %input.chat_id,
+                    prompt_len = input.prompt.len(),
+                );
+                tracing::info!(parent: &span, "fired async turn");
 
                 let state_for_worker = state.clone();
                 let chat_id_for_worker = input.chat_id.clone();
                 let prompt = input.prompt;
-                tokio::spawn(async move {
-                    if handle.is_cancelled() {
-                        handle.cancelled();
-                        return;
-                    }
-                    let conv = match state_for_worker.get_chat(&chat_id_for_worker).await {
-                        Some(c) => c,
-                        None => {
-                            handle.fail(format!(
-                                "no chat with id `{chat_id_for_worker}` (was it closed?)"
-                            ));
+                tokio::spawn(
+                    async move {
+                        if handle.is_cancelled() {
+                            tracing::info!("turn cancelled before start");
+                            handle.cancelled();
                             return;
                         }
-                    };
-                    let mut guard = conv.lock().await;
-                    if handle.is_cancelled() {
-                        handle.cancelled();
-                        return;
-                    }
-                    match guard.send(prompt).await {
-                        Ok(turn) => {
-                            handle.complete(json!({
-                                "result": turn.result_text(),
-                                "session_id": turn.session_id(),
-                                "turn_cost_usd": turn.total_cost_usd(),
-                                "duration_ms": turn.duration_ms(),
-                                "cumulative_cost_usd": guard.total_cost_usd(),
-                                "total_turns": guard.total_turns(),
-                            }));
+                        let conv = match state_for_worker.get_chat(&chat_id_for_worker).await {
+                            Some(c) => c,
+                            None => {
+                                tracing::warn!("chat closed before turn could acquire it");
+                                handle.fail(format!(
+                                    "no chat with id `{chat_id_for_worker}` (was it closed?)"
+                                ));
+                                return;
+                            }
+                        };
+                        let mut guard = conv.lock().await;
+                        if handle.is_cancelled() {
+                            tracing::info!("turn cancelled while waiting for mutex");
+                            handle.cancelled();
+                            return;
                         }
-                        Err(e) => handle.fail(e),
+                        match guard.send(prompt).await {
+                            Ok(turn) => {
+                                let cost = turn.total_cost_usd();
+                                let dur = turn.duration_ms();
+                                let result_text = turn.result_text().map(str::to_string);
+                                let session_id = turn.session_id().map(str::to_string);
+                                let cumulative = guard.total_cost_usd();
+                                let total_turns = guard.total_turns();
+                                tracing::info!(
+                                    cost_usd = ?cost,
+                                    duration_ms = ?dur,
+                                    cumulative_cost_usd = cumulative,
+                                    "turn done"
+                                );
+                                handle.complete(json!({
+                                    "result": result_text,
+                                    "session_id": session_id,
+                                    "turn_cost_usd": cost,
+                                    "duration_ms": dur,
+                                    "cumulative_cost_usd": cumulative,
+                                    "total_turns": total_turns,
+                                }));
+                            }
+                            Err(e) => {
+                                tracing::error!(error = %e, "turn failed");
+                                handle.fail(e);
+                            }
+                        }
                     }
-                });
+                    .instrument(span),
+                );
 
                 Ok(CallToolResult::json(json!({
                     "turn_id": turn_id,

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -33,6 +33,7 @@ use crate::state::ServerState;
 pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
     vec![
         tool_chat_open(state),
+        tool_chat_send(state),
         tool_chat_send_sync(state),
         tool_chat_send_stream_sync(state),
         tool_chat_list(state),
@@ -104,6 +105,85 @@ fn tool_chat_open(state: &ServerState) -> Tool {
                 Ok(CallToolResult::json(json!({
                     "chat_id": id,
                     "max_cost_usd": input.max_cost_usd,
+                })))
+            }
+        })
+        .build()
+}
+
+// -- chat_send (async, default) -------------------------------------
+//
+// Fires the turn into a background task and returns immediately
+// with the new turn_id. Within a chat, turns still serialize via
+// the Conversation mutex -- the second chat_send to the same chat
+// queues behind the first, and starts when the first finishes.
+//
+// Use turn_get / turn_wait / turn_cancel to drive the turn's
+// lifecycle. The agent never blocks on this call.
+
+fn tool_chat_send(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_send")
+        .description(
+            "Fire a turn against an open chat and return immediately with a \
+             turn_id. The turn runs in the background; poll with `turn_get`, \
+             block with `turn_wait`, or cancel with `turn_cancel`. Turns within \
+             a single chat still serialize (second turn queues behind first). \
+             For the blocking variant, see `chat_send_sync`.",
+        )
+        .handler(move |input: ChatSendInput| {
+            let state = state.clone();
+            async move {
+                // Confirm chat exists before promising a turn_id.
+                if state.get_chat(&input.chat_id).await.is_none() {
+                    return Err(tower_mcp::Error::internal(format!(
+                        "no chat with id `{}` (was it closed?)",
+                        input.chat_id
+                    )));
+                }
+                let handle = state.turns.register(Some(input.chat_id.clone())).await;
+                let turn_id = handle.turn_id.clone();
+
+                let state_for_worker = state.clone();
+                let chat_id_for_worker = input.chat_id.clone();
+                let prompt = input.prompt;
+                tokio::spawn(async move {
+                    if handle.is_cancelled() {
+                        handle.cancelled();
+                        return;
+                    }
+                    let conv = match state_for_worker.get_chat(&chat_id_for_worker).await {
+                        Some(c) => c,
+                        None => {
+                            handle.fail(format!(
+                                "no chat with id `{chat_id_for_worker}` (was it closed?)"
+                            ));
+                            return;
+                        }
+                    };
+                    let mut guard = conv.lock().await;
+                    if handle.is_cancelled() {
+                        handle.cancelled();
+                        return;
+                    }
+                    match guard.send(prompt).await {
+                        Ok(turn) => {
+                            handle.complete(json!({
+                                "result": turn.result_text(),
+                                "session_id": turn.session_id(),
+                                "turn_cost_usd": turn.total_cost_usd(),
+                                "duration_ms": turn.duration_ms(),
+                                "cumulative_cost_usd": guard.total_cost_usd(),
+                                "total_turns": guard.total_turns(),
+                            }));
+                        }
+                        Err(e) => handle.fail(e),
+                    }
+                });
+
+                Ok(CallToolResult::json(json!({
+                    "turn_id": turn_id,
+                    "chat_id": input.chat_id,
                 })))
             }
         })

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -1,0 +1,469 @@
+//! L2.5 chat surface: tools that wrap [`DuplexSession`] +
+//! [`Conversation`] for multi-turn work.
+//!
+//! Single-shot prompts go through [`crate::cli::tool_query`]
+//! (`claude_query`). For anything that needs accumulated context
+//! across turns -- coordinator/SME flows, interactive UIs, anything
+//! mid-turn-interruptible -- open a chat, send turns against it,
+//! close it when you're done.
+//!
+//! The wrapper provides:
+//! - [`DuplexSession`] -- the long-lived stream-json subprocess.
+//! - [`Conversation`] -- host-side accounting (history, cost,
+//!   optional budget) on top.
+//!
+//! We hold one [`Conversation`] per server-side chat, behind a
+//! [`tokio::sync::Mutex`] so turns within a chat are serialized.
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use tower_mcp::extract::{Context, Json, State};
+use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+
+use claude_wrapper::budget::BudgetTracker;
+use claude_wrapper::conversation::Conversation;
+use claude_wrapper::duplex::{DuplexOptions, DuplexSession, InboundEvent};
+
+use crate::state::ServerState;
+
+/// Build the L2.5 chat tool list.
+pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
+    vec![
+        tool_chat_open(state),
+        tool_chat_send(state),
+        tool_chat_send_stream(state),
+        tool_chat_list(state),
+        tool_chat_history(state),
+        tool_chat_interrupt(state),
+        tool_chat_budget(state),
+        tool_chat_close(state),
+    ]
+}
+
+// -- chat_open ------------------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct ChatOpenInput {
+    /// Optional model (e.g. `sonnet`, `haiku`).
+    #[serde(default)]
+    model: Option<String>,
+    /// Optional system prompt for the session.
+    #[serde(default)]
+    system_prompt: Option<String>,
+    /// Optional appended system prompt.
+    #[serde(default)]
+    append_system_prompt: Option<String>,
+    /// Hard cumulative cost ceiling in USD. When the chat's running
+    /// total reaches this, further chat_send calls error before
+    /// touching claude.
+    #[serde(default)]
+    max_cost_usd: Option<f64>,
+    /// Soft warning threshold in USD. Logged via tracing when crossed
+    /// (no callback wired through MCP today).
+    #[serde(default)]
+    warn_at_usd: Option<f64>,
+}
+
+fn tool_chat_open(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_open")
+        .description(
+            "Open a long-lived chat backed by a duplex `claude` subprocess. \
+             Returns a chat_id you pass to chat_send / chat_close / etc. \
+             Turns within a chat are serialized; multiple chats run in parallel.",
+        )
+        .handler(move |input: ChatOpenInput| {
+            let state = state.clone();
+            async move {
+                let mut opts = DuplexOptions::default();
+                if let Some(m) = input.model {
+                    opts = opts.model(m);
+                }
+                if let Some(s) = input.system_prompt {
+                    opts = opts.system_prompt(s);
+                }
+                if let Some(s) = input.append_system_prompt {
+                    opts = opts.append_system_prompt(s);
+                }
+
+                let session = DuplexSession::spawn(&state.claude, opts)
+                    .await
+                    .map_err(super_internal)?;
+                let mut conv = Conversation::new(session);
+                if let Some(max) = input.max_cost_usd {
+                    let mut b = BudgetTracker::builder().max_usd(max);
+                    if let Some(w) = input.warn_at_usd {
+                        b = b.warn_at_usd(w);
+                    }
+                    conv = conv.with_budget(b.build());
+                }
+                let id = state.insert_chat(conv).await;
+                Ok(CallToolResult::json(json!({
+                    "chat_id": id,
+                    "max_cost_usd": input.max_cost_usd,
+                })))
+            }
+        })
+        .build()
+}
+
+// -- chat_send -------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ChatSendInput {
+    /// Identifier returned by `chat_open`.
+    chat_id: String,
+    /// The user prompt for this turn.
+    prompt: String,
+}
+
+fn tool_chat_send(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_send")
+        .description(
+            "Send a turn to a chat opened with chat_open. Blocks until the \
+             assistant finishes the turn. Returns the assistant text, \
+             session id, cumulative cost, and turn count.",
+        )
+        .handler(move |input: ChatSendInput| {
+            let state = state.clone();
+            async move {
+                let conv = state.get_chat(&input.chat_id).await.ok_or_else(|| {
+                    tower_mcp::Error::internal(format!(
+                        "no chat with id `{}` (was it closed?)",
+                        input.chat_id
+                    ))
+                })?;
+                let mut guard = conv.lock().await;
+                let turn = guard.send(input.prompt).await.map_err(super_internal)?;
+                Ok(CallToolResult::json(json!({
+                    "result": turn.result_text(),
+                    "session_id": turn.session_id(),
+                    "turn_cost_usd": turn.total_cost_usd(),
+                    "duration_ms": turn.duration_ms(),
+                    "cumulative_cost_usd": guard.total_cost_usd(),
+                    "total_turns": guard.total_turns(),
+                })))
+            }
+        })
+        .build()
+}
+
+// -- chat_send_stream -----------------------------------------------
+//
+// Streaming variant of chat_send. Forwards every InboundEvent the
+// duplex session emits to the MCP client as a `notifications/progress`
+// message, so callers see assistant text deltas, tool-use blocks, and
+// system events as they arrive instead of waiting for the final
+// TurnResult.
+//
+// Implementation detail: we subscribe to the broadcast BEFORE calling
+// send so we never miss the SystemInit or first Assistant chunk.
+// The forwarder runs in a spawned task with a clone of `Context`;
+// when send returns we abort it.
+
+fn tool_chat_send_stream(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_send_stream")
+        .description(
+            "Streaming variant of chat_send. Each event from the underlying \
+             duplex session is forwarded as an MCP `notifications/progress` \
+             event (assistant deltas, tool-use blocks, system events). \
+             The final return is identical to chat_send.",
+        )
+        .extractor_handler(
+            state,
+            |State(state): State<ServerState>,
+             ctx: Context,
+             Json(input): Json<ChatSendInput>| async move {
+                let conv = state.get_chat(&input.chat_id).await.ok_or_else(|| {
+                    tower_mcp::Error::internal(format!(
+                        "no chat with id `{}` (was it closed?)",
+                        input.chat_id
+                    ))
+                })?;
+                let mut guard = conv.lock().await;
+
+                let mut rx = guard.session().subscribe();
+                let ctx_for_task = ctx.clone();
+                let forwarder = tokio::spawn(async move {
+                    let mut counter: f64 = 0.0;
+                    loop {
+                        match rx.recv().await {
+                            Ok(event) => {
+                                counter += 1.0;
+                                let msg = stringify_event(&event);
+                                ctx_for_task
+                                    .report_progress(counter, None, Some(&msg))
+                                    .await;
+                            }
+                            // Lagged: skip and keep going.
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                            // Closed: session ended.
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        }
+                    }
+                });
+
+                let send_result = guard.send(input.prompt).await;
+                forwarder.abort();
+                let turn = send_result.map_err(super_internal)?;
+
+                Ok(CallToolResult::json(json!({
+                    "result": turn.result_text(),
+                    "session_id": turn.session_id(),
+                    "turn_cost_usd": turn.total_cost_usd(),
+                    "duration_ms": turn.duration_ms(),
+                    "cumulative_cost_usd": guard.total_cost_usd(),
+                    "total_turns": guard.total_turns(),
+                })))
+            },
+        )
+        .build()
+}
+
+/// Render an [`InboundEvent`] as a short string suitable for the
+/// `message` field of a progress notification. We pull the assistant
+/// text where present so consumers can show progressive output;
+/// other event types fall back to a type tag.
+fn stringify_event(event: &InboundEvent) -> String {
+    match event {
+        InboundEvent::SystemInit { session_id } => format!("system.init session={session_id}"),
+        InboundEvent::Assistant(v) => {
+            if let Some(text) = extract_assistant_text(v) {
+                format!("assistant {}", truncate(&text, 200))
+            } else {
+                "assistant".to_string()
+            }
+        }
+        InboundEvent::StreamEvent(_) => "stream_event".to_string(),
+        InboundEvent::User(_) => "user".to_string(),
+        InboundEvent::Other(v) => v
+            .get("type")
+            .and_then(|t| t.as_str())
+            .map(|s| format!("other.{s}"))
+            .unwrap_or_else(|| "other".to_string()),
+    }
+}
+
+fn extract_assistant_text(v: &serde_json::Value) -> Option<String> {
+    let blocks = v
+        .get("message")
+        .and_then(|m| m.get("content"))?
+        .as_array()?;
+    let mut buf = String::new();
+    for b in blocks {
+        if b.get("type").and_then(|t| t.as_str()) == Some("text")
+            && let Some(s) = b.get("text").and_then(|t| t.as_str())
+        {
+            buf.push_str(s);
+        }
+    }
+    if buf.is_empty() { None } else { Some(buf) }
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max_chars).collect();
+        out.push('…');
+        out
+    }
+}
+
+// -- chat_list ------------------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct NoArgs {}
+
+fn tool_chat_list(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_list")
+        .description("List currently open chats with their cumulative cost and turn count.")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let state = state.clone();
+            async move {
+                let map = state.chats.read().await;
+                let mut entries = Vec::with_capacity(map.len());
+                for (id, conv) in map.iter() {
+                    let guard = conv.lock().await;
+                    entries.push(json!({
+                        "chat_id": id,
+                        "total_turns": guard.total_turns(),
+                        "total_cost_usd": guard.total_cost_usd(),
+                        "session_id": guard.session_id(),
+                    }));
+                }
+                Ok(CallToolResult::json(json!({"chats": entries})))
+            }
+        })
+        .build()
+}
+
+// -- chat_history ---------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ChatHistoryInput {
+    /// Identifier of the chat to inspect.
+    chat_id: String,
+}
+
+fn tool_chat_history(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_history")
+        .description(
+            "Return the full per-turn history of a chat: the assistant text, \
+             cost, and duration for each turn.",
+        )
+        .read_only()
+        .handler(move |input: ChatHistoryInput| {
+            let state = state.clone();
+            async move {
+                let conv = state.get_chat(&input.chat_id).await.ok_or_else(|| {
+                    tower_mcp::Error::internal(format!("no chat with id `{}`", input.chat_id))
+                })?;
+                let guard = conv.lock().await;
+                let turns: Vec<_> = guard
+                    .history()
+                    .iter()
+                    .map(|t| {
+                        json!({
+                            "result": t.result_text(),
+                            "session_id": t.session_id(),
+                            "cost_usd": t.total_cost_usd(),
+                            "duration_ms": t.duration_ms(),
+                        })
+                    })
+                    .collect();
+                Ok(CallToolResult::json(json!({
+                    "chat_id": input.chat_id,
+                    "turns": turns,
+                    "total_cost_usd": guard.total_cost_usd(),
+                    "total_turns": guard.total_turns(),
+                })))
+            }
+        })
+        .build()
+}
+
+// -- chat_interrupt -------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ChatInterruptInput {
+    /// Identifier of the chat to interrupt.
+    chat_id: String,
+}
+
+fn tool_chat_interrupt(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_interrupt")
+        .description(
+            "Send a clean mid-turn interrupt to a chat. The in-flight turn \
+             (if any) returns with a partial result; the session stays open \
+             for further turns.",
+        )
+        .handler(move |input: ChatInterruptInput| {
+            let state = state.clone();
+            async move {
+                let conv = state.get_chat(&input.chat_id).await.ok_or_else(|| {
+                    tower_mcp::Error::internal(format!("no chat with id `{}`", input.chat_id))
+                })?;
+                // Interrupting needs &DuplexSession access -- Conversation
+                // exposes that through `session()`. We don't need to hold
+                // the mutex across the interrupt; the in-flight `send`
+                // holds it for us.
+                let guard = conv.lock().await;
+                guard.session().interrupt().await.map_err(super_internal)?;
+                Ok(CallToolResult::json(json!({"ok": true})))
+            }
+        })
+        .build()
+}
+
+// -- chat_budget ----------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ChatBudgetInput {
+    /// Identifier of the chat whose budget to inspect.
+    chat_id: String,
+}
+
+fn tool_chat_budget(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_budget")
+        .description(
+            "Read the BudgetTracker state for a chat: total spent so far, \
+             configured ceiling, remaining, and warn threshold. Returns \
+             `{ \"budget\": null }` if the chat was opened without a \
+             max_cost_usd.",
+        )
+        .read_only()
+        .handler(move |input: ChatBudgetInput| {
+            let state = state.clone();
+            async move {
+                let conv = state.get_chat(&input.chat_id).await.ok_or_else(|| {
+                    tower_mcp::Error::internal(format!("no chat with id `{}`", input.chat_id))
+                })?;
+                let guard = conv.lock().await;
+                let body = match guard.budget() {
+                    None => json!({"chat_id": input.chat_id, "budget": null}),
+                    Some(b) => json!({
+                        "chat_id": input.chat_id,
+                        "budget": {
+                            "total_usd": b.total_usd(),
+                            "max_usd": b.max_usd(),
+                            "remaining_usd": b.remaining_usd(),
+                            "warn_at_usd": b.warn_at_usd(),
+                        },
+                    }),
+                };
+                Ok(CallToolResult::json(body))
+            }
+        })
+        .build()
+}
+
+// -- chat_close -----------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ChatCloseInput {
+    /// Identifier of the chat to close.
+    chat_id: String,
+}
+
+fn tool_chat_close(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_close")
+        .description("Drop a chat from the server. No-op if the id is unknown.")
+        .handler(move |input: ChatCloseInput| {
+            let state = state.clone();
+            async move {
+                let removed = state.remove_chat(&input.chat_id).await;
+                let existed = removed.is_some();
+                if let Some(arc) = removed {
+                    // Try to drain into close(); only proceed if we hold the
+                    // last reference, otherwise just drop.
+                    if let Ok(mutex) = Arc::try_unwrap(arc) {
+                        let conv = mutex.into_inner();
+                        let _ = conv.close().await;
+                    }
+                }
+                Ok(CallToolResult::json(json!({
+                    "ok": true,
+                    "existed": existed,
+                })))
+            }
+        })
+        .build()
+}
+
+// -- helpers --------------------------------------------------------
+
+fn super_internal(e: impl std::fmt::Display) -> tower_mcp::Error {
+    tower_mcp::Error::internal(e.to_string())
+}

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -132,6 +132,7 @@ fn tool_chat_open(state: &ServerState) -> Tool {
                     conv = conv.with_budget(b.build());
                 }
                 let id = state.insert_chat(conv).await;
+                state.notify_resources_list_changed();
                 Ok(CallToolResult::json(json!({
                     "chat_id": id,
                     "max_cost_usd": input.max_cost_usd,
@@ -215,6 +216,7 @@ fn tool_chat_send(state: &ServerState) -> Tool {
                                 let session_id = turn.session_id().map(str::to_string);
                                 let cumulative = guard.total_cost_usd();
                                 let total_turns = guard.total_turns();
+                                drop(guard);
                                 tracing::info!(
                                     cost_usd = ?cost,
                                     duration_ms = ?dur,
@@ -231,10 +233,14 @@ fn tool_chat_send(state: &ServerState) -> Tool {
                                 }));
                             }
                             Err(e) => {
+                                drop(guard);
                                 tracing::error!(error = %e, "turn failed");
                                 handle.fail(e);
                             }
                         }
+                        state_for_worker.notify_resource_updated(format!(
+                            "claude://chats/{chat_id_for_worker}"
+                        ));
                     }
                     .instrument(span),
                 );
@@ -279,14 +285,17 @@ fn tool_chat_send_sync(state: &ServerState) -> Tool {
                 })?;
                 let mut guard = conv.lock().await;
                 let turn = guard.send(input.prompt).await.map_err(super_internal)?;
-                Ok(CallToolResult::json(json!({
+                let body = json!({
                     "result": turn.result_text(),
                     "session_id": turn.session_id(),
                     "turn_cost_usd": turn.total_cost_usd(),
                     "duration_ms": turn.duration_ms(),
                     "cumulative_cost_usd": guard.total_cost_usd(),
                     "total_turns": guard.total_turns(),
-                })))
+                });
+                drop(guard);
+                state.notify_resource_updated(format!("claude://chats/{}", input.chat_id));
+                Ok(CallToolResult::json(body))
             }
         })
         .build()
@@ -356,14 +365,17 @@ fn tool_chat_send_stream_sync(state: &ServerState) -> Tool {
                 forwarder.abort();
                 let turn = send_result.map_err(super_internal)?;
 
-                Ok(CallToolResult::json(json!({
+                let body = json!({
                     "result": turn.result_text(),
                     "session_id": turn.session_id(),
                     "turn_cost_usd": turn.total_cost_usd(),
                     "duration_ms": turn.duration_ms(),
                     "cumulative_cost_usd": guard.total_cost_usd(),
                     "total_turns": guard.total_turns(),
-                })))
+                });
+                drop(guard);
+                state.notify_resource_updated(format!("claude://chats/{}", input.chat_id));
+                Ok(CallToolResult::json(body))
             },
         )
         .build()
@@ -599,6 +611,9 @@ fn tool_chat_close(state: &ServerState) -> Tool {
                         let conv = mutex.into_inner();
                         let _ = conv.close().await;
                     }
+                }
+                if existed {
+                    state.notify_resources_list_changed();
                 }
                 Ok(CallToolResult::json(json!({
                     "ok": true,

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -94,6 +94,18 @@ struct ChatOpenInput {
     /// roots simultaneously.
     #[serde(default)]
     working_dir: Option<std::path::PathBuf>,
+    /// Resume a prior session by id. Maps to `claude --resume
+    /// <session_id>` on the spawned duplex process. Use case:
+    /// upgrade a passive on-disk JSONL session to a live duplex
+    /// chat. Subsequent `chat_send` turns extend the existing
+    /// conversation rather than starting fresh.
+    #[serde(default)]
+    resume: Option<String>,
+    /// Continue the most recent session in the resolved working
+    /// directory (`claude --continue`). Mutually exclusive with
+    /// `resume` at the CLI level; passing both lets the CLI decide.
+    #[serde(default)]
+    continue_session: Option<bool>,
 }
 
 fn tool_chat_open(state: &ServerState) -> Tool {
@@ -116,6 +128,12 @@ fn tool_chat_open(state: &ServerState) -> Tool {
                 }
                 if let Some(s) = input.append_system_prompt {
                     opts = opts.append_system_prompt(s);
+                }
+                if let Some(id) = input.resume {
+                    opts = opts.resume(id);
+                }
+                if input.continue_session.unwrap_or(false) {
+                    opts = opts.continue_session();
                 }
                 // worktree_name implies worktree-enabled.
                 let want_worktree =

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -32,9 +32,10 @@ use claude_wrapper::duplex::{DuplexOptions, DuplexSession};
 
 use crate::state::ServerState;
 
+mod slash;
+
 /// Build the L2.5 chat tool list.
 pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
-    #[cfg_attr(not(feature = "sync-agent-turns"), allow(unused_mut))]
     let mut out = vec![
         tool_chat_open(state),
         tool_chat_send(state),
@@ -44,6 +45,7 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
         tool_chat_budget(state),
         tool_chat_close(state),
     ];
+    out.extend(slash::tools(state));
     #[cfg(feature = "sync-agent-turns")]
     {
         out.push(tool_chat_send_sync(state));

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -20,28 +20,36 @@ use std::sync::Arc;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
+#[cfg(feature = "sync-agent-turns")]
 use tower_mcp::extract::{Context, Json, State};
 use tower_mcp::{CallToolResult, Tool, ToolBuilder};
 
 use claude_wrapper::budget::BudgetTracker;
 use claude_wrapper::conversation::Conversation;
-use claude_wrapper::duplex::{DuplexOptions, DuplexSession, InboundEvent};
+#[cfg(feature = "sync-agent-turns")]
+use claude_wrapper::duplex::InboundEvent;
+use claude_wrapper::duplex::{DuplexOptions, DuplexSession};
 
 use crate::state::ServerState;
 
 /// Build the L2.5 chat tool list.
 pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
-    vec![
+    #[cfg_attr(not(feature = "sync-agent-turns"), allow(unused_mut))]
+    let mut out = vec![
         tool_chat_open(state),
         tool_chat_send(state),
-        tool_chat_send_sync(state),
-        tool_chat_send_stream_sync(state),
         tool_chat_list(state),
         tool_chat_history(state),
         tool_chat_interrupt(state),
         tool_chat_budget(state),
         tool_chat_close(state),
-    ]
+    ];
+    #[cfg(feature = "sync-agent-turns")]
+    {
+        out.push(tool_chat_send_sync(state));
+        out.push(tool_chat_send_stream_sync(state));
+    }
+    out
 }
 
 // -- chat_open ------------------------------------------------------
@@ -219,6 +227,7 @@ struct ChatSendInput {
     prompt: String,
 }
 
+#[cfg(feature = "sync-agent-turns")]
 fn tool_chat_send_sync(state: &ServerState) -> Tool {
     let state = state.clone();
     ToolBuilder::new("chat_send_sync")
@@ -267,6 +276,7 @@ fn tool_chat_send_sync(state: &ServerState) -> Tool {
 // The forwarder runs in a spawned task with a clone of `Context`;
 // when send returns we abort it.
 
+#[cfg(feature = "sync-agent-turns")]
 fn tool_chat_send_stream_sync(state: &ServerState) -> Tool {
     let state = state.clone();
     ToolBuilder::new("chat_send_stream_sync")
@@ -332,6 +342,7 @@ fn tool_chat_send_stream_sync(state: &ServerState) -> Tool {
 /// `message` field of a progress notification. We pull the assistant
 /// text where present so consumers can show progressive output;
 /// other event types fall back to a type tag.
+#[cfg(feature = "sync-agent-turns")]
 fn stringify_event(event: &InboundEvent) -> String {
     match event {
         InboundEvent::SystemInit { session_id } => format!("system.init session={session_id}"),
@@ -352,6 +363,7 @@ fn stringify_event(event: &InboundEvent) -> String {
     }
 }
 
+#[cfg(feature = "sync-agent-turns")]
 fn extract_assistant_text(v: &serde_json::Value) -> Option<String> {
     let blocks = v
         .get("message")
@@ -368,6 +380,7 @@ fn extract_assistant_text(v: &serde_json::Value) -> Option<String> {
     if buf.is_empty() { None } else { Some(buf) }
 }
 
+#[cfg(feature = "sync-agent-turns")]
 fn truncate(s: &str, max_chars: usize) -> String {
     if s.chars().count() <= max_chars {
         s.to_string()

--- a/crates/claude-server/src/chat/mod.rs
+++ b/crates/claude-server/src/chat/mod.rs
@@ -33,8 +33,8 @@ use crate::state::ServerState;
 pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
     vec![
         tool_chat_open(state),
-        tool_chat_send(state),
-        tool_chat_send_stream(state),
+        tool_chat_send_sync(state),
+        tool_chat_send_stream_sync(state),
         tool_chat_list(state),
         tool_chat_history(state),
         tool_chat_interrupt(state),
@@ -110,7 +110,7 @@ fn tool_chat_open(state: &ServerState) -> Tool {
         .build()
 }
 
-// -- chat_send -------------------------------------------------------
+// -- chat_send_sync --------------------------------------------------
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ChatSendInput {
@@ -120,13 +120,14 @@ struct ChatSendInput {
     prompt: String,
 }
 
-fn tool_chat_send(state: &ServerState) -> Tool {
+fn tool_chat_send_sync(state: &ServerState) -> Tool {
     let state = state.clone();
-    ToolBuilder::new("chat_send")
+    ToolBuilder::new("chat_send_sync")
         .description(
-            "Send a turn to a chat opened with chat_open. Blocks until the \
-             assistant finishes the turn. Returns the assistant text, \
-             session id, cumulative cost, and turn count.",
+            "Blocking turn send. Holds the connection open until the assistant \
+             finishes the turn, then returns assistant text + cost + turn count. \
+             For agent turns prefer `chat_send` (async, returns turn_id); use \
+             this when you genuinely want to block.",
         )
         .handler(move |input: ChatSendInput| {
             let state = state.clone();
@@ -152,27 +153,30 @@ fn tool_chat_send(state: &ServerState) -> Tool {
         .build()
 }
 
-// -- chat_send_stream -----------------------------------------------
+// -- chat_send_stream_sync ------------------------------------------
 //
-// Streaming variant of chat_send. Forwards every InboundEvent the
-// duplex session emits to the MCP client as a `notifications/progress`
-// message, so callers see assistant text deltas, tool-use blocks, and
-// system events as they arrive instead of waiting for the final
-// TurnResult.
+// Streaming variant of chat_send_sync. Holds the connection open and
+// forwards every InboundEvent the duplex session emits to the MCP
+// client as a `notifications/progress` message so callers see
+// assistant text deltas / tool-use blocks / system events as they
+// arrive. Sync because the request stays open for the duration of
+// the turn -- async streaming is a separate problem (likely solved
+// via resource subscriptions on per-turn URIs).
 //
 // Implementation detail: we subscribe to the broadcast BEFORE calling
 // send so we never miss the SystemInit or first Assistant chunk.
 // The forwarder runs in a spawned task with a clone of `Context`;
 // when send returns we abort it.
 
-fn tool_chat_send_stream(state: &ServerState) -> Tool {
+fn tool_chat_send_stream_sync(state: &ServerState) -> Tool {
     let state = state.clone();
-    ToolBuilder::new("chat_send_stream")
+    ToolBuilder::new("chat_send_stream_sync")
         .description(
-            "Streaming variant of chat_send. Each event from the underlying \
+            "Blocking streaming turn send. Each event from the underlying \
              duplex session is forwarded as an MCP `notifications/progress` \
              event (assistant deltas, tool-use blocks, system events). \
-             The final return is identical to chat_send.",
+             The final return is identical to chat_send_sync. Held connection \
+             for the duration of the turn -- explicit sync per design rule.",
         )
         .extractor_handler(
             state,

--- a/crates/claude-server/src/chat/slash.rs
+++ b/crates/claude-server/src/chat/slash.rs
@@ -112,17 +112,28 @@ async fn fire_slash(
         }
         match guard.send(prompt).await {
             Ok(turn) => {
+                let result_text = turn.result_text().map(str::to_string);
+                let session_id = turn.session_id().map(str::to_string);
+                let cost = turn.total_cost_usd();
+                let dur = turn.duration_ms();
+                let cumulative = guard.total_cost_usd();
+                let total_turns = guard.total_turns();
+                drop(guard);
                 handle.complete(json!({
-                    "result": turn.result_text(),
-                    "session_id": turn.session_id(),
-                    "turn_cost_usd": turn.total_cost_usd(),
-                    "duration_ms": turn.duration_ms(),
-                    "cumulative_cost_usd": guard.total_cost_usd(),
-                    "total_turns": guard.total_turns(),
+                    "result": result_text,
+                    "session_id": session_id,
+                    "turn_cost_usd": cost,
+                    "duration_ms": dur,
+                    "cumulative_cost_usd": cumulative,
+                    "total_turns": total_turns,
                 }));
             }
-            Err(e) => handle.fail(e),
+            Err(e) => {
+                drop(guard);
+                handle.fail(e);
+            }
         }
+        state_for_worker.notify_resource_updated(format!("claude://chats/{chat_id_for_worker}"));
     });
 
     Ok(CallToolResult::json(json!({

--- a/crates/claude-server/src/chat/slash.rs
+++ b/crates/claude-server/src/chat/slash.rs
@@ -22,6 +22,8 @@ use serde::Deserialize;
 use serde_json::json;
 use tower_mcp::{CallToolResult, Tool, ToolBuilder};
 
+use claude_wrapper::slash;
+
 use crate::state::ServerState;
 
 /// Build the slash-command tool list.
@@ -57,19 +59,12 @@ fn tool_chat_compact(state: &ServerState) -> Tool {
                 fire_slash(
                     &state,
                     &input.chat_id,
-                    build_compact_prompt(input.instructions),
+                    slash::compact(input.instructions.as_deref()),
                 )
                 .await
             }
         })
         .build()
-}
-
-fn build_compact_prompt(instructions: Option<String>) -> String {
-    match instructions {
-        Some(s) if !s.trim().is_empty() => format!("/compact {}", s.trim()),
-        _ => "/compact".to_string(),
-    }
 }
 
 /// Common fire-a-slash-command machinery. Same shape as the async
@@ -140,28 +135,4 @@ async fn fire_slash(
         "turn_id": turn_id,
         "chat_id": chat_id,
     })))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::build_compact_prompt;
-
-    #[test]
-    fn compact_prompt_without_instructions() {
-        assert_eq!(build_compact_prompt(None), "/compact");
-        assert_eq!(build_compact_prompt(Some(String::new())), "/compact");
-        assert_eq!(build_compact_prompt(Some("   ".into())), "/compact");
-    }
-
-    #[test]
-    fn compact_prompt_with_instructions() {
-        assert_eq!(
-            build_compact_prompt(Some("focus on auth".into())),
-            "/compact focus on auth"
-        );
-        assert_eq!(
-            build_compact_prompt(Some("  trim whitespace  ".into())),
-            "/compact trim whitespace"
-        );
-    }
 }

--- a/crates/claude-server/src/chat/slash.rs
+++ b/crates/claude-server/src/chat/slash.rs
@@ -1,0 +1,156 @@
+//! Slash-command-as-tool family for the chat surface.
+//!
+//! Claude's interactive CLI exposes commands like `/compact`,
+//! `/clear`, `/model` that the user types mid-conversation. In
+//! stream-json input mode the same `/foo args` strings are passed
+//! through as turns -- the CLI interprets them, the model doesn't
+//! see them as user prompts. We can therefore expose them as
+//! discrete MCP tools rather than asking the model to remember the
+//! `/` prefix and command names.
+//!
+//! Each tool fires the slash command via the same async-turn
+//! machinery as `chat_send` -- registers a turn in the registry,
+//! spawns a worker that acquires the Conversation mutex and writes
+//! the slash string. Returns immediately with `{ turn_id }`.
+//!
+//! Today: `chat_compact`. Other commands (`chat_clear`,
+//! `chat_model_set`, ...) follow once we've validated the pattern
+//! works through stream-json.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+
+use crate::state::ServerState;
+
+/// Build the slash-command tool list.
+pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
+    vec![tool_chat_compact(state)]
+}
+
+// -- chat_compact ---------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ChatCompactInput {
+    /// Identifier returned by `chat_open`.
+    chat_id: String,
+    /// Optional instructions appended to `/compact`. Mirrors the CLI:
+    /// `/compact focus on auth bug` becomes the prompt sent. Omit for
+    /// a default compaction.
+    #[serde(default)]
+    instructions: Option<String>,
+}
+
+fn tool_chat_compact(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("chat_compact")
+        .description(
+            "Fire `/compact` against an open chat to compact the conversation \
+             history. Returns immediately with a turn_id; poll with `turn_get` \
+             or block with `turn_wait`. Optional `instructions` are passed \
+             through to the CLI's compaction prompt.",
+        )
+        .handler(move |input: ChatCompactInput| {
+            let state = state.clone();
+            async move {
+                fire_slash(
+                    &state,
+                    &input.chat_id,
+                    build_compact_prompt(input.instructions),
+                )
+                .await
+            }
+        })
+        .build()
+}
+
+fn build_compact_prompt(instructions: Option<String>) -> String {
+    match instructions {
+        Some(s) if !s.trim().is_empty() => format!("/compact {}", s.trim()),
+        _ => "/compact".to_string(),
+    }
+}
+
+/// Common fire-a-slash-command machinery. Same shape as the async
+/// `chat_send` body -- validate chat exists, register a turn, spawn
+/// a worker that acquires the Conversation mutex and writes the
+/// slash string as the turn's prompt.
+async fn fire_slash(
+    state: &ServerState,
+    chat_id: &str,
+    prompt: String,
+) -> Result<CallToolResult, tower_mcp::Error> {
+    if state.get_chat(chat_id).await.is_none() {
+        return Err(tower_mcp::Error::internal(format!(
+            "no chat with id `{chat_id}` (was it closed?)"
+        )));
+    }
+    let handle = state.turns.register(Some(chat_id.to_string())).await;
+    let turn_id = handle.turn_id.clone();
+
+    let state_for_worker = state.clone();
+    let chat_id_for_worker = chat_id.to_string();
+    tokio::spawn(async move {
+        if handle.is_cancelled() {
+            handle.cancelled();
+            return;
+        }
+        let conv = match state_for_worker.get_chat(&chat_id_for_worker).await {
+            Some(c) => c,
+            None => {
+                handle.fail(format!(
+                    "no chat with id `{chat_id_for_worker}` (was it closed?)"
+                ));
+                return;
+            }
+        };
+        let mut guard = conv.lock().await;
+        if handle.is_cancelled() {
+            handle.cancelled();
+            return;
+        }
+        match guard.send(prompt).await {
+            Ok(turn) => {
+                handle.complete(json!({
+                    "result": turn.result_text(),
+                    "session_id": turn.session_id(),
+                    "turn_cost_usd": turn.total_cost_usd(),
+                    "duration_ms": turn.duration_ms(),
+                    "cumulative_cost_usd": guard.total_cost_usd(),
+                    "total_turns": guard.total_turns(),
+                }));
+            }
+            Err(e) => handle.fail(e),
+        }
+    });
+
+    Ok(CallToolResult::json(json!({
+        "turn_id": turn_id,
+        "chat_id": chat_id,
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_compact_prompt;
+
+    #[test]
+    fn compact_prompt_without_instructions() {
+        assert_eq!(build_compact_prompt(None), "/compact");
+        assert_eq!(build_compact_prompt(Some(String::new())), "/compact");
+        assert_eq!(build_compact_prompt(Some("   ".into())), "/compact");
+    }
+
+    #[test]
+    fn compact_prompt_with_instructions() {
+        assert_eq!(
+            build_compact_prompt(Some("focus on auth".into())),
+            "/compact focus on auth"
+        );
+        assert_eq!(
+            build_compact_prompt(Some("  trim whitespace  ".into())),
+            "/compact trim whitespace"
+        );
+    }
+}

--- a/crates/claude-server/src/config.rs
+++ b/crates/claude-server/src/config.rs
@@ -31,6 +31,14 @@ pub struct ServerConfig {
     /// non-default Claude Code installs. Only consulted when the
     /// `artifacts` Cargo feature is enabled.
     pub agents_root: Option<PathBuf>,
+    /// Override the repository path that the `worktrees` feature
+    /// targets when no explicit `repo_path` is passed to
+    /// `worktree_list`. Defaults to [`ClaudeConfig::working_dir`]
+    /// when unset, or the process cwd if neither is set. Useful for
+    /// tests (point at a `git init`'d tempdir) and for servers that
+    /// want a per-server "default repo." Only consulted when the
+    /// `worktrees` Cargo feature is enabled.
+    pub worktrees_root: Option<PathBuf>,
 }
 
 /// Server-level policy flags. Mutating tools (mcp_add, plugin_install,

--- a/crates/claude-server/src/config.rs
+++ b/crates/claude-server/src/config.rs
@@ -13,6 +13,29 @@ use serde::{Deserialize, Serialize};
 pub struct ServerConfig {
     /// Wrapper-side knobs: binary, working dir, env, global args.
     pub claude: ClaudeConfig,
+    /// Async-turn registry knobs: TTL + sweeper cadence. Defaults
+    /// to 1 hour TTL with a 60-second sweep interval.
+    pub turns: TurnConfig,
+}
+
+/// Knobs for the async-turn registry's TTL eviction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TurnConfig {
+    /// Terminal turns (done/failed/cancelled) older than this are
+    /// evicted by the background sweeper. In seconds.
+    pub ttl_secs: u64,
+    /// How often the sweeper runs. In seconds.
+    pub sweep_interval_secs: u64,
+}
+
+impl Default for TurnConfig {
+    fn default() -> Self {
+        Self {
+            ttl_secs: 3600, // 1 hour
+            sweep_interval_secs: 60,
+        }
+    }
 }
 
 /// Inputs to the [`claude_wrapper::ClaudeBuilder`].

--- a/crates/claude-server/src/config.rs
+++ b/crates/claude-server/src/config.rs
@@ -39,6 +39,12 @@ pub struct ServerConfig {
     /// want a per-server "default repo." Only consulted when the
     /// `worktrees` Cargo feature is enabled.
     pub worktrees_root: Option<PathBuf>,
+    /// Override the on-disk jobs root that the `jobs` feature reads
+    /// from. Defaults to `~/.claude/jobs`. Same semantics as
+    /// [`Self::history_root`] -- intended for tests and non-default
+    /// Claude Code installs. Only consulted when the `jobs` Cargo
+    /// feature is enabled.
+    pub jobs_root: Option<PathBuf>,
 }
 
 /// Server-level policy flags. Mutating tools (mcp_add, plugin_install,

--- a/crates/claude-server/src/config.rs
+++ b/crates/claude-server/src/config.rs
@@ -25,6 +25,12 @@ pub struct ServerConfig {
     /// installs. Only consulted when the `history` Cargo feature
     /// is enabled.
     pub history_root: Option<PathBuf>,
+    /// Override the on-disk agents root that the `artifacts` feature
+    /// reads from. Defaults to `~/.claude/agents`. Same semantics
+    /// as [`Self::history_root`] -- intended for tests and
+    /// non-default Claude Code installs. Only consulted when the
+    /// `artifacts` Cargo feature is enabled.
+    pub agents_root: Option<PathBuf>,
 }
 
 /// Server-level policy flags. Mutating tools (mcp_add, plugin_install,

--- a/crates/claude-server/src/config.rs
+++ b/crates/claude-server/src/config.rs
@@ -1,0 +1,35 @@
+//! Server configuration. Loaded from TOML or built in code.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level server configuration. Map from a TOML file or build by
+/// hand. Default is "talk to whatever `claude` is on `$PATH`, no
+/// special env, default timeout."
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ServerConfig {
+    /// Wrapper-side knobs: binary, working dir, env, global args.
+    pub claude: ClaudeConfig,
+}
+
+/// Inputs to the [`claude_wrapper::ClaudeBuilder`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ClaudeConfig {
+    /// Override the `claude` binary path. Defaults to `$PATH` lookup.
+    pub binary: Option<PathBuf>,
+    /// Default working directory for spawned processes. Tools may
+    /// override per call where it makes sense.
+    pub working_dir: Option<PathBuf>,
+    /// Per-invocation timeout in seconds. Defaults to 5 minutes.
+    pub timeout_secs: Option<u64>,
+    /// Extra environment variables passed to every spawned `claude`.
+    pub env: BTreeMap<String, String>,
+    /// Global args prepended to every `claude` invocation (after the
+    /// binary, before the subcommand). Useful for `--no-color` and
+    /// the like.
+    pub global_args: Vec<String>,
+}

--- a/crates/claude-server/src/config.rs
+++ b/crates/claude-server/src/config.rs
@@ -45,6 +45,69 @@ pub struct ServerConfig {
     /// Claude Code installs. Only consulted when the `jobs` Cargo
     /// feature is enabled.
     pub jobs_root: Option<PathBuf>,
+    /// Per-surface runtime gates. Layered on top of the compile-time
+    /// Cargo features: a Cargo feature being off means a surface is
+    /// **never** registered regardless of this config; a Cargo
+    /// feature being on means the surface defaults to registered
+    /// but can be disabled per-deployment via these flags.
+    pub surfaces: SurfacesConfig,
+}
+
+/// Per-surface runtime gates. All default `true` so out-of-the-box
+/// behavior matches the historical "if it's compiled in, it's
+/// registered" policy. Operators flip individual flags to `false`
+/// when they want a single binary that exposes only a subset.
+///
+/// **Cargo features remain the hard ceiling.** Setting
+/// `enable_artifacts = true` on a binary built without the
+/// `artifacts` feature does nothing -- the surface code isn't
+/// linked in.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SurfacesConfig {
+    /// L2 CLI passthrough tools (`claude_*`). Default `true`.
+    pub enable_core: bool,
+    /// L2.5 long-lived chat surface (`chat_*`, `turn_*`,
+    /// `claude://chats[/{id}]`). Default `true`.
+    pub enable_chat: bool,
+    /// Process counters (`metrics_summary`, `claude://metrics`).
+    /// Default `true`.
+    pub enable_metrics: bool,
+    /// Mutating CLI passthrough (`claude_mcp_add`,
+    /// `claude_plugin_install`, etc.) AND mutating artifact tools
+    /// (`agent_write`, `agent_delete`). Layered on top of the
+    /// existing `policy.allow_mutations` runtime check and the
+    /// `mutations` Cargo feature -- ALL three must be true for
+    /// mutating tools to register. Default `true`.
+    pub enable_mutations: bool,
+    /// Historical session reads (`claude_project_list`,
+    /// `claude_session_*`, `claude://projects`, `claude://sessions/{id}`).
+    /// Default `true`.
+    pub enable_history: bool,
+    /// User-level agent artifact reads (`agent_list`, `agent_get`,
+    /// `claude://agents[/{stem}]`). Default `true`.
+    pub enable_artifacts: bool,
+    /// Git worktree introspection (`worktree_list`,
+    /// `claude://worktrees`). Default `true`.
+    pub enable_worktrees: bool,
+    /// Background-job state reads (`claude_job_list`,
+    /// `claude_job_get`, `claude://jobs[/{short_id}]`). Default `true`.
+    pub enable_jobs: bool,
+}
+
+impl Default for SurfacesConfig {
+    fn default() -> Self {
+        Self {
+            enable_core: true,
+            enable_chat: true,
+            enable_metrics: true,
+            enable_mutations: true,
+            enable_history: true,
+            enable_artifacts: true,
+            enable_worktrees: true,
+            enable_jobs: true,
+        }
+    }
 }
 
 /// Server-level policy flags. Mutating tools (mcp_add, plugin_install,

--- a/crates/claude-server/src/config.rs
+++ b/crates/claude-server/src/config.rs
@@ -19,6 +19,12 @@ pub struct ServerConfig {
     /// Server-level policy: what mutating operations are allowed.
     /// Defaults are deliberately conservative (no mutations).
     pub policy: ServerPolicy,
+    /// Override the on-disk history root that the `history` feature
+    /// reads from. Defaults to `~/.claude/projects`. Useful for
+    /// tests (point at a tempdir) and non-default Claude Code
+    /// installs. Only consulted when the `history` Cargo feature
+    /// is enabled.
+    pub history_root: Option<PathBuf>,
 }
 
 /// Server-level policy flags. Mutating tools (mcp_add, plugin_install,

--- a/crates/claude-server/src/config.rs
+++ b/crates/claude-server/src/config.rs
@@ -16,6 +16,22 @@ pub struct ServerConfig {
     /// Async-turn registry knobs: TTL + sweeper cadence. Defaults
     /// to 1 hour TTL with a 60-second sweep interval.
     pub turns: TurnConfig,
+    /// Server-level policy: what mutating operations are allowed.
+    /// Defaults are deliberately conservative (no mutations).
+    pub policy: ServerPolicy,
+}
+
+/// Server-level policy flags. Mutating tools (mcp_add, plugin_install,
+/// etc.) are NOT registered unless [`Self::allow_mutations`] is true.
+/// When off the model literally cannot discover them.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ServerPolicy {
+    /// When true, register CLI mutating tools that change MCP server
+    /// config, plugins, marketplaces. Default false because an
+    /// unmonitored coordinator could otherwise rewrite your claude
+    /// setup without warning.
+    pub allow_mutations: bool,
 }
 
 /// Knobs for the async-turn registry's TTL eviction.

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -30,7 +30,9 @@ use claude_wrapper::command::auto_mode::{
 use claude_wrapper::command::doctor::DoctorCommand;
 use claude_wrapper::command::marketplace::MarketplaceListCommand;
 use claude_wrapper::command::mcp::{McpGetCommand, McpListCommand};
-use claude_wrapper::command::plugin::{PluginListCommand, PluginValidateCommand};
+use claude_wrapper::command::plugin::{
+    PluginDetailsCommand, PluginListCommand, PluginValidateCommand,
+};
 use claude_wrapper::exec::CommandOutput;
 
 use crate::state::ServerState;
@@ -47,6 +49,7 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
         tool_mcp_list(state),
         tool_mcp_get(state),
         tool_plugin_list(state),
+        tool_plugin_details(state),
         tool_plugin_validate(state),
         tool_marketplace_list(state),
         tool_auto_mode_config(state),
@@ -346,6 +349,35 @@ fn tool_plugin_list(state: &ServerState) -> Tool {
             let claude = claude.clone();
             async move {
                 let out = PluginListCommand::new()
+                    .execute(&claude)
+                    .await
+                    .map_err(from_wrapper)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_plugin_details ------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PluginDetailsInput {
+    /// Plugin name to look up.
+    plugin: String,
+}
+
+fn tool_plugin_details(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_plugin_details")
+        .description(
+            "Run `claude plugin details <name>` to show a plugin's \
+             component inventory and projected token cost. Read-only.",
+        )
+        .read_only()
+        .handler(move |input: PluginDetailsInput| {
+            let claude = claude.clone();
+            async move {
+                let out = PluginDetailsCommand::new(input.plugin)
                     .execute(&claude)
                     .await
                     .map_err(from_wrapper)?;

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -448,7 +448,7 @@ fn command_output_json(out: &CommandOutput) -> CallToolResult {
 /// two-byte sequences (`ESC c`, `ESC =`, etc.). Conservative -- if we
 /// see an `ESC` we don't recognise, we still drop it so users don't
 /// end up with stray control bytes in their MCP payloads.
-fn strip_ansi(input: &str) -> String {
+pub(crate) fn strip_ansi(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut i = 0;

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -24,7 +24,9 @@ use claude_wrapper::OutputFormat;
 use claude_wrapper::QueryCommand;
 use claude_wrapper::command::agents::AgentsCommand;
 use claude_wrapper::command::auth::AuthStatusCommand;
-use claude_wrapper::command::auto_mode::{AutoModeConfigCommand, AutoModeDefaultsCommand};
+use claude_wrapper::command::auto_mode::{
+    AutoModeConfigCommand, AutoModeCritiqueCommand, AutoModeDefaultsCommand,
+};
 use claude_wrapper::command::doctor::DoctorCommand;
 use claude_wrapper::command::marketplace::MarketplaceListCommand;
 use claude_wrapper::command::mcp::{McpGetCommand, McpListCommand};
@@ -49,6 +51,7 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
         tool_marketplace_list(state),
         tool_auto_mode_config(state),
         tool_auto_mode_defaults(state),
+        tool_auto_mode_critique(state),
         tool_doctor(state),
     ];
     #[cfg(feature = "sync-agent-turns")]
@@ -427,6 +430,70 @@ fn tool_auto_mode_defaults(state: &ServerState) -> Tool {
                     .await
                     .map_err(internal)?;
                 Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_auto_mode_critique --------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct AutoModeCritiqueInput {
+    /// Optional model override (e.g. `sonnet`, `haiku`).
+    #[serde(default)]
+    model: Option<String>,
+}
+
+fn tool_auto_mode_critique(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("claude_auto_mode_critique")
+        .description(
+            "Fire `claude auto-mode critique` to get AI feedback on the active \
+             auto-mode rules. Async by default -- returns a turn_id; the work \
+             runs in the background. Poll with turn_get / turn_wait. Single-shot \
+             agent turn (model-backed); same shape as claude_query.",
+        )
+        .handler(move |input: AutoModeCritiqueInput| {
+            let state = state.clone();
+            async move {
+                let handle = state.turns.register(None).await;
+                let turn_id = handle.turn_id.clone();
+                let claude = state.claude.clone();
+                let span = tracing::info_span!(
+                    "claude_auto_mode_critique",
+                    turn_id = %turn_id,
+                    model = input.model.as_deref().unwrap_or("default"),
+                );
+                tracing::info!(parent: &span, "fired async critique");
+                tokio::spawn(
+                    async move {
+                        if handle.is_cancelled() {
+                            handle.cancelled();
+                            return;
+                        }
+                        let mut cmd = AutoModeCritiqueCommand::new();
+                        if let Some(m) = input.model {
+                            cmd = cmd.model(m);
+                        }
+                        match cmd.execute(&claude).await {
+                            Ok(out) => {
+                                tracing::info!(exit_code = out.exit_code, "critique done");
+                                handle.complete(json!({
+                                    "stdout": strip_ansi(&out.stdout),
+                                    "stderr": strip_ansi(&out.stderr),
+                                    "exit_code": out.exit_code,
+                                    "success": out.success,
+                                }));
+                            }
+                            Err(e) => {
+                                tracing::error!(error = %e, "critique failed");
+                                handle.fail(e);
+                            }
+                        }
+                    }
+                    .instrument(span),
+                );
+                Ok(CallToolResult::json(json!({"turn_id": turn_id})))
             }
         })
         .build()

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -36,6 +36,7 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
     vec![
         tool_version(),
         tool_cli_version(state),
+        tool_query(state),
         tool_query_sync(state),
         tool_agents(state),
         tool_auth_status(state),
@@ -92,7 +93,7 @@ fn tool_cli_version(state: &ServerState) -> Tool {
         .build()
 }
 
-// -- claude_query ----------------------------------------------------
+// -- claude_query / claude_query_sync -------------------------------
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct QueryInput {
@@ -107,6 +108,80 @@ struct QueryInput {
     /// Resume a previous session by id.
     #[serde(default)]
     resume: Option<String>,
+    /// Run the query in a fresh git worktree (`claude --worktree`).
+    /// Useful for "agent runs in isolation" -- the query's writes
+    /// land in a side worktree instead of the current working tree.
+    /// Named worktrees aren't yet supported on the single-shot path
+    /// (wrapper limitation; see chat_open for the named variant).
+    #[serde(default)]
+    worktree: Option<bool>,
+}
+
+fn build_query(input: &QueryInput) -> QueryCommand {
+    // output_format on the builder lands BEFORE the `--` separator,
+    // unlike execute_json's late push -- wrapper bug worked around.
+    let mut q = QueryCommand::new(input.prompt.clone()).output_format(OutputFormat::Json);
+    if let Some(ref m) = input.model {
+        q = q.model(m.clone());
+    }
+    if let Some(ref s) = input.system_prompt {
+        q = q.system_prompt(s.clone());
+    }
+    if let Some(ref r) = input.resume {
+        q = q.resume(r.clone());
+    }
+    if input.worktree.unwrap_or(false) {
+        q = q.worktree();
+    }
+    q
+}
+
+fn parse_query_envelope(stdout: &str) -> Result<serde_json::Value, tower_mcp::Error> {
+    let parsed: serde_json::Value = serde_json::from_str(stdout)
+        .map_err(|e| internal(format!("parse query JSON: {e}; stdout={stdout}")))?;
+    Ok(json!({
+        "result": parsed.get("result").cloned().unwrap_or(serde_json::Value::Null),
+        "session_id": parsed.get("session_id").cloned().unwrap_or(serde_json::Value::Null),
+        "total_cost_usd": parsed.get("total_cost_usd").cloned().unwrap_or(serde_json::Value::Null),
+        "duration_ms": parsed.get("duration_ms").cloned().unwrap_or(serde_json::Value::Null),
+        "num_turns": parsed.get("num_turns").cloned().unwrap_or(serde_json::Value::Null),
+        "is_error": parsed.get("is_error").cloned().unwrap_or(serde_json::Value::Null),
+    }))
+}
+
+fn tool_query(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("claude_query")
+        .description(
+            "Fire a single-shot agent query and return immediately with a \
+             turn_id. The query runs in the background; poll with `turn_get`, \
+             block with `turn_wait`, cancel with `turn_cancel`. For the \
+             blocking variant, see `claude_query_sync`.",
+        )
+        .handler(move |input: QueryInput| {
+            let state = state.clone();
+            async move {
+                let handle = state.turns.register(None).await;
+                let turn_id = handle.turn_id.clone();
+                let claude = state.claude.clone();
+                tokio::spawn(async move {
+                    if handle.is_cancelled() {
+                        handle.cancelled();
+                        return;
+                    }
+                    let q = build_query(&input);
+                    match q.execute(&claude).await {
+                        Ok(out) => match parse_query_envelope(&out.stdout) {
+                            Ok(env) => handle.complete(env),
+                            Err(e) => handle.fail(e.to_string()),
+                        },
+                        Err(e) => handle.fail(e),
+                    }
+                });
+                Ok(CallToolResult::json(json!({"turn_id": turn_id})))
+            }
+        })
+        .build()
 }
 
 fn tool_query_sync(state: &ServerState) -> Tool {
@@ -122,31 +197,10 @@ fn tool_query_sync(state: &ServerState) -> Tool {
         .handler(move |input: QueryInput| {
             let claude = Arc::clone(&claude);
             async move {
-                // Setting output_format on the builder ensures it lands
-                // before the `--` separator. (execute_json appends it
-                // after, where it gets eaten as prompt text -- wrapper
-                // bug, worked around here.)
-                let mut q = QueryCommand::new(input.prompt).output_format(OutputFormat::Json);
-                if let Some(m) = input.model {
-                    q = q.model(m);
-                }
-                if let Some(s) = input.system_prompt {
-                    q = q.system_prompt(s);
-                }
-                if let Some(r) = input.resume {
-                    q = q.resume(r);
-                }
+                let q = build_query(&input);
                 let out = q.execute(&claude).await.map_err(internal)?;
-                let parsed: serde_json::Value = serde_json::from_str(&out.stdout)
-                    .map_err(|e| internal(format!("parse query JSON: {e}; stdout={}", out.stdout)))?;
-                Ok(CallToolResult::json(json!({
-                    "result": parsed.get("result").cloned().unwrap_or(serde_json::Value::Null),
-                    "session_id": parsed.get("session_id").cloned().unwrap_or(serde_json::Value::Null),
-                    "total_cost_usd": parsed.get("total_cost_usd").cloned().unwrap_or(serde_json::Value::Null),
-                    "duration_ms": parsed.get("duration_ms").cloned().unwrap_or(serde_json::Value::Null),
-                    "num_turns": parsed.get("num_turns").cloned().unwrap_or(serde_json::Value::Null),
-                    "is_error": parsed.get("is_error").cloned().unwrap_or(serde_json::Value::Null),
-                })))
+                let env = parse_query_envelope(&out.stdout)?;
+                Ok(CallToolResult::json(env))
             }
         })
         .build()

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -36,7 +36,7 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
     vec![
         tool_version(),
         tool_cli_version(state),
-        tool_query(state),
+        tool_query_sync(state),
         tool_agents(state),
         tool_auth_status(state),
         tool_mcp_list(state),
@@ -109,13 +109,14 @@ struct QueryInput {
     resume: Option<String>,
 }
 
-fn tool_query(state: &ServerState) -> Tool {
+fn tool_query_sync(state: &ServerState) -> Tool {
     let claude = state.claude.clone();
-    ToolBuilder::new("claude_query")
+    ToolBuilder::new("claude_query_sync")
         .description(
-            "Single-shot query against the claude CLI. Returns the assistant text, \
-             session id, and cost (when available). For multi-turn conversations \
-             use the chat_* tools (when wired).",
+            "Blocking single-shot query against the claude CLI. Holds the \
+             connection open for the duration of the turn. Returns assistant \
+             text, session id, and cost. Prefer the async `claude_query` for \
+             agent turns; use this when you genuinely want to block.",
         )
         .read_only()
         .handler(move |input: QueryInput| {

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -17,6 +17,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
 use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+use tracing::Instrument;
 
 use claude_wrapper::ClaudeCommand;
 use claude_wrapper::OutputFormat;
@@ -170,20 +171,46 @@ fn tool_query(state: &ServerState) -> Tool {
                 let handle = state.turns.register(None).await;
                 let turn_id = handle.turn_id.clone();
                 let claude = state.claude.clone();
-                tokio::spawn(async move {
-                    if handle.is_cancelled() {
-                        handle.cancelled();
-                        return;
+                let span = tracing::info_span!(
+                    "claude_query",
+                    turn_id = %turn_id,
+                    model = input.model.as_deref().unwrap_or("default"),
+                    prompt_len = input.prompt.len(),
+                );
+                tracing::info!(parent: &span, "fired async query");
+                tokio::spawn(
+                    async move {
+                        if handle.is_cancelled() {
+                            tracing::info!("query cancelled before start");
+                            handle.cancelled();
+                            return;
+                        }
+                        let q = build_query(&input);
+                        match q.execute(&claude).await {
+                            Ok(out) => match parse_query_envelope(&out.stdout) {
+                                Ok(env) => {
+                                    let cost = env.get("total_cost_usd").and_then(|v| v.as_f64());
+                                    let dur = env.get("duration_ms").and_then(|v| v.as_u64());
+                                    tracing::info!(
+                                        cost_usd = ?cost,
+                                        duration_ms = ?dur,
+                                        "query done"
+                                    );
+                                    handle.complete(env);
+                                }
+                                Err(e) => {
+                                    tracing::error!(error = %e, "parse failed");
+                                    handle.fail(e.to_string());
+                                }
+                            },
+                            Err(e) => {
+                                tracing::error!(error = %e, "query failed");
+                                handle.fail(e);
+                            }
+                        }
                     }
-                    let q = build_query(&input);
-                    match q.execute(&claude).await {
-                        Ok(out) => match parse_query_envelope(&out.stdout) {
-                            Ok(env) => handle.complete(env),
-                            Err(e) => handle.fail(e.to_string()),
-                        },
-                        Err(e) => handle.fail(e),
-                    }
-                });
+                    .instrument(span),
+                );
                 Ok(CallToolResult::json(json!({"turn_id": turn_id})))
             }
         })

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -10,6 +10,7 @@
 //! `claude_mcp_list`, `claude_plugin_validate`, etc. The CLI command
 //! `claude foo bar baz` maps to `claude_foo_bar_baz`.
 
+#[cfg(feature = "sync-agent-turns")]
 use std::sync::Arc;
 
 use schemars::JsonSchema;
@@ -33,11 +34,11 @@ use crate::state::ServerState;
 
 /// Build the full L2 passthrough tool list.
 pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
-    vec![
+    #[cfg_attr(not(feature = "sync-agent-turns"), allow(unused_mut))]
+    let mut out = vec![
         tool_version(),
         tool_cli_version(state),
         tool_query(state),
-        tool_query_sync(state),
         tool_agents(state),
         tool_auth_status(state),
         tool_mcp_list(state),
@@ -48,7 +49,12 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
         tool_auto_mode_config(state),
         tool_auto_mode_defaults(state),
         tool_doctor(state),
-    ]
+    ];
+    #[cfg(feature = "sync-agent-turns")]
+    {
+        out.push(tool_query_sync(state));
+    }
+    out
 }
 
 // -- shared inputs ---------------------------------------------------
@@ -184,6 +190,7 @@ fn tool_query(state: &ServerState) -> Tool {
         .build()
 }
 
+#[cfg(feature = "sync-agent-turns")]
 fn tool_query_sync(state: &ServerState) -> Tool {
     let claude = state.claude.clone();
     ToolBuilder::new("claude_query_sync")

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -508,7 +508,13 @@ fn tool_auto_mode_critique(state: &ServerState) -> Tool {
 fn tool_doctor(state: &ServerState) -> Tool {
     let claude = state.claude.clone();
     ToolBuilder::new("claude_doctor")
-        .description("Run `claude doctor` for a CLI health check. Can be slow (3+ minutes).")
+        .description(
+            "Run `claude doctor` for a CLI health check. Can be slow (3+ minutes). \
+             Output also includes `cli_version_status` (tested | newer_untested | \
+             older_than_minimum) classifying the installed CLI against the server's \
+             tested-against range, plus `tested_cli_version_range` for the range \
+             itself.",
+        )
         .read_only()
         .handler(move |_input: NoArgs| {
             let claude = claude.clone();
@@ -517,7 +523,24 @@ fn tool_doctor(state: &ServerState) -> Tool {
                     .execute(&claude)
                     .await
                     .map_err(from_wrapper)?;
-                Ok(command_output_json(&out))
+                // Best-effort classification; fall back to omitting
+                // the field if cli_version fetch fails (e.g., binary
+                // missing). Doctor itself is the more authoritative
+                // health check; we just augment.
+                let status = claude.cli_version_status().await.ok();
+                let range = claude.tested_cli_version_range();
+                let mut body = command_output_json_value(&out);
+                if let Some(s) = status {
+                    body["cli_version_status"] =
+                        serde_json::to_value(s).unwrap_or(serde_json::Value::Null);
+                }
+                if let Some((min, max)) = range {
+                    body["tested_cli_version_range"] = json!({
+                        "min": min,
+                        "max": max,
+                    });
+                }
+                Ok(CallToolResult::json(body))
             }
         })
         .build()
@@ -530,12 +553,18 @@ use crate::errors::{from_wrapper, internal};
 /// Wrap a [`CommandOutput`] as the standard tool JSON envelope.
 /// ANSI escape sequences are stripped from stdout/stderr.
 fn command_output_json(out: &CommandOutput) -> CallToolResult {
-    CallToolResult::json(json!({
+    CallToolResult::json(command_output_json_value(out))
+}
+
+/// Same as [`command_output_json`] but returns a raw `serde_json::Value`
+/// so callers can extend it with extra fields before wrapping.
+fn command_output_json_value(out: &CommandOutput) -> serde_json::Value {
+    json!({
         "stdout": strip_ansi(&out.stdout),
         "stderr": strip_ansi(&out.stderr),
         "exit_code": out.exit_code,
         "success": out.success,
-    }))
+    })
 }
 
 /// Strip ANSI/VT escape sequences from a string.

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -23,7 +23,6 @@ use claude_wrapper::ClaudeCommand;
 use claude_wrapper::OutputFormat;
 use claude_wrapper::QueryCommand;
 use claude_wrapper::auth;
-use claude_wrapper::command::agents::AgentsCommand;
 use claude_wrapper::command::auth::AuthStatusCommand;
 use claude_wrapper::command::auto_mode::{
     AutoModeConfigCommand, AutoModeCritiqueCommand, AutoModeDefaultsCommand,
@@ -43,7 +42,6 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
         tool_version(),
         tool_cli_version(state),
         tool_query(state),
-        tool_agents(state),
         tool_auth_status(state),
         tool_auth_strategy(),
         tool_mcp_list(state),
@@ -240,26 +238,6 @@ fn tool_query_sync(state: &ServerState) -> Tool {
                 let out = q.execute(&claude).await.map_err(from_wrapper)?;
                 let env = parse_query_envelope(&out.stdout)?;
                 Ok(CallToolResult::json(env))
-            }
-        })
-        .build()
-}
-
-// -- claude_agents ---------------------------------------------------
-
-fn tool_agents(state: &ServerState) -> Tool {
-    let claude = state.claude.clone();
-    ToolBuilder::new("claude_agents")
-        .description("Run `claude agents` to list configured agents.")
-        .read_only()
-        .handler(move |_input: NoArgs| {
-            let claude = claude.clone();
-            async move {
-                let out = AgentsCommand::new()
-                    .execute(&claude)
-                    .await
-                    .map_err(from_wrapper)?;
-                Ok(command_output_json(&out))
             }
         })
         .build()

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -93,7 +93,7 @@ fn tool_cli_version(state: &ServerState) -> Tool {
         .handler(move |_input: NoArgs| {
             let claude = claude.clone();
             async move {
-                let v = claude.cli_version().await.map_err(internal)?;
+                let v = claude.cli_version().await.map_err(from_wrapper)?;
                 Ok(CallToolResult::json(json!({
                     "major": v.major,
                     "minor": v.minor,
@@ -237,7 +237,7 @@ fn tool_query_sync(state: &ServerState) -> Tool {
             let claude = Arc::clone(&claude);
             async move {
                 let q = build_query(&input);
-                let out = q.execute(&claude).await.map_err(internal)?;
+                let out = q.execute(&claude).await.map_err(from_wrapper)?;
                 let env = parse_query_envelope(&out.stdout)?;
                 Ok(CallToolResult::json(env))
             }
@@ -258,7 +258,7 @@ fn tool_agents(state: &ServerState) -> Tool {
                 let out = AgentsCommand::new()
                     .execute(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(command_output_json(&out))
             }
         })
@@ -278,7 +278,7 @@ fn tool_auth_status(state: &ServerState) -> Tool {
                 let parsed = AuthStatusCommand::new()
                     .execute_json(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(CallToolResult::json(
                     serde_json::to_value(parsed).unwrap_or(json!(null)),
                 ))
@@ -324,7 +324,7 @@ fn tool_mcp_list(state: &ServerState) -> Tool {
                 let out = McpListCommand::new()
                     .execute(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(command_output_json(&out))
             }
         })
@@ -350,7 +350,7 @@ fn tool_mcp_get(state: &ServerState) -> Tool {
                 let out = McpGetCommand::new(input.name)
                     .execute(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(command_output_json(&out))
             }
         })
@@ -370,7 +370,7 @@ fn tool_plugin_list(state: &ServerState) -> Tool {
                 let out = PluginListCommand::new()
                     .execute(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(command_output_json(&out))
             }
         })
@@ -396,7 +396,7 @@ fn tool_plugin_validate(state: &ServerState) -> Tool {
                 let out = PluginValidateCommand::new(input.path)
                     .execute(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(command_output_json(&out))
             }
         })
@@ -416,7 +416,7 @@ fn tool_marketplace_list(state: &ServerState) -> Tool {
                 let out = MarketplaceListCommand::new()
                     .execute(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(command_output_json(&out))
             }
         })
@@ -436,7 +436,7 @@ fn tool_auto_mode_config(state: &ServerState) -> Tool {
                 let out = AutoModeConfigCommand::new()
                     .execute(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(command_output_json(&out))
             }
         })
@@ -454,7 +454,7 @@ fn tool_auto_mode_defaults(state: &ServerState) -> Tool {
                 let out = AutoModeDefaultsCommand::new()
                     .execute(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(command_output_json(&out))
             }
         })
@@ -538,7 +538,7 @@ fn tool_doctor(state: &ServerState) -> Tool {
                 let out = DoctorCommand::new()
                     .execute(&claude)
                     .await
-                    .map_err(internal)?;
+                    .map_err(from_wrapper)?;
                 Ok(command_output_json(&out))
             }
         })
@@ -547,9 +547,7 @@ fn tool_doctor(state: &ServerState) -> Tool {
 
 // -- helpers --------------------------------------------------------
 
-fn internal(e: impl std::fmt::Display) -> tower_mcp::Error {
-    tower_mcp::Error::internal(e.to_string())
-}
+use crate::errors::{from_wrapper, internal};
 
 /// Wrap a [`CommandOutput`] as the standard tool JSON envelope.
 /// ANSI escape sequences are stripped from stdout/stderr.

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -1,0 +1,478 @@
+//! L2 CLI passthrough tools (`claude_*`).
+//!
+//! Each tool is a thin wrapper around a [`claude_wrapper`] command
+//! builder. Inputs map to builder options, outputs are returned as
+//! JSON. Single-shot single-prompt work goes through [`tool_query`];
+//! conversational/multi-turn work belongs in the `chat_*` family
+//! (L2.5, lands later).
+//!
+//! Convention: tool names use snake_case with `claude_` prefix --
+//! `claude_mcp_list`, `claude_plugin_validate`, etc. The CLI command
+//! `claude foo bar baz` maps to `claude_foo_bar_baz`.
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+
+use claude_wrapper::ClaudeCommand;
+use claude_wrapper::OutputFormat;
+use claude_wrapper::QueryCommand;
+use claude_wrapper::command::agents::AgentsCommand;
+use claude_wrapper::command::auth::AuthStatusCommand;
+use claude_wrapper::command::auto_mode::{AutoModeConfigCommand, AutoModeDefaultsCommand};
+use claude_wrapper::command::doctor::DoctorCommand;
+use claude_wrapper::command::marketplace::MarketplaceListCommand;
+use claude_wrapper::command::mcp::{McpGetCommand, McpListCommand};
+use claude_wrapper::command::plugin::{PluginListCommand, PluginValidateCommand};
+use claude_wrapper::exec::CommandOutput;
+
+use crate::state::ServerState;
+
+/// Build the full L2 passthrough tool list.
+pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
+    vec![
+        tool_version(),
+        tool_cli_version(state),
+        tool_query(state),
+        tool_agents(state),
+        tool_auth_status(state),
+        tool_mcp_list(state),
+        tool_mcp_get(state),
+        tool_plugin_list(state),
+        tool_plugin_validate(state),
+        tool_marketplace_list(state),
+        tool_auto_mode_config(state),
+        tool_auto_mode_defaults(state),
+        tool_doctor(state),
+    ]
+}
+
+// -- shared inputs ---------------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct NoArgs {}
+
+// -- claude_version --------------------------------------------------
+
+fn tool_version() -> Tool {
+    ToolBuilder::new("claude_version")
+        .description("Return the claude-server crate version.")
+        .read_only()
+        .handler(|_input: NoArgs| async move {
+            Ok(CallToolResult::json(json!({
+                "name": env!("CARGO_PKG_NAME"),
+                "version": env!("CARGO_PKG_VERSION"),
+            })))
+        })
+        .build()
+}
+
+// -- claude_cli_version ---------------------------------------------
+
+fn tool_cli_version(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_cli_version")
+        .description("Return the version of the underlying `claude` CLI binary.")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let claude = claude.clone();
+            async move {
+                let v = claude.cli_version().await.map_err(internal)?;
+                Ok(CallToolResult::json(json!({
+                    "major": v.major,
+                    "minor": v.minor,
+                    "patch": v.patch,
+                    "raw": v.to_string(),
+                })))
+            }
+        })
+        .build()
+}
+
+// -- claude_query ----------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct QueryInput {
+    /// The prompt to send to claude.
+    prompt: String,
+    /// Optional model (e.g. `sonnet`, `haiku`).
+    #[serde(default)]
+    model: Option<String>,
+    /// Optional system prompt.
+    #[serde(default)]
+    system_prompt: Option<String>,
+    /// Resume a previous session by id.
+    #[serde(default)]
+    resume: Option<String>,
+}
+
+fn tool_query(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_query")
+        .description(
+            "Single-shot query against the claude CLI. Returns the assistant text, \
+             session id, and cost (when available). For multi-turn conversations \
+             use the chat_* tools (when wired).",
+        )
+        .read_only()
+        .handler(move |input: QueryInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                // Setting output_format on the builder ensures it lands
+                // before the `--` separator. (execute_json appends it
+                // after, where it gets eaten as prompt text -- wrapper
+                // bug, worked around here.)
+                let mut q = QueryCommand::new(input.prompt).output_format(OutputFormat::Json);
+                if let Some(m) = input.model {
+                    q = q.model(m);
+                }
+                if let Some(s) = input.system_prompt {
+                    q = q.system_prompt(s);
+                }
+                if let Some(r) = input.resume {
+                    q = q.resume(r);
+                }
+                let out = q.execute(&claude).await.map_err(internal)?;
+                let parsed: serde_json::Value = serde_json::from_str(&out.stdout)
+                    .map_err(|e| internal(format!("parse query JSON: {e}; stdout={}", out.stdout)))?;
+                Ok(CallToolResult::json(json!({
+                    "result": parsed.get("result").cloned().unwrap_or(serde_json::Value::Null),
+                    "session_id": parsed.get("session_id").cloned().unwrap_or(serde_json::Value::Null),
+                    "total_cost_usd": parsed.get("total_cost_usd").cloned().unwrap_or(serde_json::Value::Null),
+                    "duration_ms": parsed.get("duration_ms").cloned().unwrap_or(serde_json::Value::Null),
+                    "num_turns": parsed.get("num_turns").cloned().unwrap_or(serde_json::Value::Null),
+                    "is_error": parsed.get("is_error").cloned().unwrap_or(serde_json::Value::Null),
+                })))
+            }
+        })
+        .build()
+}
+
+// -- claude_agents ---------------------------------------------------
+
+fn tool_agents(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_agents")
+        .description("Run `claude agents` to list configured agents.")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let claude = claude.clone();
+            async move {
+                let out = AgentsCommand::new()
+                    .execute(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_auth_status ---------------------------------------------
+
+fn tool_auth_status(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_auth_status")
+        .description("Run `claude auth status --json` and return the parsed status.")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let claude = claude.clone();
+            async move {
+                let parsed = AuthStatusCommand::new()
+                    .execute_json(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(CallToolResult::json(
+                    serde_json::to_value(parsed).unwrap_or(json!(null)),
+                ))
+            }
+        })
+        .build()
+}
+
+// -- claude_mcp_list -------------------------------------------------
+
+fn tool_mcp_list(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_mcp_list")
+        .description("Run `claude mcp list` to list configured MCP servers.")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let claude = claude.clone();
+            async move {
+                let out = McpListCommand::new()
+                    .execute(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_mcp_get --------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct McpGetInput {
+    /// Name of the configured MCP server to inspect.
+    name: String,
+}
+
+fn tool_mcp_get(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_mcp_get")
+        .description("Run `claude mcp get <name>` to inspect a single MCP server.")
+        .read_only()
+        .handler(move |input: McpGetInput| {
+            let claude = claude.clone();
+            async move {
+                let out = McpGetCommand::new(input.name)
+                    .execute(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_plugin_list ---------------------------------------------
+
+fn tool_plugin_list(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_plugin_list")
+        .description("Run `claude plugin list` to list installed plugins.")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let claude = claude.clone();
+            async move {
+                let out = PluginListCommand::new()
+                    .execute(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_plugin_validate -----------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PluginValidateInput {
+    /// Path to the plugin directory to validate.
+    path: String,
+}
+
+fn tool_plugin_validate(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_plugin_validate")
+        .description("Run `claude plugin validate <path>` to check a plugin's manifest.")
+        .read_only()
+        .handler(move |input: PluginValidateInput| {
+            let claude = claude.clone();
+            async move {
+                let out = PluginValidateCommand::new(input.path)
+                    .execute(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_marketplace_list -----------------------------------------
+
+fn tool_marketplace_list(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_marketplace_list")
+        .description("Run `claude plugin marketplace list` to list known plugin marketplaces.")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let claude = claude.clone();
+            async move {
+                let out = MarketplaceListCommand::new()
+                    .execute(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_auto_mode_config / defaults -----------------------------
+
+fn tool_auto_mode_config(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_auto_mode_config")
+        .description("Run `claude auto-mode config` to dump the effective auto-mode config.")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let claude = claude.clone();
+            async move {
+                let out = AutoModeConfigCommand::new()
+                    .execute(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+fn tool_auto_mode_defaults(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_auto_mode_defaults")
+        .description("Run `claude auto-mode defaults` to dump the built-in auto-mode rules.")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let claude = claude.clone();
+            async move {
+                let out = AutoModeDefaultsCommand::new()
+                    .execute(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_doctor --------------------------------------------------
+
+fn tool_doctor(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_doctor")
+        .description("Run `claude doctor` for a CLI health check. Can be slow (3+ minutes).")
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let claude = claude.clone();
+            async move {
+                let out = DoctorCommand::new()
+                    .execute(&claude)
+                    .await
+                    .map_err(internal)?;
+                Ok(command_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- helpers --------------------------------------------------------
+
+fn internal(e: impl std::fmt::Display) -> tower_mcp::Error {
+    tower_mcp::Error::internal(e.to_string())
+}
+
+/// Wrap a [`CommandOutput`] as the standard tool JSON envelope.
+/// ANSI escape sequences are stripped from stdout/stderr.
+fn command_output_json(out: &CommandOutput) -> CallToolResult {
+    CallToolResult::json(json!({
+        "stdout": strip_ansi(&out.stdout),
+        "stderr": strip_ansi(&out.stderr),
+        "exit_code": out.exit_code,
+        "success": out.success,
+    }))
+}
+
+/// Strip ANSI/VT escape sequences from a string.
+///
+/// Handles the common CSI/OSC/DCS/PM/APC families plus the standalone
+/// two-byte sequences (`ESC c`, `ESC =`, etc.). Conservative -- if we
+/// see an `ESC` we don't recognise, we still drop it so users don't
+/// end up with stray control bytes in their MCP payloads.
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == 0x1b {
+            // ESC. Look at the next byte to decide which family.
+            if i + 1 >= bytes.len() {
+                i += 1;
+                continue;
+            }
+            match bytes[i + 1] {
+                b'[' => {
+                    // CSI: ESC [ params final-byte
+                    i += 2;
+                    while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
+                        i += 1;
+                    }
+                    if i < bytes.len() {
+                        i += 1;
+                    }
+                }
+                b']' | b'P' | b'^' | b'_' => {
+                    // OSC/DCS/PM/APC terminate on BEL or ST (ESC \).
+                    i += 2;
+                    while i < bytes.len() {
+                        if bytes[i] == 0x07 {
+                            i += 1;
+                            break;
+                        }
+                        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'\\' {
+                            i += 2;
+                            break;
+                        }
+                        i += 1;
+                    }
+                }
+                _ => {
+                    // Two-byte standalone (ESC c, ESC =, etc.).
+                    i += 2;
+                }
+            }
+        } else {
+            out.push(b as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod strip_ansi_tests {
+    use super::strip_ansi;
+
+    #[test]
+    fn strips_csi_color_codes() {
+        let s = "\x1b[31mhello\x1b[0m world";
+        assert_eq!(strip_ansi(s), "hello world");
+    }
+
+    #[test]
+    fn strips_osc_title() {
+        let s = "\x1b]0;title\x07hello";
+        assert_eq!(strip_ansi(s), "hello");
+    }
+
+    #[test]
+    fn passes_plain_text() {
+        assert_eq!(strip_ansi("plain text"), "plain text");
+    }
+
+    #[test]
+    fn strips_csi_with_params() {
+        let s = "\x1b[1;32;40mbright\x1b[m";
+        assert_eq!(strip_ansi(s), "bright");
+    }
+
+    #[test]
+    fn handles_trailing_esc() {
+        let s = "ok\x1b";
+        assert_eq!(strip_ansi(s), "ok");
+    }
+
+    #[test]
+    fn strips_st_terminated_osc() {
+        let s = "\x1b]8;;https://x\x1b\\link\x1b]8;;\x1b\\done";
+        assert_eq!(strip_ansi(s), "linkdone");
+    }
+}

--- a/crates/claude-server/src/core.rs
+++ b/crates/claude-server/src/core.rs
@@ -22,6 +22,7 @@ use tracing::Instrument;
 use claude_wrapper::ClaudeCommand;
 use claude_wrapper::OutputFormat;
 use claude_wrapper::QueryCommand;
+use claude_wrapper::auth;
 use claude_wrapper::command::agents::AgentsCommand;
 use claude_wrapper::command::auth::AuthStatusCommand;
 use claude_wrapper::command::auto_mode::{
@@ -44,6 +45,7 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
         tool_query(state),
         tool_agents(state),
         tool_auth_status(state),
+        tool_auth_strategy(),
         tool_mcp_list(state),
         tool_mcp_get(state),
         tool_plugin_list(state),
@@ -281,6 +283,30 @@ fn tool_auth_status(state: &ServerState) -> Tool {
                     serde_json::to_value(parsed).unwrap_or(json!(null)),
                 ))
             }
+        })
+        .build()
+}
+
+// -- claude_auth_strategy --------------------------------------------
+
+fn tool_auth_strategy() -> Tool {
+    ToolBuilder::new("claude_auth_strategy")
+        .description(
+            "Report which auth strategy the embedded `claude` CLI will use \
+             given the current process environment. Cheap; no subprocess. \
+             Returns `{ strategy, has_anthropic_api_key, has_oauth_token, \
+             bedrock_enabled, vertex_enabled }`. `strategy` is one of \
+             `bedrock | vertex | api_key | oauth_token | subscription`. \
+             `subscription` means no env auth set -- the CLI will fall back \
+             to credentials stored under `~/.claude/`; for liveness use \
+             `claude_auth_status`.",
+        )
+        .read_only()
+        .handler(|_input: NoArgs| async move {
+            let summary = auth::detect();
+            Ok(CallToolResult::json(
+                serde_json::to_value(&summary).unwrap_or(json!(null)),
+            ))
         })
         .build()
 }

--- a/crates/claude-server/src/errors.rs
+++ b/crates/claude-server/src/errors.rs
@@ -1,0 +1,143 @@
+//! Shared error mapping for tool handlers.
+//!
+//! Most handlers do `wrapper.call().await.map_err(...)?` to flatten
+//! a [`claude_wrapper::error::Error`] (or some other display-able
+//! failure) into the MCP error type. This module hosts the two
+//! shared mappers so every handler benefits from the same
+//! special-casing without duplicating the same five-line helper in
+//! every file.
+//!
+//! - [`from_wrapper`] -- typed-aware; recognizes
+//!   [`claude_wrapper::error::Error::Auth`] (and inspectable
+//!   [`Error::auth_kind`]-positive `CommandFailed`s) and emits a
+//!   friendlier one-line message with a remediation hint.
+//! - [`internal`] -- generic display fallback for failures that
+//!   aren't wrapper errors (e.g. local parse errors).
+//!
+//! Convention: prefer [`from_wrapper`] anywhere you're handling a
+//! [`claude_wrapper::error::Error`] -- it's strictly more useful.
+//! Reach for [`internal`] only when you genuinely have something
+//! else (a `&str`, a third-party error).
+
+use std::fmt::Display;
+
+use claude_wrapper::auth::AuthErrorKind;
+use claude_wrapper::error::Error;
+
+/// Map a [`claude_wrapper::error::Error`] into the MCP error type.
+///
+/// For [`Error::Auth`] (and any `CommandFailed` that
+/// [`Error::auth_kind`] positively classifies), append a
+/// remediation hint so an agent or coordinator gets actionable
+/// guidance instead of raw CLI stderr. Other variants stringify
+/// as before.
+#[allow(dead_code)] // unused under `--no-default-features` (no surface features on)
+pub(crate) fn from_wrapper(e: Error) -> tower_mcp::Error {
+    match e.auth_kind() {
+        Some(kind) => {
+            let hint = remediation(kind);
+            tower_mcp::Error::internal(format!("{e}. hint: {hint}"))
+        }
+        None => tower_mcp::Error::internal(e.to_string()),
+    }
+}
+
+/// Generic stringifying mapper for non-wrapper failures
+/// (parse errors, local validation, third-party libraries).
+#[allow(dead_code)] // unused under `--no-default-features` (no surface features on)
+pub(crate) fn internal(e: impl Display) -> tower_mcp::Error {
+    tower_mcp::Error::internal(e.to_string())
+}
+
+#[allow(dead_code)] // unused under `--no-default-features` (no surface features on)
+fn remediation(kind: AuthErrorKind) -> &'static str {
+    match kind {
+        AuthErrorKind::NotAuthenticated => {
+            "no credentials configured. Run `claude login` or set ANTHROPIC_API_KEY"
+        }
+        AuthErrorKind::Expired => "stored credentials are expired. Re-run `claude login`",
+        AuthErrorKind::InvalidCredentials => {
+            "credentials were rejected. Check ANTHROPIC_API_KEY or re-run `claude login`"
+        }
+        AuthErrorKind::RateLimit => "rate limit or quota exceeded. Wait, top up, or switch keys",
+        AuthErrorKind::ProviderError => {
+            "cloud provider auth failed (Bedrock/Vertex). Check AWS/GCP credentials"
+        }
+        AuthErrorKind::Other => "auth-shaped failure; call `claude_auth_status` for live state",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_wrapper_appends_hint_on_auth_variant() {
+        let e = Error::Auth {
+            kind: AuthErrorKind::NotAuthenticated,
+            command: "claude --print".to_string(),
+            exit_code: 1,
+            message: "Not authenticated. Run `claude login`.".to_string(),
+        };
+        let mcp = from_wrapper(e);
+        let msg = format!("{mcp}");
+        assert!(msg.contains("auth error"), "msg: {msg}");
+        assert!(msg.contains("not_authenticated") || msg.contains("NotAuthenticated"));
+        assert!(msg.contains("hint:"), "missing hint: {msg}");
+        assert!(msg.contains("claude login"), "missing remediation: {msg}");
+    }
+
+    #[test]
+    fn from_wrapper_inspects_command_failed_via_auth_kind() {
+        // The constructor would have caught this in real exec.rs --
+        // simulate a hand-built CommandFailed (older code path) to
+        // confirm the inspection fallback still adds the hint.
+        let e = Error::CommandFailed {
+            command: "claude --print".to_string(),
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "401 Unauthorized".to_string(),
+            working_dir: None,
+        };
+        let mcp = from_wrapper(e);
+        let msg = format!("{mcp}");
+        assert!(msg.contains("hint:"), "missing hint: {msg}");
+        assert!(
+            msg.contains("Check ANTHROPIC_API_KEY") || msg.contains("rejected"),
+            "expected invalid_credentials hint: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_wrapper_preserves_non_auth_errors_verbatim() {
+        let e = Error::Timeout {
+            timeout_seconds: 30,
+        };
+        let mcp = from_wrapper(e);
+        let msg = format!("{mcp}");
+        assert!(msg.contains("30s"), "msg: {msg}");
+        assert!(!msg.contains("hint:"), "should not add hint: {msg}");
+    }
+
+    #[test]
+    fn from_wrapper_does_not_add_hint_to_unrelated_command_failed() {
+        let e = Error::CommandFailed {
+            command: "claude something".to_string(),
+            exit_code: 2,
+            stdout: String::new(),
+            stderr: "syntax error".to_string(),
+            working_dir: None,
+        };
+        let mcp = from_wrapper(e);
+        let msg = format!("{mcp}");
+        assert!(!msg.contains("hint:"), "should not add hint: {msg}");
+    }
+
+    #[test]
+    fn internal_stringifies_generic_display() {
+        let mcp = internal("a parse error");
+        // tower_mcp::Error wraps in JSON-RPC framing; just confirm
+        // the original message is preserved verbatim somewhere.
+        assert!(format!("{mcp}").contains("a parse error"));
+    }
+}

--- a/crates/claude-server/src/history.rs
+++ b/crates/claude-server/src/history.rs
@@ -1,0 +1,329 @@
+//! Read-only access to Claude Code's on-disk session history,
+//! exposed as MCP tools and resources.
+//!
+//! Backed by [`claude_wrapper::history::HistoryRoot`]. The wrapper
+//! owns the JSONL parsing and slug-decoding; this module is a thin
+//! MCP surface on top.
+//!
+//! Tools:
+//! - `claude_project_list` -- enumerate project directories with
+//!   summary metadata.
+//! - `claude_session_list { project_slug? }` -- enumerate sessions,
+//!   optionally filtered to one project.
+//! - `claude_session_get { session_id }` -- full typed entry log
+//!   for one session.
+//!
+//! Resources:
+//! - `claude://projects` -- same shape as `claude_project_list` for
+//!   subscribable / cache-friendly UIs.
+//!
+//! Resource templates:
+//! - `claude://projects/{slug}` -- sessions for one project.
+//! - `claude://sessions/{id}` -- full session entry log.
+
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use tower_mcp::protocol::ReadResourceResult;
+use tower_mcp::resource::ResourceTemplate;
+use tower_mcp::{
+    CallToolResult, Resource, ResourceBuilder, ResourceTemplateBuilder, Tool, ToolBuilder,
+};
+
+use claude_wrapper::history::HistoryRoot;
+
+use crate::state::ServerState;
+
+/// Build the history-feature tool list.
+pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
+    vec![
+        tool_project_list(state),
+        tool_session_list(state),
+        tool_session_get(state),
+    ]
+}
+
+/// Build the history-feature resource list.
+pub(crate) fn resources(state: &ServerState) -> Vec<Resource> {
+    vec![resource_projects(state)]
+}
+
+/// Build the history-feature resource templates.
+pub(crate) fn templates(state: &ServerState) -> Vec<ResourceTemplate> {
+    vec![
+        template_project_detail(state),
+        template_session_detail(state),
+    ]
+}
+
+// -- tool_project_list ----------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct NoArgs {}
+
+fn tool_project_list(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("claude_project_list")
+        .description(
+            "Enumerate Claude Code project directories under `~/.claude/projects/`. \
+             Each entry: `slug` (on-disk dir name, the encoded path), \
+             `decoded_path` (best-effort decode back to a filesystem path), \
+             `session_count`, `last_modified` (Unix-epoch seconds, optional). \
+             Read-only.",
+        )
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let state = state.clone();
+            async move {
+                let root = history_root(&state).map_err(internal)?;
+                let projects = root.list_projects().map_err(internal)?;
+                Ok(CallToolResult::json(json!({
+                    "projects": projects
+                        .iter()
+                        .map(project_summary_to_json)
+                        .collect::<Vec<_>>(),
+                })))
+            }
+        })
+        .build()
+}
+
+// -- tool_session_list ----------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct SessionListInput {
+    /// Optional project slug to filter on. Omit for the union
+    /// across every project.
+    #[serde(default)]
+    project_slug: Option<String>,
+}
+
+fn tool_session_list(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("claude_session_list")
+        .description(
+            "Enumerate session JSONL files. With `project_slug`, lists \
+             sessions for that one project; without, returns the union \
+             across every project. Each entry carries summary metadata: \
+             session_id, project_slug, message_count (user + assistant), \
+             first/last timestamp, optional ai-generated title, file size. \
+             Read-only.",
+        )
+        .read_only()
+        .handler(move |input: SessionListInput| {
+            let state = state.clone();
+            async move {
+                let root = history_root(&state).map_err(internal)?;
+                let sessions = root
+                    .list_sessions(input.project_slug.as_deref())
+                    .map_err(internal)?;
+                Ok(CallToolResult::json(json!({
+                    "sessions": sessions
+                        .iter()
+                        .map(session_summary_to_json)
+                        .collect::<Vec<_>>(),
+                })))
+            }
+        })
+        .build()
+}
+
+// -- tool_session_get -----------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SessionGetInput {
+    /// Session UUID (file basename without `.jsonl`).
+    session_id: String,
+}
+
+fn tool_session_get(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("claude_session_get")
+        .description(
+            "Read one session's full entry log by `session_id`. Returns \
+             every parsed entry in arrival order: user, assistant, and \
+             other (queue-operation, attachment, ai-title, last-prompt, \
+             unknown future types). Errors if no session with that id \
+             exists under the configured history root. Read-only.",
+        )
+        .read_only()
+        .handler(move |input: SessionGetInput| {
+            let state = state.clone();
+            async move {
+                let root = history_root(&state).map_err(internal)?;
+                let log = root.read_session(&input.session_id).map_err(internal)?;
+                Ok(CallToolResult::json(session_log_to_json(&log)))
+            }
+        })
+        .build()
+}
+
+// -- resource: claude://projects -----------------------------------
+
+fn resource_projects(state: &ServerState) -> Resource {
+    let state = state.clone();
+    ResourceBuilder::new("claude://projects")
+        .name("Claude projects")
+        .description(
+            "Live view of every project directory under the configured \
+             history root. Same shape as the claude_project_list tool.",
+        )
+        .mime_type("application/json")
+        .handler(move || {
+            let state = state.clone();
+            async move {
+                let root = history_root(&state).map_err(internal)?;
+                let projects = root.list_projects().map_err(internal)?;
+                let body = json!({
+                    "projects": projects
+                        .iter()
+                        .map(project_summary_to_json)
+                        .collect::<Vec<_>>(),
+                });
+                let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+                Ok(ReadResourceResult::text("claude://projects", text))
+            }
+        })
+        .build()
+}
+
+// -- template: claude://projects/{slug} -----------------------------
+
+fn template_project_detail(state: &ServerState) -> ResourceTemplate {
+    let state = state.clone();
+    ResourceTemplateBuilder::new("claude://projects/{slug}")
+        .name("Project detail")
+        .description(
+            "Per-project session list keyed by encoded slug. Same shape \
+             as `claude_session_list { project_slug }`.",
+        )
+        .mime_type("application/json")
+        .handler(move |uri: String, vars: HashMap<String, String>| {
+            let state = state.clone();
+            async move {
+                let slug = vars.get("slug").cloned().unwrap_or_default();
+                let root = history_root(&state).map_err(internal)?;
+                let sessions = root.list_sessions(Some(&slug)).map_err(internal)?;
+                let body = json!({
+                    "project_slug": slug,
+                    "sessions": sessions
+                        .iter()
+                        .map(session_summary_to_json)
+                        .collect::<Vec<_>>(),
+                });
+                let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+                Ok(ReadResourceResult::text(uri, text))
+            }
+        })
+}
+
+// -- template: claude://sessions/{id} -------------------------------
+
+fn template_session_detail(state: &ServerState) -> ResourceTemplate {
+    let state = state.clone();
+    ResourceTemplateBuilder::new("claude://sessions/{id}")
+        .name("Session detail")
+        .description(
+            "Full parsed entry log for one session, keyed by session_id. \
+             Same shape as the claude_session_get tool.",
+        )
+        .mime_type("application/json")
+        .handler(move |uri: String, vars: HashMap<String, String>| {
+            let state = state.clone();
+            async move {
+                let id = vars.get("id").cloned().unwrap_or_default();
+                let root = history_root(&state).map_err(internal)?;
+                let log = root.read_session(&id).map_err(internal)?;
+                let text =
+                    serde_json::to_string_pretty(&session_log_to_json(&log)).unwrap_or_default();
+                Ok(ReadResourceResult::text(uri, text))
+            }
+        })
+}
+
+// -- helpers --------------------------------------------------------
+
+fn history_root(state: &ServerState) -> claude_wrapper::error::Result<HistoryRoot> {
+    match state.config.history_root.as_ref() {
+        Some(path) => Ok(HistoryRoot::at(path.clone())),
+        None => HistoryRoot::home(),
+    }
+}
+
+fn internal(e: impl std::fmt::Display) -> tower_mcp::Error {
+    tower_mcp::Error::internal(e.to_string())
+}
+
+fn project_summary_to_json(p: &claude_wrapper::history::ProjectSummary) -> serde_json::Value {
+    json!({
+        "slug": p.slug,
+        "decoded_path": p.decoded_path,
+        "session_count": p.session_count,
+        "last_modified_secs": p.last_modified.and_then(|t| {
+            t.duration_since(std::time::UNIX_EPOCH).ok().map(|d| d.as_secs())
+        }),
+    })
+}
+
+fn session_summary_to_json(s: &claude_wrapper::history::SessionSummary) -> serde_json::Value {
+    json!({
+        "session_id": s.session_id,
+        "project_slug": s.project_slug,
+        "message_count": s.message_count,
+        "first_timestamp": s.first_timestamp,
+        "last_timestamp": s.last_timestamp,
+        "title": s.title,
+        "size_bytes": s.size_bytes,
+    })
+}
+
+fn session_log_to_json(log: &claude_wrapper::history::SessionLog) -> serde_json::Value {
+    json!({
+        "session_id": log.session_id,
+        "project_slug": log.project_slug,
+        "entries": log
+            .entries
+            .iter()
+            .map(history_entry_to_json)
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn history_entry_to_json(e: &claude_wrapper::history::HistoryEntry) -> serde_json::Value {
+    use claude_wrapper::history::HistoryEntry;
+    match e {
+        HistoryEntry::User {
+            uuid,
+            timestamp,
+            cwd,
+            git_branch,
+            message,
+            ..
+        } => json!({
+            "kind": "user",
+            "uuid": uuid,
+            "timestamp": timestamp,
+            "cwd": cwd,
+            "git_branch": git_branch,
+            "message": message,
+        }),
+        HistoryEntry::Assistant {
+            uuid,
+            timestamp,
+            message,
+            ..
+        } => json!({
+            "kind": "assistant",
+            "uuid": uuid,
+            "timestamp": timestamp,
+            "message": message,
+        }),
+        HistoryEntry::Other { type_tag, raw } => json!({
+            "kind": "other",
+            "type_tag": type_tag,
+            "raw": raw,
+        }),
+    }
+}

--- a/crates/claude-server/src/history.rs
+++ b/crates/claude-server/src/history.rs
@@ -252,9 +252,7 @@ fn history_root(state: &ServerState) -> claude_wrapper::error::Result<HistoryRoo
     }
 }
 
-fn internal(e: impl std::fmt::Display) -> tower_mcp::Error {
-    tower_mcp::Error::internal(e.to_string())
-}
+use crate::errors::from_wrapper as internal;
 
 fn project_summary_to_json(p: &claude_wrapper::history::ProjectSummary) -> serde_json::Value {
     json!({

--- a/crates/claude-server/src/jobs.rs
+++ b/crates/claude-server/src/jobs.rs
@@ -1,0 +1,222 @@
+//! Read-only access to Claude Code's on-disk **background-job**
+//! state, exposed as MCP tools and resources. Backed by
+//! [`claude_wrapper::jobs::JobsRoot`].
+//!
+//! Useful for hosts that want to reason about background work
+//! launched via the `claude agents` TUI -- those tasks write to
+//! the same on-disk state we read here, and each job's session
+//! transcript ends up in `~/.claude/projects/` for the
+//! [`crate::history`] feature to parse.
+//!
+//! Tools:
+//! - `claude_job_list` -- enumerate every job at the configured root.
+//! - `claude_job_get { short_id }` -- one job's full record incl.
+//!   parsed `timeline.jsonl` and the raw `state.json` value.
+//!
+//! Resources:
+//! - `claude://jobs` -- same shape as `claude_job_list`.
+//!
+//! Resource templates:
+//! - `claude://jobs/{short_id}` -- full record for one job.
+//!
+//! Read-only by design. The dispatch protocol is undocumented and
+//! version-sensitive; mirroring it would defeat the drift defenses
+//! we built. Hosts wanting to fire background work should keep
+//! using the agents TUI or the wrapper's DuplexSession machinery.
+
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use tower_mcp::protocol::ReadResourceResult;
+use tower_mcp::resource::ResourceTemplate;
+use tower_mcp::{
+    CallToolResult, Resource, ResourceBuilder, ResourceTemplateBuilder, Tool, ToolBuilder,
+};
+
+use claude_wrapper::jobs::JobsRoot;
+
+use crate::state::ServerState;
+
+/// Build the jobs-feature tool list.
+pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
+    vec![tool_job_list(state), tool_job_get(state)]
+}
+
+/// Build the jobs-feature resource list.
+pub(crate) fn resources(state: &ServerState) -> Vec<Resource> {
+    vec![resource_jobs(state)]
+}
+
+/// Build the jobs-feature resource templates.
+pub(crate) fn templates(state: &ServerState) -> Vec<ResourceTemplate> {
+    vec![template_job_detail(state)]
+}
+
+// -- tool_job_list -------------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct NoArgs {}
+
+fn tool_job_list(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("claude_job_list")
+        .description(
+            "Enumerate background jobs under `~/.claude/jobs/`. Each \
+             entry: `short_id` (canonical lookup handle), `state` \
+             (`running | done | killed | failed | ...`), `intent` \
+             (original prompt), `name` (auto-generated short title), \
+             `session_id`, `session_path` (cross-link to the session \
+             JSONL the history feature parses), `cwd`, timestamps. \
+             Sorted by short_id. Read-only.",
+        )
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let state = state.clone();
+            async move {
+                let root = jobs_root(&state).map_err(crate::errors::from_wrapper)?;
+                let summaries = root.list().map_err(crate::errors::from_wrapper)?;
+                Ok(CallToolResult::json(json!({
+                    "jobs": summaries
+                        .iter()
+                        .map(summary_to_json)
+                        .collect::<Vec<_>>(),
+                })))
+            }
+        })
+        .build()
+}
+
+// -- tool_job_get --------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct JobGetInput {
+    /// Short id (the directory name under `~/.claude/jobs/`,
+    /// e.g. `90c961c7`).
+    short_id: String,
+}
+
+fn tool_job_get(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("claude_job_get")
+        .description(
+            "Read one job's full record by `short_id`. Returns summary \
+             metadata plus the parsed timeline (state transitions with \
+             timestamps and text bodies) and the raw `state.json` value \
+             (`raw_state`) for fields not in the typed summary. Errors \
+             if no job with that id exists. Read-only.",
+        )
+        .read_only()
+        .handler(move |input: JobGetInput| {
+            let state = state.clone();
+            async move {
+                let root = jobs_root(&state).map_err(crate::errors::from_wrapper)?;
+                let job = root
+                    .get(&input.short_id)
+                    .map_err(crate::errors::from_wrapper)?;
+                Ok(CallToolResult::json(job_to_json(&job)))
+            }
+        })
+        .build()
+}
+
+// -- resource: claude://jobs ---------------------------------------
+
+fn resource_jobs(state: &ServerState) -> Resource {
+    let state = state.clone();
+    ResourceBuilder::new("claude://jobs")
+        .name("Background jobs")
+        .description(
+            "Live view of every background job at the configured jobs \
+             root. Same shape as the claude_job_list tool.",
+        )
+        .mime_type("application/json")
+        .handler(move || {
+            let state = state.clone();
+            async move {
+                let root = jobs_root(&state).map_err(crate::errors::from_wrapper)?;
+                let summaries = root.list().map_err(crate::errors::from_wrapper)?;
+                let body = json!({
+                    "jobs": summaries
+                        .iter()
+                        .map(summary_to_json)
+                        .collect::<Vec<_>>(),
+                });
+                let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+                Ok(ReadResourceResult::text("claude://jobs", text))
+            }
+        })
+        .build()
+}
+
+// -- template: claude://jobs/{short_id} ----------------------------
+
+fn template_job_detail(state: &ServerState) -> ResourceTemplate {
+    let state = state.clone();
+    ResourceTemplateBuilder::new("claude://jobs/{short_id}")
+        .name("Job detail")
+        .description(
+            "Full job record keyed by short id. Same shape as the \
+             claude_job_get tool.",
+        )
+        .mime_type("application/json")
+        .handler(move |uri: String, vars: HashMap<String, String>| {
+            let state = state.clone();
+            async move {
+                let id = vars.get("short_id").cloned().unwrap_or_default();
+                let root = jobs_root(&state).map_err(crate::errors::from_wrapper)?;
+                let job = root.get(&id).map_err(crate::errors::from_wrapper)?;
+                let text = serde_json::to_string_pretty(&job_to_json(&job)).unwrap_or_default();
+                Ok(ReadResourceResult::text(uri, text))
+            }
+        })
+}
+
+// -- helpers --------------------------------------------------------
+
+fn jobs_root(state: &ServerState) -> claude_wrapper::error::Result<JobsRoot> {
+    match state.config.jobs_root.as_ref() {
+        Some(path) => Ok(JobsRoot::at(path.clone())),
+        None => JobsRoot::home(),
+    }
+}
+
+fn summary_to_json(s: &claude_wrapper::jobs::JobSummary) -> serde_json::Value {
+    json!({
+        "short_id": s.short_id,
+        "state": s.state,
+        "daemon_short": s.daemon_short,
+        "backend": s.backend,
+        "name": s.name,
+        "detail": s.detail,
+        "intent": s.intent,
+        "session_id": s.session_id,
+        "session_path": s.session_path,
+        "cwd": s.cwd,
+        "origin_cwd": s.origin_cwd,
+        "created_at": s.created_at,
+        "updated_at": s.updated_at,
+        "first_terminal_at": s.first_terminal_at,
+        "cli_version": s.cli_version,
+        "state_mtime_secs": s.state_mtime_secs,
+    })
+}
+
+fn job_to_json(job: &claude_wrapper::jobs::Job) -> serde_json::Value {
+    json!({
+        "summary": summary_to_json(&job.summary),
+        "timeline": job
+            .timeline
+            .iter()
+            .map(|e| json!({
+                "at": e.at,
+                "state": e.state,
+                "detail": e.detail,
+                "text": e.text,
+                "extra": e.extra,
+            }))
+            .collect::<Vec<_>>(),
+        "raw_state": job.raw_state,
+    })
+}

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -1,0 +1,155 @@
+//! MCP server layer over [`claude-wrapper`](claude_wrapper).
+//!
+//! Layer 2 of the claude stack:
+//!
+//! - **L0** Claude Code CLI (the binary)
+//! - **L1** [`claude_wrapper`] -- typed Rust API over the CLI
+//! - **L2** this crate -- 1:1ish MCP interface to the wrapper, as a
+//!   tower-mcp library. Library is the product; the example CLI
+//!   under `examples/server.rs` is one demonstration of wiring it
+//!   to a transport.
+//!
+//! Because [`tower_mcp::McpRouter`] is a `tower::Service`, the
+//! returned router IS an async `fn(Request) -> Response`. You can:
+//!
+//! - Embed it directly in another binary -- `router.call(req).await`
+//!   with no transport at all.
+//! - Hand it to [`tower_mcp::StdioTransport`] for a stdio MCP server.
+//! - Hand it to `tower_mcp::HttpTransport` (when wired) for HTTP/SSE.
+//!
+//! [`registered_tools`] returns the same tool list without wiring a
+//! transport -- useful for `tools` subcommands and diffs.
+//!
+//! # Example
+//!
+//! One-liner bootstrap. Pick a transport (or don't):
+//!
+//! ```no_run
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! use claude_server::build_router;
+//! use tower_mcp::StdioTransport;
+//!
+//! let router = build_router(Default::default())?;
+//! let mut transport = StdioTransport::new(router);
+//! transport.run().await?;
+//! # Ok(()) }
+//! ```
+//!
+//! See `examples/server.rs` for the canonical "raw MCP CLI" shape
+//! (clap + tokio + the one-liner). It's intentionally minimal so
+//! it doubles as copy-paste integration documentation.
+
+//! ## Surfaces
+//!
+//! claude-server exposes three tool surfaces, layered by intent:
+//!
+//! 1. **Core** ([`core`]) -- 1:1 mirror of the `claude` CLI. Every
+//!    subcommand you could shell out to lives here, with the
+//!    deliberate exception of interactive (no `-p`) mode. Always on.
+//! 2. **Chat** ([`chat`]) -- the duplex sidecar. We hold long-lived
+//!    `claude` subprocesses, manage turn ordering, expose cost and
+//!    history, and stream events back as MCP progress notifications.
+//!    This is where the server earns its keep over a dumb passthrough.
+//! 3. **Artifacts** (planned) -- CRUD over `~/.claude/skills/`,
+//!    `~/.claude/agents/`, plugin manifests, MCP server configs.
+//!    Not yet wired.
+
+mod chat;
+pub mod config;
+mod core;
+mod prompts;
+mod resources;
+mod state;
+
+use std::sync::Arc;
+
+use tower_mcp::McpRouter;
+
+pub use self::config::{ClaudeConfig, ServerConfig};
+pub use self::state::ServerState;
+
+use claude_wrapper::Claude;
+
+/// Build the MCP router from a [`ServerConfig`].
+///
+/// Constructs a [`Claude`] client from [`ServerConfig::claude`],
+/// builds [`ServerState`], and registers the L2 CLI passthrough
+/// surface plus resources and prompts. Hand the returned router to a
+/// transport (stdio, HTTP, etc.) to serve it.
+pub fn build_router(config: ServerConfig) -> claude_wrapper::error::Result<McpRouter> {
+    let claude = build_claude(&config.claude)?;
+    let state = ServerState::new(Arc::new(claude), Arc::new(config));
+
+    let mut router = McpRouter::new()
+        .server_info("claude-server", env!("CARGO_PKG_VERSION"))
+        .instructions(
+            "MCP server exposing the Claude Code CLI via claude-wrapper. \
+             `claude.*` tools are 1:1 passthroughs to the CLI. \
+             Read `claude://config` and `claude://tools` resources \
+             to discover the active surface.",
+        );
+
+    for tool in core::tools(&state) {
+        router = router.tool(tool);
+    }
+    for tool in chat::tools(&state) {
+        router = router.tool(tool);
+    }
+    for resource in resources::resources(&state) {
+        router = router.resource(resource);
+    }
+    for prompt in prompts::prompts(&state) {
+        router = router.prompt(prompt);
+    }
+
+    Ok(router)
+}
+
+/// Light view of a registered tool. Returned by [`registered_tools`]
+/// for introspection.
+#[derive(Debug, Clone)]
+pub struct ToolInfo {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+/// List the tools that would be registered for a given config without
+/// assembling a transport. Useful for `claude-server tools`.
+pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<Vec<ToolInfo>> {
+    let claude = build_claude(&config.claude)?;
+    let state = ServerState::new(Arc::new(claude), Arc::new(config));
+
+    let mut all: Vec<ToolInfo> = core::tools(&state)
+        .into_iter()
+        .chain(chat::tools(&state))
+        .map(|t| ToolInfo {
+            name: t.name.clone(),
+            description: t.description.clone(),
+        })
+        .collect();
+    all.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(all)
+}
+
+/// Default timeout applied to CLI invocations when the config does
+/// not set one. Five minutes covers a generous query turn while
+/// bounding pathological hangs.
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+
+fn build_claude(cfg: &ClaudeConfig) -> claude_wrapper::error::Result<Claude> {
+    let mut builder = Claude::builder();
+    if let Some(ref bin) = cfg.binary {
+        builder = builder.binary(bin);
+    }
+    if let Some(ref dir) = cfg.working_dir {
+        builder = builder.working_dir(dir);
+    }
+    builder = builder.timeout_secs(cfg.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS));
+    for (k, v) in &cfg.env {
+        builder = builder.env(k, v);
+    }
+    for arg in &cfg.global_args {
+        builder = builder.arg(arg);
+    }
+    builder.build()
+}

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -230,6 +230,13 @@ fn build_router_inner(
             router = router.resource_template(template);
         }
     }
+    #[cfg(all(feature = "artifacts", feature = "mutations"))]
+    if state.config.policy.allow_mutations {
+        for tool in artifacts::mutating_tools(&state) {
+            router = router.tool(tool);
+        }
+        tracing::info!("artifacts mutating tools registered (policy.allow_mutations = true)");
+    }
     for resource in resources::resources(&state) {
         router = router.resource(resource);
     }
@@ -290,6 +297,15 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
     #[cfg(not(feature = "artifacts"))]
     let artifacts_tools: Vec<tower_mcp::Tool> = Vec::new();
 
+    #[cfg(all(feature = "artifacts", feature = "mutations"))]
+    let artifacts_mut_tools: Vec<tower_mcp::Tool> = if state.config.policy.allow_mutations {
+        artifacts::mutating_tools(&state)
+    } else {
+        Vec::new()
+    };
+    #[cfg(not(all(feature = "artifacts", feature = "mutations")))]
+    let artifacts_mut_tools: Vec<tower_mcp::Tool> = Vec::new();
+
     #[cfg(feature = "core")]
     let core_tools = core::tools(&state);
     #[cfg(not(feature = "core"))]
@@ -310,6 +326,7 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
         .chain(muts)
         .chain(history_tools)
         .chain(artifacts_tools)
+        .chain(artifacts_mut_tools)
         .map(|t| ToolInfo {
             name: t.name.clone(),
             description: t.description.clone(),

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -67,21 +67,64 @@ mod turns;
 use std::sync::Arc;
 
 use tower_mcp::McpRouter;
+use tower_mcp::context::NotificationSender;
 
 pub use self::config::{ClaudeConfig, ServerConfig, ServerPolicy, TurnConfig};
 pub use self::state::ServerState;
+pub use tower_mcp::context::{NotificationReceiver, notification_channel};
 
 use claude_wrapper::Claude;
 
-/// Build the MCP router from a [`ServerConfig`].
+/// Build the MCP router from a [`ServerConfig`] without notification
+/// support. Subscriptions to `claude://chats/{id}` (or any other
+/// resource) won't fire `notifications/resources/updated` -- callers
+/// have to poll. Suitable for stdio-only deployments where the
+/// transport doesn't surface notifications anyway.
 ///
-/// Constructs a [`Claude`] client from [`ServerConfig::claude`],
-/// builds [`ServerState`], and registers the L2 CLI passthrough
-/// surface plus resources and prompts. Hand the returned router to a
-/// transport (stdio, HTTP, etc.) to serve it.
+/// For deployments that want subscription updates (UIs, HTTP
+/// dashboards), use [`build_router_with_notification_sender`].
 pub fn build_router(config: ServerConfig) -> claude_wrapper::error::Result<McpRouter> {
+    build_router_inner(config, None)
+}
+
+/// Build the MCP router with an attached notification sender.
+///
+/// Wires `tx` into both [`ServerState`] (so chat workers can fire
+/// `notifications/resources/updated` after a turn settles) AND into
+/// the underlying [`McpRouter`] (so router-internal events go down
+/// the same channel). The corresponding [`NotificationReceiver`]
+/// must be plumbed into the transport (e.g.
+/// `GenericStdioTransport::with_notifications` or `HttpTransport`'s
+/// notification handling).
+///
+/// Typical wiring:
+///
+/// ```no_run
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// use claude_server::{build_router_with_notification_sender, notification_channel};
+///
+/// let (tx, rx) = notification_channel(256);
+/// let router = build_router_with_notification_sender(Default::default(), tx)?;
+/// // ... hand `router` and `rx` to a notification-aware transport
+/// # let _ = (router, rx);
+/// # Ok(()) }
+/// ```
+pub fn build_router_with_notification_sender(
+    config: ServerConfig,
+    tx: NotificationSender,
+) -> claude_wrapper::error::Result<McpRouter> {
+    build_router_inner(config, Some(tx))
+}
+
+fn build_router_inner(
+    config: ServerConfig,
+    notifier: Option<NotificationSender>,
+) -> claude_wrapper::error::Result<McpRouter> {
     let claude = build_claude(&config.claude)?;
-    let state = ServerState::new(Arc::new(claude), Arc::new(config));
+    let mut state = ServerState::new(Arc::new(claude), Arc::new(config));
+    if let Some(ref tx) = notifier {
+        state = state.with_notifier(tx.clone());
+    }
 
     // Spawn the turn-registry TTL sweeper. Runs forever until the
     // registry's last Arc is dropped (the JoinHandle is intentionally
@@ -122,6 +165,10 @@ pub fn build_router(config: ServerConfig) -> claude_wrapper::error::Result<McpRo
     }
     for prompt in prompts::prompts(&state) {
         router = router.prompt(prompt);
+    }
+
+    if let Some(tx) = notifier {
+        router = router.with_notification_sender(tx);
     }
 
     Ok(router)

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -68,6 +68,7 @@ mod chat;
 pub mod config;
 #[cfg(feature = "core")]
 mod core;
+mod errors;
 #[cfg(feature = "history")]
 mod history;
 #[cfg(feature = "mutations")]

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -110,6 +110,9 @@ pub fn build_router(config: ServerConfig) -> claude_wrapper::error::Result<McpRo
     for resource in resources::resources(&state) {
         router = router.resource(resource);
     }
+    for template in resources::templates(&state) {
+        router = router.resource_template(template);
+    }
     for prompt in prompts::prompts(&state) {
         router = router.prompt(prompt);
     }

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -41,7 +41,7 @@
 
 //! ## Surfaces
 //!
-//! claude-server exposes three tool surfaces, layered by intent:
+//! claude-server exposes several tool surfaces, layered by intent:
 //!
 //! 1. **Core** -- 1:1 mirror of the `claude` CLI. Every
 //!    subcommand you could shell out to lives here, with the
@@ -50,7 +50,12 @@
 //!    `claude` subprocesses, manage turn ordering, expose cost and
 //!    history, and stream events back as MCP progress notifications.
 //!    This is where the server earns its keep over a dumb passthrough.
-//! 3. **Artifacts** (planned) -- CRUD over `~/.claude/skills/`,
+//! 3. **History** (`history` feature) -- read-only access to
+//!    `~/.claude/projects/<slug>/<session_id>.jsonl` files. Tools:
+//!    `claude_project_list`, `claude_session_list`,
+//!    `claude_session_get`. Resources: `claude://projects`,
+//!    `claude://projects/{slug}`, `claude://sessions/{id}`.
+//! 4. **Artifacts** (planned) -- CRUD over `~/.claude/skills/`,
 //!    `~/.claude/agents/`, plugin manifests, MCP server configs.
 //!    Not yet wired.
 
@@ -59,6 +64,8 @@ mod chat;
 pub mod config;
 #[cfg(feature = "core")]
 mod core;
+#[cfg(feature = "history")]
+mod history;
 #[cfg(feature = "mutations")]
 mod mutations;
 mod prompts;
@@ -162,11 +169,13 @@ fn build_router_inner(
                - Resume:        chat_open(resume: \"<session_id>\")\n\
              \n\
              DISCOVERY:\n\
-               - claude://tools      -- the full registered tool surface\n\
-               - claude://config     -- server config (env values redacted)\n\
-               - claude://chats      -- live chats with cost + turn count\n\
-               - claude://chats/{id} -- one chat's full history (subscribable)\n\
-               - claude://metrics    -- process counters; check spend mid-run\n\
+               - claude://tools         -- the full registered tool surface\n\
+               - claude://config        -- server config (env values redacted)\n\
+               - claude://chats         -- live chats with cost + turn count\n\
+               - claude://chats/{id}    -- one chat's full history (subscribable)\n\
+               - claude://metrics       -- process counters; check spend mid-run\n\
+               - claude://projects      -- on-disk project history (history feature)\n\
+               - claude://sessions/{id} -- full parsed JSONL log for a session\n\
              \n\
              For a longer walkthrough call `prompts/get usage_guide`.",
         );
@@ -189,6 +198,18 @@ fn build_router_inner(
             router = router.tool(tool);
         }
         tracing::info!("mutating tools registered (policy.allow_mutations = true)");
+    }
+    #[cfg(feature = "history")]
+    {
+        for tool in history::tools(&state) {
+            router = router.tool(tool);
+        }
+        for resource in history::resources(&state) {
+            router = router.resource(resource);
+        }
+        for template in history::templates(&state) {
+            router = router.resource_template(template);
+        }
     }
     for resource in resources::resources(&state) {
         router = router.resource(resource);
@@ -220,7 +241,12 @@ pub struct ToolInfo {
 pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<Vec<ToolInfo>> {
     let claude = build_claude(&config.claude)?;
     #[cfg_attr(
-        not(any(feature = "core", feature = "chat", feature = "mutations")),
+        not(any(
+            feature = "core",
+            feature = "chat",
+            feature = "mutations",
+            feature = "history"
+        )),
         allow(unused_variables)
     )]
     let state = ServerState::new(Arc::new(claude), Arc::new(config));
@@ -233,6 +259,11 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
     };
     #[cfg(not(feature = "mutations"))]
     let muts: Vec<tower_mcp::Tool> = Vec::new();
+
+    #[cfg(feature = "history")]
+    let history_tools = history::tools(&state);
+    #[cfg(not(feature = "history"))]
+    let history_tools: Vec<tower_mcp::Tool> = Vec::new();
 
     #[cfg(feature = "core")]
     let core_tools = core::tools(&state);
@@ -252,6 +283,7 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
         .chain(chat_tools)
         .chain(turn_tool_list)
         .chain(muts)
+        .chain(history_tools)
         .map(|t| ToolInfo {
             name: t.name.clone(),
             description: t.description.clone(),

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -67,7 +67,7 @@ use std::sync::Arc;
 
 use tower_mcp::McpRouter;
 
-pub use self::config::{ClaudeConfig, ServerConfig};
+pub use self::config::{ClaudeConfig, ServerConfig, TurnConfig};
 pub use self::state::ServerState;
 
 use claude_wrapper::Claude;
@@ -81,6 +81,13 @@ use claude_wrapper::Claude;
 pub fn build_router(config: ServerConfig) -> claude_wrapper::error::Result<McpRouter> {
     let claude = build_claude(&config.claude)?;
     let state = ServerState::new(Arc::new(claude), Arc::new(config));
+
+    // Spawn the turn-registry TTL sweeper. Runs forever until the
+    // registry's last Arc is dropped (the JoinHandle is intentionally
+    // not retained -- we don't have a graceful-shutdown story today).
+    let ttl = std::time::Duration::from_secs(state.config.turns.ttl_secs);
+    let interval = std::time::Duration::from_secs(state.config.turns.sweep_interval_secs);
+    let _sweeper = state.turns.clone().spawn_sweeper(ttl, interval);
 
     let mut router = McpRouter::new()
         .server_info("claude-server", env!("CARGO_PKG_VERSION"))

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -368,8 +368,31 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
 /// bounding pathological hangs.
 const DEFAULT_TIMEOUT_SECS: u64 = 300;
 
+/// Minimum `claude` CLI version this server has been verified
+/// against. Below this we know flags / argument shapes are missing
+/// or different. See [`claude_wrapper::Claude::cli_version_status`]
+/// for the runtime classifier.
+const TESTED_CLI_MIN: claude_wrapper::CliVersion = claude_wrapper::CliVersion {
+    major: 2,
+    minor: 1,
+    patch: 0,
+};
+
+/// Maximum `claude` CLI version this server has been verified
+/// against. Above this is "untested" -- the wrapper will warn
+/// (via tracing) and the typed status surfaces on
+/// `claude_doctor` + `claude://config`. Bump as we verify against
+/// later releases. Notable past breakage: 2.1.143 repurposed
+/// `claude agents` from a list-agents subcommand to a background-
+/// session TUI, which we caught and worked around.
+const TESTED_CLI_MAX: claude_wrapper::CliVersion = claude_wrapper::CliVersion {
+    major: 2,
+    minor: 1,
+    patch: 143,
+};
+
 fn build_claude(cfg: &ClaudeConfig) -> claude_wrapper::error::Result<Claude> {
-    let mut builder = Claude::builder();
+    let mut builder = Claude::builder().tested_cli_version_range(TESTED_CLI_MIN, TESTED_CLI_MAX);
     if let Some(ref bin) = cfg.binary {
         builder = builder.binary(bin);
     }

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -55,10 +55,14 @@
 //!    `claude_project_list`, `claude_session_list`,
 //!    `claude_session_get`. Resources: `claude://projects`,
 //!    `claude://projects/{slug}`, `claude://sessions/{id}`.
-//! 4. **Artifacts** (planned) -- CRUD over `~/.claude/skills/`,
-//!    `~/.claude/agents/`, plugin manifests, MCP server configs.
-//!    Not yet wired.
+//! 4. **Artifacts** (`artifacts` feature) -- read-only access to
+//!    `~/.claude/agents/<stem>.md`. Tools: `agent_list`, `agent_get`.
+//!    Resources: `claude://agents`, `claude://agents/{file_stem}`.
+//!    Skills CRUD and write/delete on agents are planned but not
+//!    yet wired.
 
+#[cfg(feature = "artifacts")]
+mod artifacts;
 #[cfg(feature = "chat")]
 mod chat;
 pub mod config;
@@ -176,6 +180,8 @@ fn build_router_inner(
                - claude://metrics       -- process counters; check spend mid-run\n\
                - claude://projects      -- on-disk project history (history feature)\n\
                - claude://sessions/{id} -- full parsed JSONL log for a session\n\
+               - claude://agents        -- user-level agents (artifacts feature)\n\
+               - claude://agents/{stem} -- one agent's full record + body\n\
              \n\
              For a longer walkthrough call `prompts/get usage_guide`.",
         );
@@ -208,6 +214,18 @@ fn build_router_inner(
             router = router.resource(resource);
         }
         for template in history::templates(&state) {
+            router = router.resource_template(template);
+        }
+    }
+    #[cfg(feature = "artifacts")]
+    {
+        for tool in artifacts::tools(&state) {
+            router = router.tool(tool);
+        }
+        for resource in artifacts::resources(&state) {
+            router = router.resource(resource);
+        }
+        for template in artifacts::templates(&state) {
             router = router.resource_template(template);
         }
     }
@@ -245,7 +263,8 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
             feature = "core",
             feature = "chat",
             feature = "mutations",
-            feature = "history"
+            feature = "history",
+            feature = "artifacts"
         )),
         allow(unused_variables)
     )]
@@ -264,6 +283,11 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
     let history_tools = history::tools(&state);
     #[cfg(not(feature = "history"))]
     let history_tools: Vec<tower_mcp::Tool> = Vec::new();
+
+    #[cfg(feature = "artifacts")]
+    let artifacts_tools = artifacts::tools(&state);
+    #[cfg(not(feature = "artifacts"))]
+    let artifacts_tools: Vec<tower_mcp::Tool> = Vec::new();
 
     #[cfg(feature = "core")]
     let core_tools = core::tools(&state);
@@ -284,6 +308,7 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
         .chain(turn_tool_list)
         .chain(muts)
         .chain(history_tools)
+        .chain(artifacts_tools)
         .map(|t| ToolInfo {
             name: t.name.clone(),
             description: t.description.clone(),

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -55,11 +55,16 @@
 //!    `claude_project_list`, `claude_session_list`,
 //!    `claude_session_get`. Resources: `claude://projects`,
 //!    `claude://projects/{slug}`, `claude://sessions/{id}`.
-//! 4. **Artifacts** (`artifacts` feature) -- read-only access to
-//!    `~/.claude/agents/<stem>.md`. Tools: `agent_list`, `agent_get`.
-//!    Resources: `claude://agents`, `claude://agents/{file_stem}`.
-//!    Skills CRUD and write/delete on agents are planned but not
-//!    yet wired.
+//! 4. **Artifacts** (`artifacts` feature) -- access to
+//!    `~/.claude/agents/<stem>.md`. Read tools: `agent_list`,
+//!    `agent_get`. Mutating tools (gated by `mutations` Cargo
+//!    feature + runtime `policy.allow_mutations`): `agent_write`,
+//!    `agent_delete`. Resources: `claude://agents`,
+//!    `claude://agents/{file_stem}`. Skills CRUD is planned.
+//! 5. **Worktrees** (`worktrees` feature) -- read-only git worktree
+//!    introspection. Tools: `worktree_list`. Resources:
+//!    `claude://worktrees`. Useful for hosts orchestrating
+//!    `chat_open(worktree=true)` to inspect what they've spawned.
 
 #[cfg(feature = "artifacts")]
 mod artifacts;
@@ -79,6 +84,8 @@ mod state;
 #[cfg(feature = "chat")]
 mod turn_tools;
 mod turns;
+#[cfg(feature = "worktrees")]
+mod worktrees;
 
 use std::sync::Arc;
 
@@ -183,6 +190,7 @@ fn build_router_inner(
                - claude://sessions/{id} -- full parsed JSONL log for a session\n\
                - claude://agents        -- user-level agents (artifacts feature)\n\
                - claude://agents/{stem} -- one agent's full record + body\n\
+               - claude://worktrees     -- git worktrees (worktrees feature)\n\
              \n\
              For a longer walkthrough call `prompts/get usage_guide`.",
         );
@@ -237,6 +245,18 @@ fn build_router_inner(
         }
         tracing::info!("artifacts mutating tools registered (policy.allow_mutations = true)");
     }
+    #[cfg(feature = "worktrees")]
+    {
+        for tool in worktrees::tools(&state) {
+            router = router.tool(tool);
+        }
+        for resource in worktrees::resources(&state) {
+            router = router.resource(resource);
+        }
+        for template in worktrees::templates(&state) {
+            router = router.resource_template(template);
+        }
+    }
     for resource in resources::resources(&state) {
         router = router.resource(resource);
     }
@@ -272,7 +292,8 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
             feature = "chat",
             feature = "mutations",
             feature = "history",
-            feature = "artifacts"
+            feature = "artifacts",
+            feature = "worktrees"
         )),
         allow(unused_variables)
     )]
@@ -306,6 +327,11 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
     #[cfg(not(all(feature = "artifacts", feature = "mutations")))]
     let artifacts_mut_tools: Vec<tower_mcp::Tool> = Vec::new();
 
+    #[cfg(feature = "worktrees")]
+    let worktrees_tools = worktrees::tools(&state);
+    #[cfg(not(feature = "worktrees"))]
+    let worktrees_tools: Vec<tower_mcp::Tool> = Vec::new();
+
     #[cfg(feature = "core")]
     let core_tools = core::tools(&state);
     #[cfg(not(feature = "core"))]
@@ -327,6 +353,7 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
         .chain(history_tools)
         .chain(artifacts_tools)
         .chain(artifacts_mut_tools)
+        .chain(worktrees_tools)
         .map(|t| ToolInfo {
             name: t.name.clone(),
             description: t.description.clone(),

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -43,10 +43,10 @@
 //!
 //! claude-server exposes three tool surfaces, layered by intent:
 //!
-//! 1. **Core** ([`core`]) -- 1:1 mirror of the `claude` CLI. Every
+//! 1. **Core** -- 1:1 mirror of the `claude` CLI. Every
 //!    subcommand you could shell out to lives here, with the
 //!    deliberate exception of interactive (no `-p`) mode. Always on.
-//! 2. **Chat** ([`chat`]) -- the duplex sidecar. We hold long-lived
+//! 2. **Chat** -- the duplex sidecar. We hold long-lived
 //!    `claude` subprocesses, manage turn ordering, expose cost and
 //!    history, and stream events back as MCP progress notifications.
 //!    This is where the server earns its keep over a dumb passthrough.

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -100,7 +100,7 @@ use std::sync::Arc;
 use tower_mcp::McpRouter;
 use tower_mcp::context::NotificationSender;
 
-pub use self::config::{ClaudeConfig, ServerConfig, ServerPolicy, TurnConfig};
+pub use self::config::{ClaudeConfig, ServerConfig, ServerPolicy, SurfacesConfig, TurnConfig};
 pub use self::state::ServerState;
 pub use tower_mcp::context::{NotificationReceiver, notification_channel};
 
@@ -205,27 +205,36 @@ fn build_router_inner(
              For a longer walkthrough call `prompts/get usage_guide`.",
         );
 
+    // Each surface block applies BOTH the compile-time Cargo
+    // feature gate AND the runtime config.surfaces.enable_X
+    // dimmer. Cargo feature is the hard ceiling; runtime config
+    // can disable but not enable beyond what was compiled in.
     #[cfg(feature = "core")]
-    for tool in core::tools(&state) {
-        router = router.tool(tool);
+    if state.config.surfaces.enable_core {
+        for tool in core::tools(&state) {
+            router = router.tool(tool);
+        }
     }
     #[cfg(feature = "chat")]
-    for tool in chat::tools(&state) {
-        router = router.tool(tool);
-    }
-    #[cfg(feature = "chat")]
-    for tool in turn_tools::tools(&state) {
-        router = router.tool(tool);
+    if state.config.surfaces.enable_chat {
+        for tool in chat::tools(&state) {
+            router = router.tool(tool);
+        }
+        for tool in turn_tools::tools(&state) {
+            router = router.tool(tool);
+        }
     }
     #[cfg(feature = "mutations")]
-    if state.config.policy.allow_mutations {
+    if state.config.policy.allow_mutations && state.config.surfaces.enable_mutations {
         for tool in mutations::tools(&state) {
             router = router.tool(tool);
         }
-        tracing::info!("mutating tools registered (policy.allow_mutations = true)");
+        tracing::info!(
+            "mutating tools registered (policy.allow_mutations + surfaces.enable_mutations = true)"
+        );
     }
     #[cfg(feature = "history")]
-    {
+    if state.config.surfaces.enable_history {
         for tool in history::tools(&state) {
             router = router.tool(tool);
         }
@@ -237,7 +246,7 @@ fn build_router_inner(
         }
     }
     #[cfg(feature = "artifacts")]
-    {
+    if state.config.surfaces.enable_artifacts {
         for tool in artifacts::tools(&state) {
             router = router.tool(tool);
         }
@@ -249,14 +258,17 @@ fn build_router_inner(
         }
     }
     #[cfg(all(feature = "artifacts", feature = "mutations"))]
-    if state.config.policy.allow_mutations {
+    if state.config.policy.allow_mutations
+        && state.config.surfaces.enable_mutations
+        && state.config.surfaces.enable_artifacts
+    {
         for tool in artifacts::mutating_tools(&state) {
             router = router.tool(tool);
         }
-        tracing::info!("artifacts mutating tools registered (policy.allow_mutations = true)");
+        tracing::info!("artifacts mutating tools registered");
     }
     #[cfg(feature = "worktrees")]
-    {
+    if state.config.surfaces.enable_worktrees {
         for tool in worktrees::tools(&state) {
             router = router.tool(tool);
         }
@@ -268,7 +280,7 @@ fn build_router_inner(
         }
     }
     #[cfg(feature = "jobs")]
-    {
+    if state.config.surfaces.enable_jobs {
         for tool in jobs::tools(&state) {
             router = router.tool(tool);
         }
@@ -322,27 +334,42 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
     )]
     let state = ServerState::new(Arc::new(claude), Arc::new(config));
 
+    // Runtime gate dimmer + compile-time feature ceiling. Each
+    // surface returns an empty Vec when either the Cargo feature
+    // is off OR the runtime surfaces.enable_X flag is false.
     #[cfg(feature = "mutations")]
-    let muts: Vec<tower_mcp::Tool> = if state.config.policy.allow_mutations {
-        mutations::tools(&state)
-    } else {
-        Vec::new()
-    };
+    let muts: Vec<tower_mcp::Tool> =
+        if state.config.policy.allow_mutations && state.config.surfaces.enable_mutations {
+            mutations::tools(&state)
+        } else {
+            Vec::new()
+        };
     #[cfg(not(feature = "mutations"))]
     let muts: Vec<tower_mcp::Tool> = Vec::new();
 
     #[cfg(feature = "history")]
-    let history_tools = history::tools(&state);
+    let history_tools = if state.config.surfaces.enable_history {
+        history::tools(&state)
+    } else {
+        Vec::new()
+    };
     #[cfg(not(feature = "history"))]
     let history_tools: Vec<tower_mcp::Tool> = Vec::new();
 
     #[cfg(feature = "artifacts")]
-    let artifacts_tools = artifacts::tools(&state);
+    let artifacts_tools = if state.config.surfaces.enable_artifacts {
+        artifacts::tools(&state)
+    } else {
+        Vec::new()
+    };
     #[cfg(not(feature = "artifacts"))]
     let artifacts_tools: Vec<tower_mcp::Tool> = Vec::new();
 
     #[cfg(all(feature = "artifacts", feature = "mutations"))]
-    let artifacts_mut_tools: Vec<tower_mcp::Tool> = if state.config.policy.allow_mutations {
+    let artifacts_mut_tools: Vec<tower_mcp::Tool> = if state.config.policy.allow_mutations
+        && state.config.surfaces.enable_mutations
+        && state.config.surfaces.enable_artifacts
+    {
         artifacts::mutating_tools(&state)
     } else {
         Vec::new()
@@ -351,25 +378,45 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
     let artifacts_mut_tools: Vec<tower_mcp::Tool> = Vec::new();
 
     #[cfg(feature = "worktrees")]
-    let worktrees_tools = worktrees::tools(&state);
+    let worktrees_tools = if state.config.surfaces.enable_worktrees {
+        worktrees::tools(&state)
+    } else {
+        Vec::new()
+    };
     #[cfg(not(feature = "worktrees"))]
     let worktrees_tools: Vec<tower_mcp::Tool> = Vec::new();
 
     #[cfg(feature = "jobs")]
-    let jobs_tools = jobs::tools(&state);
+    let jobs_tools = if state.config.surfaces.enable_jobs {
+        jobs::tools(&state)
+    } else {
+        Vec::new()
+    };
     #[cfg(not(feature = "jobs"))]
     let jobs_tools: Vec<tower_mcp::Tool> = Vec::new();
 
     #[cfg(feature = "core")]
-    let core_tools = core::tools(&state);
+    let core_tools = if state.config.surfaces.enable_core {
+        core::tools(&state)
+    } else {
+        Vec::new()
+    };
     #[cfg(not(feature = "core"))]
     let core_tools: Vec<tower_mcp::Tool> = Vec::new();
     #[cfg(feature = "chat")]
-    let chat_tools = chat::tools(&state);
+    let chat_tools = if state.config.surfaces.enable_chat {
+        chat::tools(&state)
+    } else {
+        Vec::new()
+    };
     #[cfg(not(feature = "chat"))]
     let chat_tools: Vec<tower_mcp::Tool> = Vec::new();
     #[cfg(feature = "chat")]
-    let turn_tool_list = turn_tools::tools(&state);
+    let turn_tool_list = if state.config.surfaces.enable_chat {
+        turn_tools::tools(&state)
+    } else {
+        Vec::new()
+    };
     #[cfg(not(feature = "chat"))]
     let turn_tool_list: Vec<tower_mcp::Tool> = Vec::new();
 

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -60,6 +60,7 @@ mod core;
 mod prompts;
 mod resources;
 mod state;
+mod turn_tools;
 mod turns;
 
 use std::sync::Arc;
@@ -96,6 +97,9 @@ pub fn build_router(config: ServerConfig) -> claude_wrapper::error::Result<McpRo
     for tool in chat::tools(&state) {
         router = router.tool(tool);
     }
+    for tool in turn_tools::tools(&state) {
+        router = router.tool(tool);
+    }
     for resource in resources::resources(&state) {
         router = router.resource(resource);
     }
@@ -123,6 +127,7 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
     let mut all: Vec<ToolInfo> = core::tools(&state)
         .into_iter()
         .chain(chat::tools(&state))
+        .chain(turn_tools::tools(&state))
         .map(|t| ToolInfo {
             name: t.name.clone(),
             description: t.description.clone(),

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -54,13 +54,17 @@
 //!    `~/.claude/agents/`, plugin manifests, MCP server configs.
 //!    Not yet wired.
 
+#[cfg(feature = "chat")]
 mod chat;
 pub mod config;
+#[cfg(feature = "core")]
 mod core;
+#[cfg(feature = "mutations")]
 mod mutations;
 mod prompts;
 mod resources;
 mod state;
+#[cfg(feature = "chat")]
 mod turn_tools;
 mod turns;
 
@@ -142,15 +146,19 @@ fn build_router_inner(
              to discover the active surface.",
         );
 
+    #[cfg(feature = "core")]
     for tool in core::tools(&state) {
         router = router.tool(tool);
     }
+    #[cfg(feature = "chat")]
     for tool in chat::tools(&state) {
         router = router.tool(tool);
     }
+    #[cfg(feature = "chat")]
     for tool in turn_tools::tools(&state) {
         router = router.tool(tool);
     }
+    #[cfg(feature = "mutations")]
     if state.config.policy.allow_mutations {
         for tool in mutations::tools(&state) {
             router = router.tool(tool);
@@ -186,17 +194,38 @@ pub struct ToolInfo {
 /// assembling a transport. Useful for `claude-server tools`.
 pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<Vec<ToolInfo>> {
     let claude = build_claude(&config.claude)?;
+    #[cfg_attr(
+        not(any(feature = "core", feature = "chat", feature = "mutations")),
+        allow(unused_variables)
+    )]
     let state = ServerState::new(Arc::new(claude), Arc::new(config));
 
-    let muts: Vec<_> = if state.config.policy.allow_mutations {
+    #[cfg(feature = "mutations")]
+    let muts: Vec<tower_mcp::Tool> = if state.config.policy.allow_mutations {
         mutations::tools(&state)
     } else {
         Vec::new()
     };
-    let mut all: Vec<ToolInfo> = core::tools(&state)
+    #[cfg(not(feature = "mutations"))]
+    let muts: Vec<tower_mcp::Tool> = Vec::new();
+
+    #[cfg(feature = "core")]
+    let core_tools = core::tools(&state);
+    #[cfg(not(feature = "core"))]
+    let core_tools: Vec<tower_mcp::Tool> = Vec::new();
+    #[cfg(feature = "chat")]
+    let chat_tools = chat::tools(&state);
+    #[cfg(not(feature = "chat"))]
+    let chat_tools: Vec<tower_mcp::Tool> = Vec::new();
+    #[cfg(feature = "chat")]
+    let turn_tool_list = turn_tools::tools(&state);
+    #[cfg(not(feature = "chat"))]
+    let turn_tool_list: Vec<tower_mcp::Tool> = Vec::new();
+
+    let mut all: Vec<ToolInfo> = core_tools
         .into_iter()
-        .chain(chat::tools(&state))
-        .chain(turn_tools::tools(&state))
+        .chain(chat_tools)
+        .chain(turn_tool_list)
         .chain(muts)
         .map(|t| ToolInfo {
             name: t.name.clone(),

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -140,10 +140,35 @@ fn build_router_inner(
     let mut router = McpRouter::new()
         .server_info("claude-server", env!("CARGO_PKG_VERSION"))
         .instructions(
-            "MCP server exposing the Claude Code CLI via claude-wrapper. \
-             `claude.*` tools are 1:1 passthroughs to the CLI. \
-             Read `claude://config` and `claude://tools` resources \
-             to discover the active surface.",
+            "MCP server exposing the Claude Code CLI via claude-wrapper.\n\
+             \n\
+             THREE SURFACES:\n\
+               - claude_*  -- 1:1 mirror of the `claude` CLI\n\
+               - chat_*    -- long-lived multi-turn conversations\n\
+               - turn_*    -- async lifecycle for in-flight turns\n\
+             \n\
+             ASYNC BY DEFAULT for agent turns. The bare `chat_send` and \
+             `claude_query` return a turn_id immediately and run in the \
+             background -- poll with `turn_get`, block with `turn_wait`, \
+             cancel with `turn_cancel`. The `*_sync` variants hold your \
+             request connection open until the turn completes; reach for \
+             them only if you genuinely need to block.\n\
+             \n\
+             TYPICAL FLOWS:\n\
+               - Single-shot:   claude_query(prompt) -> turn_id; turn_wait(id)\n\
+               - Conversation:  chat_open -> chat_id; \
+             chat_send(id, prompt) -> turn_id; turn_wait; repeat; chat_close\n\
+               - Multi-project: chat_open(working_dir: \"/path/to/repo\")\n\
+               - Resume:        chat_open(resume: \"<session_id>\")\n\
+             \n\
+             DISCOVERY:\n\
+               - claude://tools      -- the full registered tool surface\n\
+               - claude://config     -- server config (env values redacted)\n\
+               - claude://chats      -- live chats with cost + turn count\n\
+               - claude://chats/{id} -- one chat's full history (subscribable)\n\
+               - claude://metrics    -- process counters; check spend mid-run\n\
+             \n\
+             For a longer walkthrough call `prompts/get usage_guide`.",
         );
 
     #[cfg(feature = "core")]

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -57,6 +57,7 @@
 mod chat;
 pub mod config;
 mod core;
+mod mutations;
 mod prompts;
 mod resources;
 mod state;
@@ -67,7 +68,7 @@ use std::sync::Arc;
 
 use tower_mcp::McpRouter;
 
-pub use self::config::{ClaudeConfig, ServerConfig, TurnConfig};
+pub use self::config::{ClaudeConfig, ServerConfig, ServerPolicy, TurnConfig};
 pub use self::state::ServerState;
 
 use claude_wrapper::Claude;
@@ -107,6 +108,12 @@ pub fn build_router(config: ServerConfig) -> claude_wrapper::error::Result<McpRo
     for tool in turn_tools::tools(&state) {
         router = router.tool(tool);
     }
+    if state.config.policy.allow_mutations {
+        for tool in mutations::tools(&state) {
+            router = router.tool(tool);
+        }
+        tracing::info!("mutating tools registered (policy.allow_mutations = true)");
+    }
     for resource in resources::resources(&state) {
         router = router.resource(resource);
     }
@@ -134,10 +141,16 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
     let claude = build_claude(&config.claude)?;
     let state = ServerState::new(Arc::new(claude), Arc::new(config));
 
+    let muts: Vec<_> = if state.config.policy.allow_mutations {
+        mutations::tools(&state)
+    } else {
+        Vec::new()
+    };
     let mut all: Vec<ToolInfo> = core::tools(&state)
         .into_iter()
         .chain(chat::tools(&state))
         .chain(turn_tools::tools(&state))
+        .chain(muts)
         .map(|t| ToolInfo {
             name: t.name.clone(),
             description: t.description.clone(),

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -60,6 +60,7 @@ mod core;
 mod prompts;
 mod resources;
 mod state;
+mod turns;
 
 use std::sync::Arc;
 

--- a/crates/claude-server/src/lib.rs
+++ b/crates/claude-server/src/lib.rs
@@ -65,6 +65,12 @@
 //!    introspection. Tools: `worktree_list`. Resources:
 //!    `claude://worktrees`. Useful for hosts orchestrating
 //!    `chat_open(worktree=true)` to inspect what they've spawned.
+//! 6. **Jobs** (`jobs` feature) -- read-only access to background-job
+//!    state Claude Code's `claude agents` daemon writes to
+//!    `~/.claude/jobs/`. Tools: `claude_job_list`,
+//!    `claude_job_get`. Resources: `claude://jobs`,
+//!    `claude://jobs/{short_id}`. Cross-link with the `history`
+//!    feature via the job's `session_path`.
 
 #[cfg(feature = "artifacts")]
 mod artifacts;
@@ -76,6 +82,8 @@ mod core;
 mod errors;
 #[cfg(feature = "history")]
 mod history;
+#[cfg(feature = "jobs")]
+mod jobs;
 #[cfg(feature = "mutations")]
 mod mutations;
 mod prompts;
@@ -191,6 +199,8 @@ fn build_router_inner(
                - claude://agents        -- user-level agents (artifacts feature)\n\
                - claude://agents/{stem} -- one agent's full record + body\n\
                - claude://worktrees     -- git worktrees (worktrees feature)\n\
+               - claude://jobs          -- background-job state (jobs feature)\n\
+               - claude://jobs/{id}     -- one job's full timeline + state\n\
              \n\
              For a longer walkthrough call `prompts/get usage_guide`.",
         );
@@ -257,6 +267,18 @@ fn build_router_inner(
             router = router.resource_template(template);
         }
     }
+    #[cfg(feature = "jobs")]
+    {
+        for tool in jobs::tools(&state) {
+            router = router.tool(tool);
+        }
+        for resource in jobs::resources(&state) {
+            router = router.resource(resource);
+        }
+        for template in jobs::templates(&state) {
+            router = router.resource_template(template);
+        }
+    }
     for resource in resources::resources(&state) {
         router = router.resource(resource);
     }
@@ -293,7 +315,8 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
             feature = "mutations",
             feature = "history",
             feature = "artifacts",
-            feature = "worktrees"
+            feature = "worktrees",
+            feature = "jobs"
         )),
         allow(unused_variables)
     )]
@@ -332,6 +355,11 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
     #[cfg(not(feature = "worktrees"))]
     let worktrees_tools: Vec<tower_mcp::Tool> = Vec::new();
 
+    #[cfg(feature = "jobs")]
+    let jobs_tools = jobs::tools(&state);
+    #[cfg(not(feature = "jobs"))]
+    let jobs_tools: Vec<tower_mcp::Tool> = Vec::new();
+
     #[cfg(feature = "core")]
     let core_tools = core::tools(&state);
     #[cfg(not(feature = "core"))]
@@ -354,6 +382,7 @@ pub fn registered_tools(config: ServerConfig) -> claude_wrapper::error::Result<V
         .chain(artifacts_tools)
         .chain(artifacts_mut_tools)
         .chain(worktrees_tools)
+        .chain(jobs_tools)
         .map(|t| ToolInfo {
             name: t.name.clone(),
             description: t.description.clone(),

--- a/crates/claude-server/src/mutations.rs
+++ b/crates/claude-server/src/mutations.rs
@@ -1,0 +1,348 @@
+//! Mutating CLI passthrough tools. Registered only when
+//! [`crate::ServerPolicy::allow_mutations`] is true.
+//!
+//! Each tool wraps a `claude_wrapper` command builder for a CLI
+//! subcommand that modifies user/project/local state -- adding MCP
+//! servers, installing plugins, adding marketplaces. The tool shape
+//! is identical to the read-only core: typed input, JSON output
+//! mirroring CommandOutput with ANSI stripped.
+//!
+//! Naming convention matches the read-only core: `claude_<sub>_<verb>`.
+//! `claude mcp add foo` -> `claude_mcp_add`, etc.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+
+use claude_wrapper::Claude;
+use claude_wrapper::ClaudeCommand;
+use claude_wrapper::command::marketplace::{
+    MarketplaceAddCommand, MarketplaceRemoveCommand, MarketplaceUpdateCommand,
+};
+use claude_wrapper::command::mcp::{McpAddCommand, McpAddJsonCommand, McpRemoveCommand};
+use claude_wrapper::command::plugin::{
+    PluginDisableCommand, PluginEnableCommand, PluginInstallCommand, PluginUninstallCommand,
+    PluginUpdateCommand,
+};
+use claude_wrapper::types::Scope;
+
+use crate::state::ServerState;
+
+pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
+    vec![
+        tool_mcp_add(state),
+        tool_mcp_add_json(state),
+        tool_mcp_remove(state),
+        tool_plugin_install(state),
+        tool_plugin_uninstall(state),
+        tool_plugin_enable(state),
+        tool_plugin_disable(state),
+        tool_plugin_update(state),
+        tool_marketplace_add(state),
+        tool_marketplace_remove(state),
+        tool_marketplace_update(state),
+    ]
+}
+
+fn parse_scope(s: &str) -> Result<Scope, tower_mcp::Error> {
+    match s {
+        "user" => Ok(Scope::User),
+        "project" => Ok(Scope::Project),
+        "local" => Ok(Scope::Local),
+        other => Err(tower_mcp::Error::internal(format!(
+            "invalid scope `{other}` (expected user / project / local)"
+        ))),
+    }
+}
+
+fn cmd_output_json(out: &claude_wrapper::exec::CommandOutput) -> CallToolResult {
+    CallToolResult::json(json!({
+        "stdout": crate::core::strip_ansi(&out.stdout),
+        "stderr": crate::core::strip_ansi(&out.stderr),
+        "exit_code": out.exit_code,
+        "success": out.success,
+    }))
+}
+
+fn internal(e: impl std::fmt::Display) -> tower_mcp::Error {
+    tower_mcp::Error::internal(e.to_string())
+}
+
+// -- claude_mcp_add --------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct McpAddInput {
+    /// Name to register the MCP server under.
+    name: String,
+    /// Command (for stdio) or URL (for http/sse).
+    command_or_url: String,
+    /// Optional scope: user, project, or local. Default: CLI default.
+    #[serde(default)]
+    scope: Option<String>,
+    /// Optional transport: stdio, http, sse.
+    #[serde(default)]
+    transport: Option<String>,
+    /// Environment variables to pass to the spawned server.
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    /// Extra arguments for the server command.
+    #[serde(default)]
+    server_args: Vec<String>,
+}
+
+fn tool_mcp_add(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_mcp_add")
+        .description("Run `claude mcp add` to register a new MCP server.")
+        .handler(move |input: McpAddInput| {
+            let claude = Arc::clone(&claude);
+            async move { run_mcp_add(claude, input).await }
+        })
+        .build()
+}
+
+async fn run_mcp_add(
+    claude: Arc<Claude>,
+    input: McpAddInput,
+) -> Result<CallToolResult, tower_mcp::Error> {
+    let mut cmd = McpAddCommand::new(input.name, input.command_or_url);
+    if let Some(s) = input.scope {
+        cmd = cmd.scope(parse_scope(&s)?);
+    }
+    if let Some(t) = input.transport {
+        use claude_wrapper::types::Transport;
+        let parsed: Transport = t.parse().map_err(internal)?;
+        cmd = cmd.transport(parsed);
+    }
+    for (k, v) in input.env {
+        cmd = cmd.env(k, v);
+    }
+    if !input.server_args.is_empty() {
+        cmd = cmd.server_args(input.server_args);
+    }
+    let out = cmd.execute(&claude).await.map_err(internal)?;
+    Ok(cmd_output_json(&out))
+}
+
+// -- claude_mcp_add_json --------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct McpAddJsonInput {
+    /// Name to register the server under.
+    name: String,
+    /// Full JSON config blob for the server.
+    json: String,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+fn tool_mcp_add_json(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_mcp_add_json")
+        .description("Run `claude mcp add-json` with a full JSON server config.")
+        .handler(move |input: McpAddJsonInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let mut cmd = McpAddJsonCommand::new(input.name, input.json);
+                if let Some(s) = input.scope {
+                    cmd = cmd.scope(parse_scope(&s)?);
+                }
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_mcp_remove ----------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct McpRemoveInput {
+    name: String,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+fn tool_mcp_remove(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_mcp_remove")
+        .description("Run `claude mcp remove` to unregister an MCP server.")
+        .handler(move |input: McpRemoveInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let mut cmd = McpRemoveCommand::new(input.name);
+                if let Some(s) = input.scope {
+                    cmd = cmd.scope(parse_scope(&s)?);
+                }
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_plugin_{install,uninstall,enable,disable,update} ---------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PluginScopedInput {
+    plugin: String,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+fn tool_plugin_install(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_plugin_install")
+        .description("Run `claude plugin install <plugin>`.")
+        .handler(move |input: PluginScopedInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let mut cmd = PluginInstallCommand::new(input.plugin);
+                if let Some(s) = input.scope {
+                    cmd = cmd.scope(parse_scope(&s)?);
+                }
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+fn tool_plugin_uninstall(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_plugin_uninstall")
+        .description("Run `claude plugin uninstall <plugin>`.")
+        .handler(move |input: PluginScopedInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let mut cmd = PluginUninstallCommand::new(input.plugin);
+                if let Some(s) = input.scope {
+                    cmd = cmd.scope(parse_scope(&s)?);
+                }
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+fn tool_plugin_enable(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_plugin_enable")
+        .description("Run `claude plugin enable <plugin>`.")
+        .handler(move |input: PluginScopedInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let mut cmd = PluginEnableCommand::new(input.plugin);
+                if let Some(s) = input.scope {
+                    cmd = cmd.scope(parse_scope(&s)?);
+                }
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+fn tool_plugin_disable(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_plugin_disable")
+        .description("Run `claude plugin disable <plugin>`.")
+        .handler(move |input: PluginScopedInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let mut cmd = PluginDisableCommand::new(input.plugin);
+                if let Some(s) = input.scope {
+                    cmd = cmd.scope(parse_scope(&s)?);
+                }
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+fn tool_plugin_update(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_plugin_update")
+        .description("Run `claude plugin update <plugin>`.")
+        .handler(move |input: PluginScopedInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let mut cmd = PluginUpdateCommand::new(input.plugin);
+                if let Some(s) = input.scope {
+                    cmd = cmd.scope(parse_scope(&s)?);
+                }
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+// -- claude_marketplace_{add,remove,update} -------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct MarketplaceAddInput {
+    /// Source (git URL or filesystem path).
+    source: String,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+fn tool_marketplace_add(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_marketplace_add")
+        .description("Run `claude plugin marketplace add <source>`.")
+        .handler(move |input: MarketplaceAddInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let mut cmd = MarketplaceAddCommand::new(input.source);
+                if let Some(s) = input.scope {
+                    cmd = cmd.scope(parse_scope(&s)?);
+                }
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct MarketplaceNameInput {
+    name: String,
+}
+
+fn tool_marketplace_remove(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_marketplace_remove")
+        .description("Run `claude plugin marketplace remove <name>`.")
+        .handler(move |input: MarketplaceNameInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let cmd = MarketplaceRemoveCommand::new(input.name);
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+fn tool_marketplace_update(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_marketplace_update")
+        .description("Run `claude plugin marketplace update <name>`.")
+        .handler(move |input: MarketplaceNameInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let cmd = MarketplaceUpdateCommand::new(input.name);
+                let out = cmd.execute(&claude).await.map_err(internal)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}

--- a/crates/claude-server/src/mutations.rs
+++ b/crates/claude-server/src/mutations.rs
@@ -25,8 +25,8 @@ use claude_wrapper::command::marketplace::{
 };
 use claude_wrapper::command::mcp::{McpAddCommand, McpAddJsonCommand, McpRemoveCommand};
 use claude_wrapper::command::plugin::{
-    PluginDisableCommand, PluginEnableCommand, PluginInstallCommand, PluginUninstallCommand,
-    PluginUpdateCommand,
+    PluginDisableCommand, PluginEnableCommand, PluginInstallCommand, PluginPruneCommand,
+    PluginUninstallCommand, PluginUpdateCommand,
 };
 use claude_wrapper::types::Scope;
 
@@ -39,6 +39,7 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
         tool_mcp_remove(state),
         tool_plugin_install(state),
         tool_plugin_uninstall(state),
+        tool_plugin_prune(state),
         tool_plugin_enable(state),
         tool_plugin_disable(state),
         tool_plugin_update(state),
@@ -53,8 +54,9 @@ fn parse_scope(s: &str) -> Result<Scope, tower_mcp::Error> {
         "user" => Ok(Scope::User),
         "project" => Ok(Scope::Project),
         "local" => Ok(Scope::Local),
+        "managed" => Ok(Scope::Managed),
         other => Err(tower_mcp::Error::internal(format!(
-            "invalid scope `{other}` (expected user / project / local)"
+            "invalid scope `{other}` (expected user / project / local / managed)"
         ))),
     }
 }
@@ -210,16 +212,103 @@ fn tool_plugin_install(state: &ServerState) -> Tool {
         .build()
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PluginUninstallInput {
+    plugin: String,
+    /// Scope: user / project / local / managed.
+    #[serde(default)]
+    scope: Option<String>,
+    /// Preserve the plugin's persistent data directory
+    /// (`~/.claude/plugins/data/{id}/`) on uninstall (`--keep-data`).
+    /// Default: data is removed alongside the plugin.
+    #[serde(default)]
+    keep_data: bool,
+    /// Also remove auto-installed dependencies that are no longer
+    /// needed (`--prune`). Requires `yes: true` in non-interactive
+    /// contexts -- which the server always is.
+    #[serde(default)]
+    prune: bool,
+    /// Skip the confirmation prompt (`-y`). **The server is always
+    /// non-TTY**, so leaving this off will hang the underlying CLI
+    /// on its prompt. Default true here so the common case doesn't
+    /// trip; pass `false` if you want the CLI to prompt (only useful
+    /// for testing).
+    #[serde(default = "default_true")]
+    yes: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
 fn tool_plugin_uninstall(state: &ServerState) -> Tool {
     let claude = state.claude.clone();
     ToolBuilder::new("claude_plugin_uninstall")
-        .description("Run `claude plugin uninstall <plugin>`.")
-        .handler(move |input: PluginScopedInput| {
+        .description(
+            "Run `claude plugin uninstall <plugin>`. Defaults `yes: true` \
+             since the server is always non-TTY and the underlying CLI \
+             would otherwise hang on its confirmation prompt. Optional \
+             flags: `keep_data` (preserve data dir), `prune` (remove \
+             auto-installed deps), `scope` (user|project|local|managed).",
+        )
+        .handler(move |input: PluginUninstallInput| {
             let claude = Arc::clone(&claude);
             async move {
                 let mut cmd = PluginUninstallCommand::new(input.plugin);
                 if let Some(s) = input.scope {
                     cmd = cmd.scope(parse_scope(&s)?);
+                }
+                if input.keep_data {
+                    cmd = cmd.keep_data();
+                }
+                if input.prune {
+                    cmd = cmd.prune();
+                }
+                if input.yes {
+                    cmd = cmd.yes();
+                }
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
+                Ok(cmd_output_json(&out))
+            }
+        })
+        .build()
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct PluginPruneInput {
+    /// Print what would be removed without removing anything.
+    #[serde(default)]
+    dry_run: bool,
+    /// Scope: user / project / local / managed.
+    #[serde(default)]
+    scope: Option<String>,
+    /// Skip confirmation (`-y`). Defaults true for non-TTY safety;
+    /// pass `false` to let the CLI prompt (only useful for testing).
+    #[serde(default = "default_true")]
+    yes: bool,
+}
+
+fn tool_plugin_prune(state: &ServerState) -> Tool {
+    let claude = state.claude.clone();
+    ToolBuilder::new("claude_plugin_prune")
+        .description(
+            "Run `claude plugin prune` (alias `autoremove`) to remove \
+             auto-installed dependencies that are no longer needed. \
+             Defaults `yes: true` since the server is always non-TTY. \
+             Optional `dry_run` previews without removing.",
+        )
+        .handler(move |input: PluginPruneInput| {
+            let claude = Arc::clone(&claude);
+            async move {
+                let mut cmd = PluginPruneCommand::new();
+                if input.dry_run {
+                    cmd = cmd.dry_run();
+                }
+                if let Some(s) = input.scope {
+                    cmd = cmd.scope(parse_scope(&s)?);
+                }
+                if input.yes {
+                    cmd = cmd.yes();
                 }
                 let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))

--- a/crates/claude-server/src/mutations.rs
+++ b/crates/claude-server/src/mutations.rs
@@ -68,9 +68,7 @@ fn cmd_output_json(out: &claude_wrapper::exec::CommandOutput) -> CallToolResult 
     }))
 }
 
-fn internal(e: impl std::fmt::Display) -> tower_mcp::Error {
-    tower_mcp::Error::internal(e.to_string())
-}
+use crate::errors::{from_wrapper, internal};
 
 // -- claude_mcp_add --------------------------------------------------
 
@@ -124,7 +122,7 @@ async fn run_mcp_add(
     if !input.server_args.is_empty() {
         cmd = cmd.server_args(input.server_args);
     }
-    let out = cmd.execute(&claude).await.map_err(internal)?;
+    let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
     Ok(cmd_output_json(&out))
 }
 
@@ -151,7 +149,7 @@ fn tool_mcp_add_json(state: &ServerState) -> Tool {
                 if let Some(s) = input.scope {
                     cmd = cmd.scope(parse_scope(&s)?);
                 }
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })
@@ -178,7 +176,7 @@ fn tool_mcp_remove(state: &ServerState) -> Tool {
                 if let Some(s) = input.scope {
                     cmd = cmd.scope(parse_scope(&s)?);
                 }
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })
@@ -205,7 +203,7 @@ fn tool_plugin_install(state: &ServerState) -> Tool {
                 if let Some(s) = input.scope {
                     cmd = cmd.scope(parse_scope(&s)?);
                 }
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })
@@ -223,7 +221,7 @@ fn tool_plugin_uninstall(state: &ServerState) -> Tool {
                 if let Some(s) = input.scope {
                     cmd = cmd.scope(parse_scope(&s)?);
                 }
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })
@@ -241,7 +239,7 @@ fn tool_plugin_enable(state: &ServerState) -> Tool {
                 if let Some(s) = input.scope {
                     cmd = cmd.scope(parse_scope(&s)?);
                 }
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })
@@ -259,7 +257,7 @@ fn tool_plugin_disable(state: &ServerState) -> Tool {
                 if let Some(s) = input.scope {
                     cmd = cmd.scope(parse_scope(&s)?);
                 }
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })
@@ -277,7 +275,7 @@ fn tool_plugin_update(state: &ServerState) -> Tool {
                 if let Some(s) = input.scope {
                     cmd = cmd.scope(parse_scope(&s)?);
                 }
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })
@@ -305,7 +303,7 @@ fn tool_marketplace_add(state: &ServerState) -> Tool {
                 if let Some(s) = input.scope {
                     cmd = cmd.scope(parse_scope(&s)?);
                 }
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })
@@ -325,7 +323,7 @@ fn tool_marketplace_remove(state: &ServerState) -> Tool {
             let claude = Arc::clone(&claude);
             async move {
                 let cmd = MarketplaceRemoveCommand::new(input.name);
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })
@@ -340,7 +338,7 @@ fn tool_marketplace_update(state: &ServerState) -> Tool {
             let claude = Arc::clone(&claude);
             async move {
                 let cmd = MarketplaceUpdateCommand::new(input.name);
-                let out = cmd.execute(&claude).await.map_err(internal)?;
+                let out = cmd.execute(&claude).await.map_err(from_wrapper)?;
                 Ok(cmd_output_json(&out))
             }
         })

--- a/crates/claude-server/src/prompts.rs
+++ b/crates/claude-server/src/prompts.rs
@@ -173,8 +173,11 @@ within a single chat queue.
 - `claude://agents` (artifacts feature) -- user-level agent \
   definitions read from `~/.claude/agents/<stem>.md`. Pair with \
   `claude://agents/{file_stem}` for one agent's full record. Same \
-  shape as the `agent_list` / `agent_get` tools. Read-only -- \
-  write/delete will arrive later under `mutations`.
+  shape as the `agent_list` / `agent_get` tools. Mutating tools \
+  `agent_write` and `agent_delete` are gated by both the `mutations` \
+  Cargo feature AND `policy.allow_mutations = true` at runtime; \
+  when on, `agent_write` is upsert by default (`if_not_exists: true` \
+  for create-only).
 
 Before firing an expensive turn, `metrics_summary` lets you check \
 cumulative spend. Open chats with `max_cost_usd` to enforce a hard \

--- a/crates/claude-server/src/prompts.rs
+++ b/crates/claude-server/src/prompts.rs
@@ -161,7 +161,11 @@ within a single chat queue.
   active strategy (`bedrock | vertex | api_key | oauth_token | \
   subscription`) -- same shape as the `claude_auth_strategy` tool. \
   `subscription` means no env auth pin; for liveness call \
-  `claude_auth_status`.
+  `claude_auth_status`. Also includes a `cli_version` block: \
+  `tested_range` (the [min, max] this server build was verified \
+  against) and `status` (`tested | newer_untested | \
+  older_than_minimum`). `claude_doctor` returns the same \
+  `cli_version_status` field.
 - `claude://tools` -- the registered tool surface; useful for \
   programmatic introspection.
 - `claude://projects` (history feature) -- every project under \

--- a/crates/claude-server/src/prompts.rs
+++ b/crates/claude-server/src/prompts.rs
@@ -157,7 +157,11 @@ within a single chat queue.
   failed / cancelled, in_flight, total_cost_usd. Same shape as \
   `metrics_summary`.
 - `claude://config` -- sanitized server config (env values redacted \
-  on KEY/TOKEN/SECRET/PASSWORD).
+  on KEY/TOKEN/SECRET/PASSWORD). Includes an `auth` block with the \
+  active strategy (`bedrock | vertex | api_key | oauth_token | \
+  subscription`) -- same shape as the `claude_auth_strategy` tool. \
+  `subscription` means no env auth pin; for liveness call \
+  `claude_auth_status`.
 - `claude://tools` -- the registered tool surface; useful for \
   programmatic introspection.
 - `claude://projects` (history feature) -- every project under \

--- a/crates/claude-server/src/prompts.rs
+++ b/crates/claude-server/src/prompts.rs
@@ -166,6 +166,11 @@ within a single chat queue.
   `claude://sessions/{id}` for the full parsed entry log. Same \
   shape as the `claude_project_list` / `claude_session_list` / \
   `claude_session_get` tools.
+- `claude://agents` (artifacts feature) -- user-level agent \
+  definitions read from `~/.claude/agents/<stem>.md`. Pair with \
+  `claude://agents/{file_stem}` for one agent's full record. Same \
+  shape as the `agent_list` / `agent_get` tools. Read-only -- \
+  write/delete will arrive later under `mutations`.
 
 Before firing an expensive turn, `metrics_summary` lets you check \
 cumulative spend. Open chats with `max_cost_usd` to enforce a hard \
@@ -190,7 +195,8 @@ the budget is exhausted.
 ## What this server does NOT cover
 
 - Skills CRUD (`~/.claude/skills/`) -- planned, not yet wired
-- Agents CRUD (`~/.claude/agents/`) -- planned
+- Agent write/delete (`~/.claude/agents/<stem>.md`) -- planned \
+  under `mutations`. Reads are live as of the artifacts feature.
 - Worktree introspection / removal -- planned
 
 For now, those surfaces live elsewhere or require direct filesystem access.

--- a/crates/claude-server/src/prompts.rs
+++ b/crates/claude-server/src/prompts.rs
@@ -8,7 +8,7 @@ use tower_mcp::{Prompt, PromptBuilder};
 use crate::state::ServerState;
 
 pub(crate) fn prompts(_state: &ServerState) -> Vec<Prompt> {
-    vec![prompt_describe_server()]
+    vec![prompt_describe_server(), prompt_usage_guide()]
 }
 
 fn prompt_describe_server() -> Prompt {
@@ -32,3 +32,161 @@ fn prompt_describe_server() -> Prompt {
         })
         .build()
 }
+
+fn prompt_usage_guide() -> Prompt {
+    PromptBuilder::new("usage_guide")
+        .description(
+            "Pull the claude-server usage handbook into the calling \
+             agent's context. Covers the three-surface taxonomy, the \
+             async-by-default rule, common flows, error patterns, and \
+             where to find live state. Read this once when you connect.",
+        )
+        .handler(|_args: HashMap<String, String>| async move {
+            Ok(GetPromptResult::builder()
+                .description("How to use this claude-server effectively.")
+                .user(USAGE_GUIDE_TEXT)
+                .build())
+        })
+        .build()
+}
+
+const USAGE_GUIDE_TEXT: &str = "\
+# claude-server usage guide
+
+You are connected to claude-server -- an MCP server that wraps the \
+Claude Code CLI. Treat this as your operator manual.
+
+## Three surfaces
+
+1. **`claude_*`** -- 1:1 mirror of the `claude` CLI. Single-shot \
+queries, version checks, agent listing, MCP / plugin / marketplace \
+inspection, doctor.
+
+2. **`chat_*`** -- long-lived multi-turn conversations. Each chat is \
+a duplex `claude` subprocess held open across turns; turns within a \
+chat serialize, chats run in parallel.
+
+3. **`turn_*`** -- async lifecycle for in-flight turns. Whenever you \
+fire an agent turn (via the bare `chat_send` or `claude_query`) you \
+get back a `turn_id`; these tools let you observe and control it.
+
+Plus `metrics_summary` for process-wide counters and the gated \
+mutation surface (claude_mcp_add, claude_plugin_install, ...) when \
+the server is started with `policy.allow_mutations = true`.
+
+## The async-by-default rule
+
+Agent turns are async. Always.
+
+- `chat_send(chat_id, prompt)` returns `{ turn_id }` immediately. \
+The turn runs in the background. Use `turn_wait(turn_id, \
+timeout_secs)` to block, `turn_get(turn_id)` to poll, or \
+`turn_cancel(turn_id)` to abort.
+
+- `claude_query(prompt)` returns `{ turn_id }` immediately for \
+single-shot queries.
+
+- `chat_send_sync` and `claude_query_sync` exist as escape hatches: \
+they hold your request connection open until the turn completes. \
+**Use these only when you genuinely need to block.** The async \
+variants are the right choice 99% of the time -- they let you fire \
+multiple turns in parallel, observe progress, and cancel.
+
+- `chat_send_stream_sync` is sync and emits MCP progress \
+notifications during the turn so callers see assistant deltas as \
+they arrive. Useful for streaming UIs; otherwise prefer async.
+
+## Typical flows
+
+### Single question, get the answer
+
+```
+turn_id = claude_query(prompt: \"explain this error\", model: \"haiku\").turn_id
+result  = turn_wait(turn_id: turn_id, timeout_secs: 30)
+# result.result is the JSON envelope: { result, session_id, total_cost_usd, ... }
+```
+
+### Multi-turn conversation
+
+```
+chat_id = chat_open(model: \"haiku\", max_cost_usd: 1.0).chat_id
+
+turn1 = chat_send(chat_id: chat_id, prompt: \"hi\").turn_id
+done1 = turn_wait(turn_id: turn1)
+
+turn2 = chat_send(chat_id: chat_id, prompt: \"follow-up\").turn_id
+done2 = turn_wait(turn_id: turn2)
+
+chat_close(chat_id: chat_id)
+```
+
+### Talk to a different project
+
+```
+chat_open(model: \"haiku\",
+          working_dir: \"/path/to/other/project\",
+          system_prompt: \"you're working in project X\")
+```
+The spawned `claude` subprocess starts in `working_dir`. One server \
+can hold parallel chats against multiple project roots.
+
+### Resume an on-disk session
+
+```
+chat_open(resume: \"<session_id from ~/.claude/projects/...>\")
+```
+Picks up the conversation that produced `session_id`. Subsequent \
+turns extend the existing history.
+
+### Coordinator / fan-out pattern
+
+Fire several `claude_query` or `chat_send` calls without waiting \
+between them; each returns a `turn_id` instantly. Then either \
+`turn_wait` each in sequence or use `turn_list` to inspect all \
+in-flight turns. Different chats run in parallel; multiple turns \
+within a single chat queue.
+
+## Live state and observability
+
+- `claude://chats` -- list of currently open chats with cost + turn count.
+- `claude://chats/{id}` -- one chat's full snapshot: history, \
+  budget, session_id, cumulative cost. Subscribable -- you'll get \
+  `notifications/resources/updated` when a turn settles, no polling \
+  needed.
+- `claude://metrics` -- process counters: turns_fired / done / \
+  failed / cancelled, in_flight, total_cost_usd. Same shape as \
+  `metrics_summary`.
+- `claude://config` -- sanitized server config (env values redacted \
+  on KEY/TOKEN/SECRET/PASSWORD).
+- `claude://tools` -- the registered tool surface; useful for \
+  programmatic introspection.
+
+Before firing an expensive turn, `metrics_summary` lets you check \
+cumulative spend. Open chats with `max_cost_usd` to enforce a hard \
+ceiling -- the next `chat_send` errors before touching claude if \
+the budget is exhausted.
+
+## Common error patterns
+
+- **\"no chat with id X\"** from `chat_send` / `chat_history` / \
+  `chat_budget`: the chat was closed or never opened. Check \
+  `chat_list` first if you're not sure.
+- **\"no turn with id X\"** from `turn_get` / `turn_wait`: same \
+  shape. Either the turn never existed or it was evicted by the \
+  TTL sweeper (default 1 hour after terminal). Re-fire if needed.
+- **`turn_wait` returns `{ status: \"timeout\" }`**: the turn is \
+  still running; the timeout elapsed. Poll again or cancel.
+- **Budget exceeded**: `chat_send` errors before calling claude \
+  when cumulative cost reaches `max_cost_usd`. Open a new chat or \
+  cancel the budget on this one (currently no API for the latter \
+  -- close + reopen).
+
+## What this server does NOT cover
+
+- Skills CRUD (`~/.claude/skills/`) -- planned, not yet wired
+- Agents CRUD (`~/.claude/agents/`) -- planned
+- Historical session reads from `.jsonl` -- planned (P1 on the roadmap)
+- Worktree introspection / removal -- planned
+
+For now, those surfaces live elsewhere or require direct filesystem access.
+";

--- a/crates/claude-server/src/prompts.rs
+++ b/crates/claude-server/src/prompts.rs
@@ -1,0 +1,34 @@
+//! MCP prompts: message templates clients can pull into context.
+
+use std::collections::HashMap;
+
+use tower_mcp::protocol::GetPromptResult;
+use tower_mcp::{Prompt, PromptBuilder};
+
+use crate::state::ServerState;
+
+pub(crate) fn prompts(_state: &ServerState) -> Vec<Prompt> {
+    vec![prompt_describe_server()]
+}
+
+fn prompt_describe_server() -> Prompt {
+    PromptBuilder::new("describe_server")
+        .description(
+            "Ask the recipient LLM to describe this claude-server by \
+             reading its own MCP resources. Zero args. Intended for \
+             bootstrapping a new client / coordinator.",
+        )
+        .handler(|_args: HashMap<String, String>| async move {
+            Ok(GetPromptResult::builder()
+                .description("Summarize this claude-server via its resources.")
+                .user(
+                    "Read the MCP resources `claude://config` and `claude://tools` \
+                     from this server, then summarize: what is this server, what \
+                     tools does it expose, and what is the active configuration? \
+                     Keep the summary under 200 words. Do not invoke any tools \
+                     beyond reading these resources.",
+                )
+                .build())
+        })
+        .build()
+}

--- a/crates/claude-server/src/prompts.rs
+++ b/crates/claude-server/src/prompts.rs
@@ -178,6 +178,14 @@ within a single chat queue.
   Cargo feature AND `policy.allow_mutations = true` at runtime; \
   when on, `agent_write` is upsert by default (`if_not_exists: true` \
   for create-only).
+- `claude://worktrees` (worktrees feature) -- git worktrees for \
+  the server's default repo (config.worktrees_root, then \
+  config.claude.working_dir, then process cwd). Same shape as the \
+  `worktree_list` tool, which also accepts an optional `repo_path` \
+  to target a different repo. Each entry: `path`, `head`, `branch`, \
+  `is_main`, `is_detached`, `is_bare`, `is_locked`, `is_prunable`. \
+  Useful after `chat_open(worktree=true, worktree_name=X)` to see \
+  what got spawned.
 
 Before firing an expensive turn, `metrics_summary` lets you check \
 cumulative spend. Open chats with `max_cost_usd` to enforce a hard \

--- a/crates/claude-server/src/prompts.rs
+++ b/crates/claude-server/src/prompts.rs
@@ -160,6 +160,12 @@ within a single chat queue.
   on KEY/TOKEN/SECRET/PASSWORD).
 - `claude://tools` -- the registered tool surface; useful for \
   programmatic introspection.
+- `claude://projects` (history feature) -- every project under \
+  `~/.claude/projects/` with session counts. Pair with \
+  `claude://projects/{slug}` for that project's session list and \
+  `claude://sessions/{id}` for the full parsed entry log. Same \
+  shape as the `claude_project_list` / `claude_session_list` / \
+  `claude_session_get` tools.
 
 Before firing an expensive turn, `metrics_summary` lets you check \
 cumulative spend. Open chats with `max_cost_usd` to enforce a hard \
@@ -185,7 +191,6 @@ the budget is exhausted.
 
 - Skills CRUD (`~/.claude/skills/`) -- planned, not yet wired
 - Agents CRUD (`~/.claude/agents/`) -- planned
-- Historical session reads from `.jsonl` -- planned (P1 on the roadmap)
 - Worktree introspection / removal -- planned
 
 For now, those surfaces live elsewhere or require direct filesystem access.

--- a/crates/claude-server/src/prompts.rs
+++ b/crates/claude-server/src/prompts.rs
@@ -190,6 +190,12 @@ within a single chat queue.
   `is_main`, `is_detached`, `is_bare`, `is_locked`, `is_prunable`. \
   Useful after `chat_open(worktree=true, worktree_name=X)` to see \
   what got spawned.
+- `claude://jobs` (jobs feature) -- background-job state from \
+  `~/.claude/jobs/` -- the same on-disk store the `claude agents` \
+  TUI writes to. Pair with `claude://jobs/{short_id}` for one \
+  job's full record. Same shape as the `claude_job_list` / \
+  `claude_job_get` tools. Each job carries a `session_path` -- \
+  cross-link to the `history` feature to read the full transcript.
 
 Before firing an expensive turn, `metrics_summary` lets you check \
 cumulative spend. Open chats with `max_cost_usd` to enforce a hard \

--- a/crates/claude-server/src/resources.rs
+++ b/crates/claude-server/src/resources.rs
@@ -156,14 +156,19 @@ fn resource_chats(state: &ServerState) -> Resource {
 }
 
 fn resource_config(state: &ServerState) -> Resource {
-    let cfg = state.config.clone();
+    let state = state.clone();
     ResourceBuilder::new("claude://config")
         .name("Server config")
-        .description("Sanitized view of the active ServerConfig (env values redacted).")
+        .description(
+            "Sanitized view of the active ServerConfig (env values redacted). \
+             Includes an `auth` block (env-derived strategy) and a `cli_version` \
+             block (declared tested-against range plus best-effort live status).",
+        )
         .mime_type("application/json")
         .handler(move || {
-            let cfg = cfg.clone();
+            let state = state.clone();
             async move {
+                let cfg = &state.config;
                 let env: serde_json::Map<String, serde_json::Value> = cfg
                     .claude
                     .env
@@ -171,6 +176,21 @@ fn resource_config(state: &ServerState) -> Resource {
                     .map(|(k, v)| (k.clone(), json!(redact(k, v))))
                     .collect();
                 let auth_summary = claude_wrapper::auth::detect();
+
+                // Best-effort: fetching the live CLI version spawns
+                // a subprocess. If it fails (binary missing, etc.)
+                // we still emit the declared range so callers know
+                // what we WOULD compare against.
+                let live_status = state.claude.cli_version_status().await.ok();
+                let range = state.claude.tested_cli_version_range();
+                let cli_version_block = json!({
+                    "tested_range": range.map(|(min, max)| json!({
+                        "min": min,
+                        "max": max,
+                    })),
+                    "status": live_status,
+                });
+
                 let body = json!({
                     "claude": {
                         "binary": cfg.claude.binary,
@@ -180,6 +200,7 @@ fn resource_config(state: &ServerState) -> Resource {
                         "global_args": cfg.claude.global_args,
                     },
                     "auth": auth_summary,
+                    "cli_version": cli_version_block,
                 });
                 let text = serde_json::to_string_pretty(&body).unwrap_or_default();
                 Ok(ReadResourceResult::text("claude://config", text))

--- a/crates/claude-server/src/resources.rs
+++ b/crates/claude-server/src/resources.rs
@@ -21,7 +21,37 @@ pub(crate) fn resources(state: &ServerState) -> Vec<Resource> {
         resource_config(state),
         resource_tools(state),
         resource_chats(state),
+        resource_metrics(state),
     ]
+}
+
+fn resource_metrics(state: &ServerState) -> Resource {
+    let state = state.clone();
+    ResourceBuilder::new("claude://metrics")
+        .name("Process metrics")
+        .description(
+            "Process-wide turn counters as JSON: turns_fired/done/failed/\
+             cancelled, in_flight, total_cost_usd. Same shape as the \
+             metrics_summary tool. UIs subscribe here for live dashboards.",
+        )
+        .mime_type("application/json")
+        .handler(move || {
+            let state = state.clone();
+            async move {
+                let snap = state.turns.metrics().snapshot();
+                let body = json!({
+                    "turns_fired": snap.turns_fired,
+                    "turns_done": snap.turns_done,
+                    "turns_failed": snap.turns_failed,
+                    "turns_cancelled": snap.turns_cancelled,
+                    "in_flight": snap.in_flight,
+                    "total_cost_usd": snap.total_cost_usd,
+                });
+                let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+                Ok(ReadResourceResult::text("claude://metrics", text))
+            }
+        })
+        .build()
 }
 
 /// MCP resource templates -- URI-templated resources that take

--- a/crates/claude-server/src/resources.rs
+++ b/crates/claude-server/src/resources.rs
@@ -1,0 +1,139 @@
+//! MCP resources exposed by the server.
+//!
+//! Resources are read-only state the client can fetch via
+//! `resources/list` and `resources/read`. They complement tools
+//! (which take action) and prompts (which template messages).
+//!
+//! Today: a sanitized view of the server config and a list of the
+//! registered tools. Chat resources land with the L2.5 surface.
+
+use serde_json::json;
+use tower_mcp::protocol::ReadResourceResult;
+use tower_mcp::{Resource, ResourceBuilder};
+
+use crate::state::ServerState;
+
+pub(crate) fn resources(state: &ServerState) -> Vec<Resource> {
+    vec![
+        resource_config(state),
+        resource_tools(state),
+        resource_chats(state),
+    ]
+}
+
+fn resource_chats(state: &ServerState) -> Resource {
+    let state = state.clone();
+    ResourceBuilder::new("claude://chats")
+        .name("Open chats")
+        .description("Live view of every server-held chat: id, turn count, cumulative cost.")
+        .mime_type("application/json")
+        .handler(move || {
+            let state = state.clone();
+            async move {
+                let map = state.chats.read().await;
+                let mut entries = Vec::with_capacity(map.len());
+                for (id, conv) in map.iter() {
+                    let guard = conv.lock().await;
+                    entries.push(json!({
+                        "chat_id": id,
+                        "total_turns": guard.total_turns(),
+                        "total_cost_usd": guard.total_cost_usd(),
+                        "session_id": guard.session_id(),
+                    }));
+                }
+                let text =
+                    serde_json::to_string_pretty(&json!({"chats": entries})).unwrap_or_default();
+                Ok(ReadResourceResult::text("claude://chats", text))
+            }
+        })
+        .build()
+}
+
+fn resource_config(state: &ServerState) -> Resource {
+    let cfg = state.config.clone();
+    ResourceBuilder::new("claude://config")
+        .name("Server config")
+        .description("Sanitized view of the active ServerConfig (env values redacted).")
+        .mime_type("application/json")
+        .handler(move || {
+            let cfg = cfg.clone();
+            async move {
+                let env: serde_json::Map<String, serde_json::Value> = cfg
+                    .claude
+                    .env
+                    .iter()
+                    .map(|(k, v)| (k.clone(), json!(redact(k, v))))
+                    .collect();
+                let body = json!({
+                    "claude": {
+                        "binary": cfg.claude.binary,
+                        "working_dir": cfg.claude.working_dir,
+                        "timeout_secs": cfg.claude.timeout_secs,
+                        "env": env,
+                        "global_args": cfg.claude.global_args,
+                    }
+                });
+                let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+                Ok(ReadResourceResult::text("claude://config", text))
+            }
+        })
+        .build()
+}
+
+fn resource_tools(state: &ServerState) -> Resource {
+    let cfg = state.config.clone();
+    ResourceBuilder::new("claude://tools")
+        .name("Registered tools")
+        .description("List of tools currently registered on this server.")
+        .mime_type("application/json")
+        .handler(move || {
+            let cfg = cfg.clone();
+            async move {
+                let cfg_clone = (*cfg).clone();
+                let tools = crate::registered_tools(cfg_clone)
+                    .map_err(|e| tower_mcp::Error::internal(e.to_string()))?;
+                let listed: Vec<_> = tools
+                    .into_iter()
+                    .map(|t| json!({"name": t.name, "description": t.description}))
+                    .collect();
+                let text = serde_json::to_string_pretty(&json!(listed)).unwrap_or_default();
+                Ok(ReadResourceResult::text("claude://tools", text))
+            }
+        })
+        .build()
+}
+
+/// Redact env var values for keys that look secret.
+fn redact(key: &str, value: &str) -> String {
+    let upper = key.to_ascii_uppercase();
+    if ["KEY", "TOKEN", "SECRET", "PASSWORD"]
+        .iter()
+        .any(|needle| upper.contains(needle))
+    {
+        if value.is_empty() {
+            "<unset>".to_string()
+        } else {
+            "<redacted>".to_string()
+        }
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact;
+
+    #[test]
+    fn redacts_obvious_secret_keys() {
+        assert_eq!(redact("ANTHROPIC_API_KEY", "sk-abc"), "<redacted>");
+        assert_eq!(redact("github_token", "ghp_abc"), "<redacted>");
+        assert_eq!(redact("USER_SECRET", "x"), "<redacted>");
+    }
+
+    #[test]
+    fn passes_non_secret_values_through() {
+        assert_eq!(redact("PATH", "/usr/bin"), "/usr/bin");
+        assert_eq!(redact("LANG", "en_US"), "en_US");
+    }
+}

--- a/crates/claude-server/src/resources.rs
+++ b/crates/claude-server/src/resources.rs
@@ -170,6 +170,7 @@ fn resource_config(state: &ServerState) -> Resource {
                     .iter()
                     .map(|(k, v)| (k.clone(), json!(redact(k, v))))
                     .collect();
+                let auth_summary = claude_wrapper::auth::detect();
                 let body = json!({
                     "claude": {
                         "binary": cfg.claude.binary,
@@ -177,7 +178,8 @@ fn resource_config(state: &ServerState) -> Resource {
                         "timeout_secs": cfg.claude.timeout_secs,
                         "env": env,
                         "global_args": cfg.claude.global_args,
-                    }
+                    },
+                    "auth": auth_summary,
                 });
                 let text = serde_json::to_string_pretty(&body).unwrap_or_default();
                 Ok(ReadResourceResult::text("claude://config", text))

--- a/crates/claude-server/src/resources.rs
+++ b/crates/claude-server/src/resources.rs
@@ -7,9 +7,12 @@
 //! Today: a sanitized view of the server config and a list of the
 //! registered tools. Chat resources land with the L2.5 surface.
 
+use std::collections::HashMap;
+
 use serde_json::json;
 use tower_mcp::protocol::ReadResourceResult;
-use tower_mcp::{Resource, ResourceBuilder};
+use tower_mcp::resource::ResourceTemplate;
+use tower_mcp::{Resource, ResourceBuilder, ResourceTemplateBuilder};
 
 use crate::state::ServerState;
 
@@ -19,6 +22,65 @@ pub(crate) fn resources(state: &ServerState) -> Vec<Resource> {
         resource_tools(state),
         resource_chats(state),
     ]
+}
+
+/// MCP resource templates -- URI-templated resources that take
+/// path parameters (RFC 6570 Level 1, e.g. `{id}`).
+pub(crate) fn templates(state: &ServerState) -> Vec<ResourceTemplate> {
+    vec![template_chat_detail(state)]
+}
+
+fn template_chat_detail(state: &ServerState) -> ResourceTemplate {
+    let state = state.clone();
+    ResourceTemplateBuilder::new("claude://chats/{id}")
+        .name("Chat detail")
+        .description(
+            "Per-chat snapshot keyed by chat_id: full TurnResult history, \
+             cumulative cost, session id, optional budget state. UIs subscribe \
+             here instead of polling chat_history.",
+        )
+        .mime_type("application/json")
+        .handler(move |uri: String, vars: HashMap<String, String>| {
+            let state = state.clone();
+            async move {
+                let id = vars.get("id").cloned().unwrap_or_default();
+                let conv = state
+                    .get_chat(&id)
+                    .await
+                    .ok_or_else(|| tower_mcp::Error::internal(format!("no chat with id `{id}`")))?;
+                let guard = conv.lock().await;
+                let turns: Vec<_> = guard
+                    .history()
+                    .iter()
+                    .map(|t| {
+                        json!({
+                            "result": t.result_text(),
+                            "session_id": t.session_id(),
+                            "cost_usd": t.total_cost_usd(),
+                            "duration_ms": t.duration_ms(),
+                        })
+                    })
+                    .collect();
+                let budget = guard.budget().map(|b| {
+                    json!({
+                        "total_usd": b.total_usd(),
+                        "max_usd": b.max_usd(),
+                        "remaining_usd": b.remaining_usd(),
+                        "warn_at_usd": b.warn_at_usd(),
+                    })
+                });
+                let body = json!({
+                    "chat_id": id,
+                    "session_id": guard.session_id(),
+                    "total_turns": guard.total_turns(),
+                    "total_cost_usd": guard.total_cost_usd(),
+                    "budget": budget,
+                    "turns": turns,
+                });
+                let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+                Ok(ReadResourceResult::text(uri, text))
+            }
+        })
 }
 
 fn resource_chats(state: &ServerState) -> Resource {

--- a/crates/claude-server/src/resources.rs
+++ b/crates/claude-server/src/resources.rs
@@ -7,24 +7,29 @@
 //! Today: a sanitized view of the server config and a list of the
 //! registered tools. Chat resources land with the L2.5 surface.
 
+#[cfg(feature = "chat")]
 use std::collections::HashMap;
 
 use serde_json::json;
+#[cfg(feature = "chat")]
+use tower_mcp::ResourceTemplateBuilder;
 use tower_mcp::protocol::ReadResourceResult;
 use tower_mcp::resource::ResourceTemplate;
-use tower_mcp::{Resource, ResourceBuilder, ResourceTemplateBuilder};
+use tower_mcp::{Resource, ResourceBuilder};
 
 use crate::state::ServerState;
 
 pub(crate) fn resources(state: &ServerState) -> Vec<Resource> {
-    vec![
-        resource_config(state),
-        resource_tools(state),
-        resource_chats(state),
-        resource_metrics(state),
-    ]
+    #[cfg_attr(not(any(feature = "chat", feature = "metrics")), allow(unused_mut))]
+    let mut out = vec![resource_config(state), resource_tools(state)];
+    #[cfg(feature = "chat")]
+    out.push(resource_chats(state));
+    #[cfg(feature = "metrics")]
+    out.push(resource_metrics(state));
+    out
 }
 
+#[cfg(feature = "metrics")]
 fn resource_metrics(state: &ServerState) -> Resource {
     let state = state.clone();
     ResourceBuilder::new("claude://metrics")
@@ -56,10 +61,18 @@ fn resource_metrics(state: &ServerState) -> Resource {
 
 /// MCP resource templates -- URI-templated resources that take
 /// path parameters (RFC 6570 Level 1, e.g. `{id}`).
-pub(crate) fn templates(state: &ServerState) -> Vec<ResourceTemplate> {
-    vec![template_chat_detail(state)]
+pub(crate) fn templates(_state: &ServerState) -> Vec<ResourceTemplate> {
+    #[cfg(feature = "chat")]
+    {
+        vec![template_chat_detail(_state)]
+    }
+    #[cfg(not(feature = "chat"))]
+    {
+        Vec::new()
+    }
 }
 
+#[cfg(feature = "chat")]
 fn template_chat_detail(state: &ServerState) -> ResourceTemplate {
     let state = state.clone();
     ResourceTemplateBuilder::new("claude://chats/{id}")
@@ -113,6 +126,7 @@ fn template_chat_detail(state: &ServerState) -> ResourceTemplate {
         })
 }
 
+#[cfg(feature = "chat")]
 fn resource_chats(state: &ServerState) -> Resource {
     let state = state.clone();
     ResourceBuilder::new("claude://chats")

--- a/crates/claude-server/src/resources.rs
+++ b/crates/claude-server/src/resources.rs
@@ -161,8 +161,9 @@ fn resource_config(state: &ServerState) -> Resource {
         .name("Server config")
         .description(
             "Sanitized view of the active ServerConfig (env values redacted). \
-             Includes an `auth` block (env-derived strategy) and a `cli_version` \
-             block (declared tested-against range plus best-effort live status).",
+             Includes an `auth` block (env-derived strategy), a `cli_version` \
+             block (declared tested-against range plus best-effort live status), \
+             and a `policy` block (effective mutation gate).",
         )
         .mime_type("application/json")
         .handler(move || {
@@ -191,6 +192,16 @@ fn resource_config(state: &ServerState) -> Resource {
                     "status": live_status,
                 });
 
+                // Compile-time vs runtime mutation gate. Surfaced so
+                // operators can answer "is this server allowed to
+                // mutate?" from the config resource alone.
+                let mutations_compiled_in = cfg!(feature = "mutations");
+                let policy_block = json!({
+                    "allow_mutations": cfg.policy.allow_mutations,
+                    "mutations_feature_compiled_in": mutations_compiled_in,
+                    "mutations_effective": mutations_compiled_in && cfg.policy.allow_mutations,
+                });
+
                 let body = json!({
                     "claude": {
                         "binary": cfg.claude.binary,
@@ -201,6 +212,7 @@ fn resource_config(state: &ServerState) -> Resource {
                     },
                     "auth": auth_summary,
                     "cli_version": cli_version_block,
+                    "policy": policy_block,
                 });
                 let text = serde_json::to_string_pretty(&body).unwrap_or_default();
                 Ok(ReadResourceResult::text("claude://config", text))

--- a/crates/claude-server/src/resources.rs
+++ b/crates/claude-server/src/resources.rs
@@ -202,6 +202,56 @@ fn resource_config(state: &ServerState) -> Resource {
                     "mutations_effective": mutations_compiled_in && cfg.policy.allow_mutations,
                 });
 
+                // Per-surface effective gates -- combine the
+                // compile-time feature with the runtime config flag
+                // so operators can see at a glance what's actually
+                // exposed.
+                let surfaces_block = json!({
+                    "core": {
+                        "compiled_in": cfg!(feature = "core"),
+                        "enabled": cfg.surfaces.enable_core,
+                        "effective": cfg!(feature = "core") && cfg.surfaces.enable_core,
+                    },
+                    "chat": {
+                        "compiled_in": cfg!(feature = "chat"),
+                        "enabled": cfg.surfaces.enable_chat,
+                        "effective": cfg!(feature = "chat") && cfg.surfaces.enable_chat,
+                    },
+                    "metrics": {
+                        "compiled_in": cfg!(feature = "metrics"),
+                        "enabled": cfg.surfaces.enable_metrics,
+                        "effective": cfg!(feature = "metrics") && cfg.surfaces.enable_metrics,
+                    },
+                    "mutations": {
+                        "compiled_in": cfg!(feature = "mutations"),
+                        "enabled": cfg.surfaces.enable_mutations,
+                        // mutations is triple-gated (Cargo + surfaces + policy)
+                        "effective": cfg!(feature = "mutations")
+                            && cfg.surfaces.enable_mutations
+                            && cfg.policy.allow_mutations,
+                    },
+                    "history": {
+                        "compiled_in": cfg!(feature = "history"),
+                        "enabled": cfg.surfaces.enable_history,
+                        "effective": cfg!(feature = "history") && cfg.surfaces.enable_history,
+                    },
+                    "artifacts": {
+                        "compiled_in": cfg!(feature = "artifacts"),
+                        "enabled": cfg.surfaces.enable_artifacts,
+                        "effective": cfg!(feature = "artifacts") && cfg.surfaces.enable_artifacts,
+                    },
+                    "worktrees": {
+                        "compiled_in": cfg!(feature = "worktrees"),
+                        "enabled": cfg.surfaces.enable_worktrees,
+                        "effective": cfg!(feature = "worktrees") && cfg.surfaces.enable_worktrees,
+                    },
+                    "jobs": {
+                        "compiled_in": cfg!(feature = "jobs"),
+                        "enabled": cfg.surfaces.enable_jobs,
+                        "effective": cfg!(feature = "jobs") && cfg.surfaces.enable_jobs,
+                    },
+                });
+
                 let body = json!({
                     "claude": {
                         "binary": cfg.claude.binary,
@@ -213,6 +263,7 @@ fn resource_config(state: &ServerState) -> Resource {
                     "auth": auth_summary,
                     "cli_version": cli_version_block,
                     "policy": policy_block,
+                    "surfaces": surfaces_block,
                 });
                 let text = serde_json::to_string_pretty(&body).unwrap_or_default();
                 Ok(ReadResourceResult::text("claude://config", text))

--- a/crates/claude-server/src/state.rs
+++ b/crates/claude-server/src/state.rs
@@ -15,6 +15,7 @@ use claude_wrapper::Claude;
 use claude_wrapper::conversation::Conversation;
 
 use crate::config::ServerConfig;
+use crate::turns::TurnRegistry;
 
 /// Opaque identifier for a server-held chat.
 pub type ChatId = String;
@@ -25,6 +26,10 @@ pub struct ServerState {
     pub claude: Arc<Claude>,
     pub config: Arc<ServerConfig>,
     pub chats: Arc<RwLock<HashMap<ChatId, Arc<Mutex<Conversation>>>>>,
+    /// Async-turn registry. Bare-named `chat_send` / `claude_query`
+    /// fire a turn into the background and register a handle here;
+    /// `turn_get` / `turn_wait` / `turn_cancel` operate on it.
+    pub turns: Arc<TurnRegistry>,
 }
 
 impl ServerState {
@@ -33,6 +38,7 @@ impl ServerState {
             claude,
             config,
             chats: Arc::new(RwLock::new(HashMap::new())),
+            turns: Arc::new(TurnRegistry::new()),
         }
     }
 

--- a/crates/claude-server/src/state.rs
+++ b/crates/claude-server/src/state.rs
@@ -1,0 +1,93 @@
+//! Shared server state.
+//!
+//! Lives inside tool handler closures so they can reach the
+//! [`Claude`] client, the active [`ServerConfig`], and the registry
+//! of open chats.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::sync::{Mutex, RwLock};
+
+use claude_wrapper::Claude;
+use claude_wrapper::conversation::Conversation;
+
+use crate::config::ServerConfig;
+
+/// Opaque identifier for a server-held chat.
+pub type ChatId = String;
+
+/// State shared by every tool handler.
+#[derive(Clone)]
+pub struct ServerState {
+    pub claude: Arc<Claude>,
+    pub config: Arc<ServerConfig>,
+    pub chats: Arc<RwLock<HashMap<ChatId, Arc<Mutex<Conversation>>>>>,
+}
+
+impl ServerState {
+    pub fn new(claude: Arc<Claude>, config: Arc<ServerConfig>) -> Self {
+        Self {
+            claude,
+            config,
+            chats: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Insert a chat and return its id.
+    pub async fn insert_chat(&self, conv: Conversation) -> ChatId {
+        let id = new_chat_id();
+        self.chats
+            .write()
+            .await
+            .insert(id.clone(), Arc::new(Mutex::new(conv)));
+        id
+    }
+
+    /// Look up a chat by id without removing it. Returns the handle
+    /// so the caller can lock it for the duration of a turn.
+    pub async fn get_chat(&self, id: &str) -> Option<Arc<Mutex<Conversation>>> {
+        self.chats.read().await.get(id).cloned()
+    }
+
+    /// Remove a chat from the registry. Returns the handle if it
+    /// existed, leaving close-and-drop to the caller.
+    pub async fn remove_chat(&self, id: &str) -> Option<Arc<Mutex<Conversation>>> {
+        self.chats.write().await.remove(id)
+    }
+}
+
+/// Generate a fresh chat id. Combines microseconds-since-epoch with a
+/// monotonic counter to dodge same-microsecond collisions; not a
+/// security boundary, just a unique handle.
+pub fn new_chat_id() -> ChatId {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let t = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros())
+        .unwrap_or(0);
+    format!("chat_{t:x}_{n:x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::new_chat_id;
+
+    #[test]
+    fn ids_are_unique_across_calls() {
+        let a = new_chat_id();
+        let b = new_chat_id();
+        let c = new_chat_id();
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn ids_have_chat_prefix() {
+        assert!(new_chat_id().starts_with("chat_"));
+    }
+}

--- a/crates/claude-server/src/state.rs
+++ b/crates/claude-server/src/state.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::sync::{Mutex, RwLock};
+use tower_mcp::context::{NotificationSender, ServerNotification};
 
 use claude_wrapper::Claude;
 use claude_wrapper::conversation::Conversation;
@@ -30,6 +31,12 @@ pub struct ServerState {
     /// fire a turn into the background and register a handle here;
     /// `turn_get` / `turn_wait` / `turn_cancel` operate on it.
     pub turns: Arc<TurnRegistry>,
+    /// Optional notification sender. Set when the server is built
+    /// via [`crate::build_router_with_notification_sender`] so chat
+    /// workers can fire `notifications/resources/updated` for
+    /// `claude://chats/{id}` after a turn settles. None means
+    /// notifications no-op (the legacy `build_router` path).
+    pub notifier: Option<NotificationSender>,
 }
 
 impl ServerState {
@@ -39,7 +46,32 @@ impl ServerState {
             config,
             chats: Arc::new(RwLock::new(HashMap::new())),
             turns: Arc::new(TurnRegistry::new()),
+            notifier: None,
         }
+    }
+
+    /// Construct with an attached notification sender. Workers will
+    /// fire `notifications/resources/updated` events through this
+    /// channel; the corresponding receiver feeds the transport.
+    pub fn with_notifier(mut self, notifier: NotificationSender) -> Self {
+        self.notifier = Some(notifier);
+        self
+    }
+
+    /// Fire a `notifications/resources/updated` for `uri` if a
+    /// notifier is attached. Best-effort -- a full channel or
+    /// missing notifier is a silent no-op.
+    pub fn notify_resource_updated(&self, uri: impl Into<String>) {
+        let Some(tx) = &self.notifier else { return };
+        let _ = tx.try_send(ServerNotification::ResourceUpdated { uri: uri.into() });
+    }
+
+    /// Fire `notifications/resources/list_changed`. Best-effort.
+    /// Used when a chat opens or closes -- the `claude://chats` list
+    /// resource shape changed.
+    pub fn notify_resources_list_changed(&self) {
+        let Some(tx) = &self.notifier else { return };
+        let _ = tx.try_send(ServerNotification::ResourcesListChanged);
     }
 
     /// Insert a chat and return its id.

--- a/crates/claude-server/src/turn_tools.rs
+++ b/crates/claude-server/src/turn_tools.rs
@@ -20,20 +20,25 @@ use crate::state::ServerState;
 use crate::turns::TurnSnapshot;
 
 pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
-    vec![
+    #[cfg_attr(not(feature = "metrics"), allow(unused_mut))]
+    let mut out = vec![
         tool_turn_get(state),
         tool_turn_wait(state),
         tool_turn_cancel(state),
         tool_turn_list(state),
-        tool_metrics_summary(state),
-    ]
+    ];
+    #[cfg(feature = "metrics")]
+    out.push(tool_metrics_summary(state));
+    out
 }
 
 // -- metrics_summary -------------------------------------------------
 
+#[cfg(feature = "metrics")]
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 struct NoArgs {}
 
+#[cfg(feature = "metrics")]
 fn tool_metrics_summary(state: &ServerState) -> Tool {
     let state = state.clone();
     ToolBuilder::new("metrics_summary")

--- a/crates/claude-server/src/turn_tools.rs
+++ b/crates/claude-server/src/turn_tools.rs
@@ -25,7 +25,40 @@ pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
         tool_turn_wait(state),
         tool_turn_cancel(state),
         tool_turn_list(state),
+        tool_metrics_summary(state),
     ]
+}
+
+// -- metrics_summary -------------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct NoArgs {}
+
+fn tool_metrics_summary(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("metrics_summary")
+        .description(
+            "Snapshot of process-wide turn counters: turns_fired / done / \
+             failed / cancelled, in_flight, total_cost_usd. Lets a \
+             coordinator agent introspect its own spend mid-run -- \
+             \"before I fire another turn, how much have I spent?\"",
+        )
+        .read_only()
+        .handler(move |_input: NoArgs| {
+            let state = state.clone();
+            async move {
+                let snap = state.turns.metrics().snapshot();
+                Ok(CallToolResult::json(json!({
+                    "turns_fired": snap.turns_fired,
+                    "turns_done": snap.turns_done,
+                    "turns_failed": snap.turns_failed,
+                    "turns_cancelled": snap.turns_cancelled,
+                    "in_flight": snap.in_flight,
+                    "total_cost_usd": snap.total_cost_usd,
+                })))
+            }
+        })
+        .build()
 }
 
 // -- turn_get --------------------------------------------------------

--- a/crates/claude-server/src/turn_tools.rs
+++ b/crates/claude-server/src/turn_tools.rs
@@ -1,0 +1,180 @@
+//! MCP tools that drive the async turn registry.
+//!
+//! Fire a turn with `chat_send` (or `claude_query` once step 5
+//! lands), get a `turn_id`, then use these to inspect, wait, cancel,
+//! or list:
+//!
+//! - `turn_get(turn_id)` -- non-blocking status snapshot
+//! - `turn_wait(turn_id, timeout_secs?)` -- block until terminal
+//!   (or timeout; turn keeps running on timeout)
+//! - `turn_cancel(turn_id)` -- cooperative cancel (flips a flag;
+//!   the worker observes and short-circuits)
+//! - `turn_list(chat_id?)` -- enumerate, optional chat filter
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+
+use crate::state::ServerState;
+use crate::turns::TurnSnapshot;
+
+pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
+    vec![
+        tool_turn_get(state),
+        tool_turn_wait(state),
+        tool_turn_cancel(state),
+        tool_turn_list(state),
+    ]
+}
+
+// -- turn_get --------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct TurnIdInput {
+    /// Identifier returned by `chat_send` / `claude_query`.
+    turn_id: String,
+}
+
+fn tool_turn_get(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("turn_get")
+        .description(
+            "Non-blocking snapshot of an async turn. Returns the turn's \
+             current status (running / done / failed / cancelled), plus \
+             the JSON result on `done` or the error string on `failed`. \
+             Errors if the turn_id is unknown.",
+        )
+        .read_only()
+        .handler(move |input: TurnIdInput| {
+            let state = state.clone();
+            async move {
+                match state.turns.get(&input.turn_id).await {
+                    Some(snap) => Ok(CallToolResult::json(snapshot_to_json(&snap))),
+                    None => Err(unknown_turn(&input.turn_id)),
+                }
+            }
+        })
+        .build()
+}
+
+// -- turn_wait -------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct TurnWaitInput {
+    /// Identifier returned by `chat_send` / `claude_query`.
+    turn_id: String,
+    /// Optional timeout in seconds. If the turn doesn't settle in
+    /// this window, returns `{ status: "timeout", turn_id }` with
+    /// the turn still running. Omit to wait indefinitely (request
+    /// connection stays open).
+    #[serde(default)]
+    timeout_secs: Option<f64>,
+}
+
+fn tool_turn_wait(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("turn_wait")
+        .description(
+            "Block until an async turn reaches a terminal status, or until \
+             the optional timeout_secs elapses. On settle: returns the same \
+             shape as turn_get. On timeout: returns `{ status: \"timeout\", \
+             turn_id }` and the turn keeps running -- callers can poll again \
+             or cancel.",
+        )
+        .handler(move |input: TurnWaitInput| {
+            let state = state.clone();
+            async move {
+                let timeout = input.timeout_secs.map(std::time::Duration::from_secs_f64);
+                match state.turns.wait(&input.turn_id, timeout).await {
+                    Ok(Some(snap)) => Ok(CallToolResult::json(snapshot_to_json(&snap))),
+                    Ok(None) => Ok(CallToolResult::json(json!({
+                        "turn_id": input.turn_id,
+                        "status": "timeout",
+                    }))),
+                    Err(_) => Err(unknown_turn(&input.turn_id)),
+                }
+            }
+        })
+        .build()
+}
+
+// -- turn_cancel -----------------------------------------------------
+
+fn tool_turn_cancel(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("turn_cancel")
+        .description(
+            "Request cancellation of an async turn. This flips a cooperative \
+             flag the worker checks between awaits; an already-in-flight \
+             claude turn is not interrupted by this alone (use chat_interrupt \
+             at the chat level for that). Returns `{ ok: true, existed }`.",
+        )
+        .handler(move |input: TurnIdInput| {
+            let state = state.clone();
+            async move {
+                let existed = state.turns.cancel(&input.turn_id).await;
+                Ok(CallToolResult::json(json!({
+                    "ok": true,
+                    "existed": existed,
+                    "turn_id": input.turn_id,
+                })))
+            }
+        })
+        .build()
+}
+
+// -- turn_list -------------------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct TurnListInput {
+    /// Optional chat filter; omit for all turns across all chats
+    /// plus single-shot (no chat_id) turns.
+    #[serde(default)]
+    chat_id: Option<String>,
+}
+
+fn tool_turn_list(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("turn_list")
+        .description(
+            "Enumerate registered turns -- running and recently-terminal. \
+             Optional `chat_id` filters to one chat. Each entry has the same \
+             shape as turn_get.",
+        )
+        .read_only()
+        .handler(move |input: TurnListInput| {
+            let state = state.clone();
+            async move {
+                let snaps = state.turns.list(input.chat_id.as_deref()).await;
+                let body: Vec<Value> = snaps.iter().map(snapshot_to_json).collect();
+                Ok(CallToolResult::json(json!({"turns": body})))
+            }
+        })
+        .build()
+}
+
+// -- helpers --------------------------------------------------------
+
+fn snapshot_to_json(snap: &TurnSnapshot) -> Value {
+    // Hand-rolled rather than serde_json::to_value(snap) so the
+    // wire shape stays an explicit thing we can change in one place.
+    json!({
+        "turn_id": snap.turn_id,
+        "chat_id": snap.chat_id,
+        "status": match snap.status {
+            crate::turns::TurnStatus::Running => "running",
+            crate::turns::TurnStatus::Done => "done",
+            crate::turns::TurnStatus::Failed => "failed",
+            crate::turns::TurnStatus::Cancelled => "cancelled",
+        },
+        "started_at_us": snap.started_at_us,
+        "finished_at_us": snap.finished_at_us,
+        "result": snap.result,
+        "error": snap.error,
+    })
+}
+
+fn unknown_turn(turn_id: &str) -> tower_mcp::Error {
+    tower_mcp::Error::internal(format!("no turn with id `{turn_id}`"))
+}

--- a/crates/claude-server/src/turns.rs
+++ b/crates/claude-server/src/turns.rs
@@ -1,0 +1,378 @@
+//! Turn registry: tracks in-flight and recently-completed agent
+//! turns by stable [`TurnId`].
+//!
+//! Async-by-default agent tools (the bare-named `chat_send` /
+//! `claude_query` introduced in steps 3 and 5) fire a turn into the
+//! background and immediately return a [`TurnId`]. Callers poll
+//! status with `turn_get`, block on completion with `turn_wait`, or
+//! cancel with `turn_cancel`. Sync variants (`*_sync`) bypass this
+//! registry entirely -- they hold the request connection open.
+//!
+//! Internally each entry holds a [`tokio::sync::watch::Sender`]
+//! whose value is the latest [`TurnSnapshot`]. Workers update by
+//! sending a new snapshot; waiters subscribe to the receiver and
+//! `wait_for(terminal)`. Cancellation is a separate cooperative
+//! flag (an `AtomicBool`) so the worker can check between awaits.
+//!
+//! TTL eviction is a separate concern (step 6); for now the
+//! registry grows monotonically until `cancel_turn` / process exit.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::{RwLock, watch};
+
+use crate::state::ChatId;
+
+/// Opaque identifier for an async turn. Format: `turn_<hex>_<counter>`.
+pub type TurnId = String;
+
+/// Lifecycle states for a turn. Three terminal: [`Done`], [`Failed`],
+/// [`Cancelled`].
+///
+/// [`Done`]: TurnStatus::Done
+/// [`Failed`]: TurnStatus::Failed
+/// [`Cancelled`]: TurnStatus::Cancelled
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStatus {
+    Running,
+    Done,
+    Failed,
+    Cancelled,
+}
+
+impl TurnStatus {
+    /// True when no further transitions are expected.
+    pub fn is_terminal(self) -> bool {
+        !matches!(self, TurnStatus::Running)
+    }
+}
+
+/// Point-in-time view of a turn. Cloneable so multiple waiters can
+/// hold copies.
+#[derive(Debug, Clone, Serialize)]
+pub struct TurnSnapshot {
+    pub turn_id: TurnId,
+    /// The chat that owns this turn, when the turn was fired from
+    /// the chat surface. None for single-shot turns (`claude_query`).
+    pub chat_id: Option<ChatId>,
+    pub status: TurnStatus,
+    /// Unix-epoch microseconds when the turn was registered.
+    pub started_at_us: u128,
+    /// Unix-epoch microseconds when the turn reached a terminal
+    /// status. None while running.
+    pub finished_at_us: Option<u128>,
+    /// On `Done`, the JSON envelope produced by the worker (matches
+    /// the shape `chat_send_sync` / `claude_query_sync` returns).
+    pub result: Option<Value>,
+    /// On `Failed`, the worker's `Display`'d error.
+    pub error: Option<String>,
+}
+
+/// Handle returned by [`TurnRegistry::register`] to the worker that
+/// will run the turn. Drop semantics intentionally permissive: if
+/// the worker panics or exits without calling `complete` / `fail`,
+/// the turn stays in `Running` until something else cleans it up.
+/// (Step 6's TTL sweeper will handle that case.)
+pub struct TurnHandle {
+    pub turn_id: TurnId,
+    pub cancel: Arc<AtomicBool>,
+    snapshot_tx: watch::Sender<TurnSnapshot>,
+}
+
+impl TurnHandle {
+    /// True if a cancel was requested via [`TurnRegistry::cancel`].
+    /// Workers should check this between awaits and short-circuit
+    /// out via [`TurnHandle::cancelled`] if set.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.load(Ordering::SeqCst)
+    }
+
+    /// Publish a Done terminal state with the worker's JSON result.
+    pub fn complete(self, result: Value) {
+        let mut snap = self.snapshot_tx.borrow().clone();
+        snap.status = TurnStatus::Done;
+        snap.finished_at_us = Some(now_us());
+        snap.result = Some(result);
+        let _ = self.snapshot_tx.send(snap);
+    }
+
+    /// Publish a Failed terminal state.
+    pub fn fail(self, error: impl std::fmt::Display) {
+        let mut snap = self.snapshot_tx.borrow().clone();
+        snap.status = TurnStatus::Failed;
+        snap.finished_at_us = Some(now_us());
+        snap.error = Some(error.to_string());
+        let _ = self.snapshot_tx.send(snap);
+    }
+
+    /// Publish a Cancelled terminal state. Workers call this when
+    /// they observe `is_cancelled()` and short-circuit out.
+    pub fn cancelled(self) {
+        let mut snap = self.snapshot_tx.borrow().clone();
+        snap.status = TurnStatus::Cancelled;
+        snap.finished_at_us = Some(now_us());
+        let _ = self.snapshot_tx.send(snap);
+    }
+}
+
+struct TurnEntry {
+    snapshot_rx: watch::Receiver<TurnSnapshot>,
+    cancel: Arc<AtomicBool>,
+}
+
+/// Concurrent map from [`TurnId`] to live + terminal turns.
+///
+/// Designed around the small handful of operations the tools need:
+/// [`Self::register`] (fire), [`Self::get`] (poll),
+/// [`Self::wait`] (block), [`Self::cancel`] (cooperative),
+/// [`Self::list`] (enumerate).
+#[derive(Default)]
+pub struct TurnRegistry {
+    entries: RwLock<HashMap<TurnId, TurnEntry>>,
+}
+
+impl TurnRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a fresh turn. Returns a worker-side [`TurnHandle`]
+    /// the caller must move into the spawned task -- the handle's
+    /// terminal methods (complete / fail / cancelled) publish the
+    /// final snapshot.
+    pub async fn register(&self, chat_id: Option<ChatId>) -> TurnHandle {
+        let turn_id = new_turn_id();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let snapshot = TurnSnapshot {
+            turn_id: turn_id.clone(),
+            chat_id,
+            status: TurnStatus::Running,
+            started_at_us: now_us(),
+            finished_at_us: None,
+            result: None,
+            error: None,
+        };
+        let (tx, rx) = watch::channel(snapshot);
+        self.entries.write().await.insert(
+            turn_id.clone(),
+            TurnEntry {
+                snapshot_rx: rx,
+                cancel: cancel.clone(),
+            },
+        );
+        TurnHandle {
+            turn_id,
+            cancel,
+            snapshot_tx: tx,
+        }
+    }
+
+    /// Non-blocking snapshot read. Returns None for unknown ids.
+    pub async fn get(&self, id: &str) -> Option<TurnSnapshot> {
+        let entries = self.entries.read().await;
+        entries.get(id).map(|e| e.snapshot_rx.borrow().clone())
+    }
+
+    /// Block until the turn reaches a terminal status, or until the
+    /// optional timeout elapses. Returns:
+    /// - `Ok(Some(snapshot))` -- turn settled, returns the terminal snapshot
+    /// - `Ok(None)`           -- timeout elapsed; turn still running
+    /// - `Err(...)`           -- unknown turn id
+    pub async fn wait(
+        &self,
+        id: &str,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<Option<TurnSnapshot>, UnknownTurn> {
+        let mut rx = {
+            let entries = self.entries.read().await;
+            let entry = entries.get(id).ok_or_else(|| UnknownTurn(id.to_string()))?;
+            entry.snapshot_rx.clone()
+        };
+        // Fast path: already terminal.
+        if rx.borrow().status.is_terminal() {
+            return Ok(Some(rx.borrow().clone()));
+        }
+        let fut = async {
+            // wait_for returns once the predicate returns true OR the
+            // sender is dropped. We treat sender-drop as "still running",
+            // which becomes a stale entry that the TTL sweeper handles.
+            let _ = rx.wait_for(|s| s.status.is_terminal()).await;
+            rx.borrow().clone()
+        };
+        match timeout {
+            Some(d) => match tokio::time::timeout(d, fut).await {
+                Ok(snap) => Ok(Some(snap)),
+                Err(_) => Ok(None),
+            },
+            None => Ok(Some(fut.await)),
+        }
+    }
+
+    /// Signal cancellation. The worker is responsible for checking
+    /// [`TurnHandle::is_cancelled`] and short-circuiting out; this
+    /// method only flips the flag.
+    pub async fn cancel(&self, id: &str) -> bool {
+        let entries = self.entries.read().await;
+        match entries.get(id) {
+            Some(e) => {
+                e.cancel.store(true, Ordering::SeqCst);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// List snapshots, optionally filtered to one chat.
+    pub async fn list(&self, chat_id: Option<&str>) -> Vec<TurnSnapshot> {
+        let entries = self.entries.read().await;
+        entries
+            .values()
+            .map(|e| e.snapshot_rx.borrow().clone())
+            .filter(|s| match chat_id {
+                Some(want) => s.chat_id.as_deref() == Some(want),
+                None => true,
+            })
+            .collect()
+    }
+}
+
+/// Error type when a turn id is not present in the registry.
+#[derive(Debug, Clone)]
+pub struct UnknownTurn(pub String);
+
+impl std::fmt::Display for UnknownTurn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "no turn with id `{}`", self.0)
+    }
+}
+
+impl std::error::Error for UnknownTurn {}
+
+fn new_turn_id() -> TurnId {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let t = now_us();
+    format!("turn_{t:x}_{n:x}")
+}
+
+fn now_us() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn register_assigns_running_turn_id() {
+        let r = TurnRegistry::new();
+        let h = r.register(None).await;
+        assert!(h.turn_id.starts_with("turn_"));
+        let snap = r.get(&h.turn_id).await.expect("found");
+        assert_eq!(snap.status, TurnStatus::Running);
+        assert!(snap.finished_at_us.is_none());
+    }
+
+    #[tokio::test]
+    async fn complete_transitions_to_done_with_result() {
+        let r = TurnRegistry::new();
+        let h = r.register(Some("chat_x".into())).await;
+        let id = h.turn_id.clone();
+        h.complete(serde_json::json!({"result": "ok"}));
+        let snap = r.get(&id).await.expect("found");
+        assert_eq!(snap.status, TurnStatus::Done);
+        assert_eq!(snap.chat_id.as_deref(), Some("chat_x"));
+        assert_eq!(snap.result, Some(serde_json::json!({"result": "ok"})));
+        assert!(snap.finished_at_us.is_some());
+    }
+
+    #[tokio::test]
+    async fn wait_returns_immediately_when_already_terminal() {
+        let r = TurnRegistry::new();
+        let h = r.register(None).await;
+        let id = h.turn_id.clone();
+        h.complete(serde_json::json!(null));
+        let snap = r
+            .wait(&id, Some(Duration::from_millis(1)))
+            .await
+            .expect("ok")
+            .expect("terminal");
+        assert_eq!(snap.status, TurnStatus::Done);
+    }
+
+    #[tokio::test]
+    async fn wait_blocks_until_complete() {
+        let r = Arc::new(TurnRegistry::new());
+        let h = r.register(None).await;
+        let id = h.turn_id.clone();
+        let r2 = r.clone();
+        let waiter = tokio::spawn(async move {
+            r2.wait(&id, None).await.expect("ok").expect("terminal")
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        h.complete(serde_json::json!({"x": 1}));
+        let snap = waiter.await.expect("joined");
+        assert_eq!(snap.status, TurnStatus::Done);
+        assert_eq!(snap.result, Some(serde_json::json!({"x": 1})));
+    }
+
+    #[tokio::test]
+    async fn wait_with_timeout_returns_none_on_timeout() {
+        let r = TurnRegistry::new();
+        let h = r.register(None).await;
+        let res = r
+            .wait(&h.turn_id, Some(Duration::from_millis(10)))
+            .await
+            .expect("ok");
+        assert!(res.is_none(), "expected timeout to yield None");
+    }
+
+    #[tokio::test]
+    async fn cancel_sets_flag_visible_to_handle() {
+        let r = TurnRegistry::new();
+        let h = r.register(None).await;
+        let id = h.turn_id.clone();
+        assert!(!h.is_cancelled());
+        assert!(r.cancel(&id).await);
+        assert!(h.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancel_unknown_id_returns_false() {
+        let r = TurnRegistry::new();
+        assert!(!r.cancel("turn_nope").await);
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_chat_id() {
+        let r = TurnRegistry::new();
+        let _h1 = r.register(Some("chat_a".into())).await;
+        let _h2 = r.register(Some("chat_b".into())).await;
+        let _h3 = r.register(None).await;
+        let all = r.list(None).await;
+        assert_eq!(all.len(), 3);
+        let a = r.list(Some("chat_a")).await;
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].chat_id.as_deref(), Some("chat_a"));
+    }
+
+    #[test]
+    fn ids_are_unique() {
+        let a = new_turn_id();
+        let b = new_turn_id();
+        let c = new_turn_id();
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert!(a.starts_with("turn_"));
+    }
+}

--- a/crates/claude-server/src/turns.rs
+++ b/crates/claude-server/src/turns.rs
@@ -228,6 +228,52 @@ impl TurnRegistry {
         }
     }
 
+    /// Evict terminal-status entries whose `finished_at_us` is older
+    /// than `ttl`. Running entries are never evicted. Returns the
+    /// number of entries removed.
+    ///
+    /// Designed to be called periodically by [`Self::spawn_sweeper`].
+    /// Tests can call directly with a small ttl to verify behavior.
+    pub async fn evict_expired(&self, ttl: std::time::Duration) -> usize {
+        let cutoff = now_us().saturating_sub(ttl.as_micros());
+        let mut entries = self.entries.write().await;
+        let before = entries.len();
+        entries.retain(|_, e| {
+            let snap = e.snapshot_rx.borrow();
+            if !snap.status.is_terminal() {
+                return true; // keep all running
+            }
+            match snap.finished_at_us {
+                Some(t) => t > cutoff, // keep if newer than cutoff
+                None => true,          // weird state; keep
+            }
+        });
+        before - entries.len()
+    }
+
+    /// Spawn a background tokio task that calls
+    /// [`Self::evict_expired`] every `interval` until the registry is
+    /// dropped. Returns the [`tokio::task::JoinHandle`] in case the
+    /// caller wants to abort it during shutdown.
+    pub fn spawn_sweeper(
+        self: Arc<Self>,
+        ttl: std::time::Duration,
+        interval: std::time::Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(interval);
+            // Skip the immediate firing; first eviction happens after `interval`.
+            tick.tick().await;
+            loop {
+                tick.tick().await;
+                let n = self.evict_expired(ttl).await;
+                if n > 0 {
+                    tracing::debug!(evicted = n, "turn registry sweeper");
+                }
+            }
+        })
+    }
+
     /// List snapshots, optionally filtered to one chat.
     pub async fn list(&self, chat_id: Option<&str>) -> Vec<TurnSnapshot> {
         let entries = self.entries.read().await;
@@ -363,6 +409,45 @@ mod tests {
         let a = r.list(Some("chat_a")).await;
         assert_eq!(a.len(), 1);
         assert_eq!(a[0].chat_id.as_deref(), Some("chat_a"));
+    }
+
+    #[tokio::test]
+    async fn evict_expired_keeps_running_drops_old_terminal() {
+        let r = TurnRegistry::new();
+        let still_running = r.register(None).await;
+        let h_done = r.register(None).await;
+        h_done.complete(serde_json::json!(null));
+
+        // ttl = 0 should evict the just-completed entry but keep the
+        // running one. (now_us > finished_at_us by definition.)
+        let n = r.evict_expired(Duration::from_micros(0)).await;
+        assert_eq!(n, 1);
+        assert!(r.get(&still_running.turn_id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn evict_expired_keeps_recent_terminal() {
+        let r = TurnRegistry::new();
+        let h = r.register(None).await;
+        let id = h.turn_id.clone();
+        h.complete(serde_json::json!(null));
+
+        // ttl = 1 hour: the entry just completed, well within ttl.
+        let n = r.evict_expired(Duration::from_secs(3600)).await;
+        assert_eq!(n, 0);
+        assert!(r.get(&id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn evict_expired_handles_failed_and_cancelled() {
+        let r = TurnRegistry::new();
+        let h_failed = r.register(None).await;
+        let h_cancelled = r.register(None).await;
+        h_failed.fail("oops");
+        h_cancelled.cancelled();
+
+        let n = r.evict_expired(Duration::from_micros(0)).await;
+        assert_eq!(n, 2);
     }
 
     #[test]

--- a/crates/claude-server/src/turns.rs
+++ b/crates/claude-server/src/turns.rs
@@ -316,9 +316,8 @@ mod tests {
         let h = r.register(None).await;
         let id = h.turn_id.clone();
         let r2 = r.clone();
-        let waiter = tokio::spawn(async move {
-            r2.wait(&id, None).await.expect("ok").expect("terminal")
-        });
+        let waiter =
+            tokio::spawn(async move { r2.wait(&id, None).await.expect("ok").expect("terminal") });
         tokio::time::sleep(Duration::from_millis(20)).await;
         h.complete(serde_json::json!({"x": 1}));
         let snap = waiter.await.expect("joined");

--- a/crates/claude-server/src/turns.rs
+++ b/crates/claude-server/src/turns.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
@@ -27,6 +27,49 @@ use serde_json::Value;
 use tokio::sync::{RwLock, watch};
 
 use crate::state::ChatId;
+
+/// Process-wide counters maintained by [`TurnRegistry`]. All updates
+/// happen from the [`TurnHandle`] terminal methods so workers don't
+/// have to remember to bump anything explicitly. Snapshots are
+/// surfaced via the `metrics_summary` tool and `claude://metrics`
+/// resource.
+#[derive(Default, Debug)]
+pub struct Metrics {
+    pub turns_fired: AtomicU64,
+    pub turns_done: AtomicU64,
+    pub turns_failed: AtomicU64,
+    pub turns_cancelled: AtomicU64,
+    /// Currently-running turns. Signed because a worker that races
+    /// to complete after a registry shutdown could underflow; we'd
+    /// rather see -1 than wrap to u64::MAX.
+    pub in_flight: AtomicI64,
+    /// Cumulative cost in micro-USD (multiply by 1e-6 for USD).
+    /// u64 storage so atomic ops work; 1 USD = 1_000_000.
+    pub total_cost_micros: AtomicU64,
+}
+
+impl Metrics {
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        MetricsSnapshot {
+            turns_fired: self.turns_fired.load(Ordering::Relaxed),
+            turns_done: self.turns_done.load(Ordering::Relaxed),
+            turns_failed: self.turns_failed.load(Ordering::Relaxed),
+            turns_cancelled: self.turns_cancelled.load(Ordering::Relaxed),
+            in_flight: self.in_flight.load(Ordering::Relaxed),
+            total_cost_usd: (self.total_cost_micros.load(Ordering::Relaxed) as f64) / 1_000_000.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MetricsSnapshot {
+    pub turns_fired: u64,
+    pub turns_done: u64,
+    pub turns_failed: u64,
+    pub turns_cancelled: u64,
+    pub in_flight: i64,
+    pub total_cost_usd: f64,
+}
 
 /// Opaque identifier for an async turn. Format: `turn_<hex>_<counter>`.
 pub type TurnId = String;
@@ -83,6 +126,7 @@ pub struct TurnHandle {
     pub turn_id: TurnId,
     pub cancel: Arc<AtomicBool>,
     snapshot_tx: watch::Sender<TurnSnapshot>,
+    metrics: Arc<Metrics>,
 }
 
 impl TurnHandle {
@@ -95,11 +139,27 @@ impl TurnHandle {
 
     /// Publish a Done terminal state with the worker's JSON result.
     pub fn complete(self, result: Value) {
+        // Pull the per-turn cost out of the standard envelope shape
+        // chat_send / claude_query workers produce, so total_cost
+        // metrics tick up automatically.
+        let cost = result
+            .get("turn_cost_usd")
+            .and_then(Value::as_f64)
+            .or_else(|| result.get("total_cost_usd").and_then(Value::as_f64))
+            .unwrap_or(0.0);
+        let micros = (cost.max(0.0) * 1_000_000.0) as u64;
         let mut snap = self.snapshot_tx.borrow().clone();
         snap.status = TurnStatus::Done;
         snap.finished_at_us = Some(now_us());
         snap.result = Some(result);
         let _ = self.snapshot_tx.send(snap);
+        self.metrics.turns_done.fetch_add(1, Ordering::Relaxed);
+        self.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+        if micros > 0 {
+            self.metrics
+                .total_cost_micros
+                .fetch_add(micros, Ordering::Relaxed);
+        }
     }
 
     /// Publish a Failed terminal state.
@@ -109,6 +169,8 @@ impl TurnHandle {
         snap.finished_at_us = Some(now_us());
         snap.error = Some(error.to_string());
         let _ = self.snapshot_tx.send(snap);
+        self.metrics.turns_failed.fetch_add(1, Ordering::Relaxed);
+        self.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
     }
 
     /// Publish a Cancelled terminal state. Workers call this when
@@ -118,6 +180,8 @@ impl TurnHandle {
         snap.status = TurnStatus::Cancelled;
         snap.finished_at_us = Some(now_us());
         let _ = self.snapshot_tx.send(snap);
+        self.metrics.turns_cancelled.fetch_add(1, Ordering::Relaxed);
+        self.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
@@ -135,11 +199,17 @@ struct TurnEntry {
 #[derive(Default)]
 pub struct TurnRegistry {
     entries: RwLock<HashMap<TurnId, TurnEntry>>,
+    metrics: Arc<Metrics>,
 }
 
 impl TurnRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Read-only handle to the process-wide metrics counters.
+    pub fn metrics(&self) -> &Metrics {
+        &self.metrics
     }
 
     /// Register a fresh turn. Returns a worker-side [`TurnHandle`]
@@ -166,10 +236,13 @@ impl TurnRegistry {
                 cancel: cancel.clone(),
             },
         );
+        self.metrics.turns_fired.fetch_add(1, Ordering::Relaxed);
+        self.metrics.in_flight.fetch_add(1, Ordering::Relaxed);
         TurnHandle {
             turn_id,
             cancel,
             snapshot_tx: tx,
+            metrics: self.metrics.clone(),
         }
     }
 

--- a/crates/claude-server/src/worktrees.rs
+++ b/crates/claude-server/src/worktrees.rs
@@ -1,0 +1,148 @@
+//! Read-only access to git worktrees, exposed as MCP tools and
+//! resources. Backed by [`claude_wrapper::worktrees::WorktreeRoot`].
+//!
+//! Useful for hosts that orchestrate worktree-isolated chats via
+//! `chat_open(worktree=true, worktree_name=...)` -- the host can
+//! later list the worktrees its chats produced and decide what to
+//! do with them.
+//!
+//! Tools:
+//! - `worktree_list { repo_path? }` -- enumerate worktrees for a
+//!   given repo. `repo_path` defaults to the server's resolved
+//!   default repo (see [`crate::config::ServerConfig::worktrees_root`]).
+//!
+//! Resources:
+//! - `claude://worktrees` -- same shape as `worktree_list` against
+//!   the server's default repo.
+//!
+//! Mutations (worktree_remove, prune) are not yet wired -- they
+//! belong behind the `mutations` feature double-gate.
+
+use std::path::PathBuf;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use tower_mcp::protocol::ReadResourceResult;
+use tower_mcp::resource::ResourceTemplate;
+use tower_mcp::{CallToolResult, Resource, ResourceBuilder, Tool, ToolBuilder};
+
+use claude_wrapper::worktrees::{Worktree, WorktreeRoot};
+
+use crate::state::ServerState;
+
+/// Build the worktrees-feature tool list.
+pub(crate) fn tools(state: &ServerState) -> Vec<Tool> {
+    vec![tool_worktree_list(state)]
+}
+
+/// Build the worktrees-feature resource list.
+pub(crate) fn resources(state: &ServerState) -> Vec<Resource> {
+    vec![resource_worktrees(state)]
+}
+
+/// Build the worktrees-feature resource templates.
+/// Empty for the first cut; per-repo templates may come later.
+pub(crate) fn templates(_state: &ServerState) -> Vec<ResourceTemplate> {
+    Vec::new()
+}
+
+// -- tool_worktree_list --------------------------------------------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct WorktreeListInput {
+    /// Optional path inside the target repo. Defaults to the
+    /// server's resolved default repo (config.worktrees_root,
+    /// then config.claude.working_dir, then process cwd).
+    #[serde(default)]
+    repo_path: Option<PathBuf>,
+}
+
+fn tool_worktree_list(state: &ServerState) -> Tool {
+    let state = state.clone();
+    ToolBuilder::new("worktree_list")
+        .description(
+            "Enumerate git worktrees for a repository. Optional \
+             `repo_path` selects which repo (defaults to the \
+             server's resolved default). Each entry: `path`, `head`, \
+             `branch`, `is_main`, `is_detached`, `is_bare`, \
+             `is_locked` (with optional `lock_reason`), `is_prunable` \
+             (with optional `prune_reason`). The first entry in the \
+             list is always the main worktree. Read-only.",
+        )
+        .read_only()
+        .handler(move |input: WorktreeListInput| {
+            let state = state.clone();
+            async move {
+                let path = resolve_repo_path(&state, input.repo_path);
+                let root = WorktreeRoot::for_repo(path);
+                let wts = root.list().map_err(crate::errors::from_wrapper)?;
+                Ok(CallToolResult::json(json!({
+                    "worktrees": wts.iter().map(worktree_to_json).collect::<Vec<_>>(),
+                })))
+            }
+        })
+        .build()
+}
+
+// -- resource: claude://worktrees -----------------------------------
+
+fn resource_worktrees(state: &ServerState) -> Resource {
+    let state = state.clone();
+    ResourceBuilder::new("claude://worktrees")
+        .name("Git worktrees")
+        .description(
+            "Live view of git worktrees for the server's default \
+             repo. Same shape as the worktree_list tool.",
+        )
+        .mime_type("application/json")
+        .handler(move || {
+            let state = state.clone();
+            async move {
+                let path = resolve_repo_path(&state, None);
+                let root = WorktreeRoot::for_repo(path);
+                let wts = root.list().map_err(crate::errors::from_wrapper)?;
+                let body = json!({
+                    "worktrees": wts.iter().map(worktree_to_json).collect::<Vec<_>>(),
+                });
+                let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+                Ok(ReadResourceResult::text("claude://worktrees", text))
+            }
+        })
+        .build()
+}
+
+// -- helpers --------------------------------------------------------
+
+/// Resolution order for the target repo path:
+/// 1. caller-provided `repo_path` argument
+/// 2. `config.worktrees_root` (per-server default)
+/// 3. `config.claude.working_dir` (server's spawn cwd)
+/// 4. process cwd (last resort)
+fn resolve_repo_path(state: &ServerState, explicit: Option<PathBuf>) -> PathBuf {
+    if let Some(p) = explicit {
+        return p;
+    }
+    if let Some(p) = state.config.worktrees_root.as_ref() {
+        return p.clone();
+    }
+    if let Some(p) = state.config.claude.working_dir.as_ref() {
+        return p.clone();
+    }
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+fn worktree_to_json(w: &Worktree) -> serde_json::Value {
+    json!({
+        "path": w.path,
+        "head": w.head,
+        "branch": w.branch,
+        "is_main": w.is_main,
+        "is_detached": w.is_detached,
+        "is_bare": w.is_bare,
+        "is_locked": w.is_locked,
+        "lock_reason": w.lock_reason,
+        "is_prunable": w.is_prunable,
+        "prune_reason": w.prune_reason,
+    })
+}

--- a/crates/claude-server/tests/artifacts_surface.rs
+++ b/crates/claude-server/tests/artifacts_surface.rs
@@ -198,6 +198,207 @@ async fn agent_detail_template_returns_full_record() {
 }
 
 // ---------------------------------------------------------------
+// Mutating tools -- gated by the `mutations` Cargo feature AND
+// `policy.allow_mutations` at runtime. Test both gates.
+// ---------------------------------------------------------------
+
+#[cfg(feature = "mutations")]
+fn cfg_with_mutations(root: &Path) -> ServerConfig {
+    use claude_server::ServerPolicy;
+    ServerConfig {
+        agents_root: Some(root.to_path_buf()),
+        policy: ServerPolicy {
+            allow_mutations: true,
+        },
+        ..Default::default()
+    }
+}
+
+#[cfg(feature = "mutations")]
+#[test]
+fn mutating_tools_registered_when_both_gates_open() {
+    let tmp = fixture_root();
+    let tools = registered_tools(cfg_with_mutations(tmp.path())).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    for expected in ["agent_write", "agent_delete"] {
+        assert!(
+            names.contains(&expected),
+            "missing mutating tool {expected} in {names:?}"
+        );
+    }
+}
+
+#[cfg(feature = "mutations")]
+#[test]
+fn mutating_tools_omitted_when_policy_off() {
+    let tmp = fixture_root();
+    // Default policy.allow_mutations = false.
+    let tools = registered_tools(cfg_with(tmp.path())).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    for forbidden in ["agent_write", "agent_delete"] {
+        assert!(
+            !names.contains(&forbidden),
+            "mutating tool {forbidden} leaked through with policy off; got {names:?}"
+        );
+    }
+}
+
+#[cfg(feature = "mutations")]
+#[tokio::test]
+async fn agent_write_creates_new_agent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let router = build_router(cfg_with_mutations(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "agent_write",
+            serde_json::json!({
+                "file_stem": "fresh",
+                "description": "a new agent",
+                "tools": ["Read", "Bash"],
+                "model": "haiku",
+                "body": "You are fresh.",
+            }),
+        )
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    assert_eq!(v["file_stem"].as_str().unwrap(), "fresh");
+    assert_eq!(v["status"].as_str().unwrap(), "written");
+
+    // Round-trip via the read tool.
+    let got = client
+        .call_tool("agent_get", serde_json::json!({"file_stem": "fresh"}))
+        .await;
+    let g: serde_json::Value = serde_json::from_str(&got.all_text()).expect("json");
+    assert_eq!(g["body"].as_str().unwrap(), "You are fresh.");
+    assert_eq!(g["model"].as_str().unwrap(), "haiku");
+}
+
+#[cfg(feature = "mutations")]
+#[tokio::test]
+async fn agent_write_overwrites_by_default() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with_mutations(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "agent_write",
+            serde_json::json!({
+                "file_stem": "rust-qa",
+                "body": "rewritten body",
+            }),
+        )
+        .await;
+    assert!(!result.is_error, "overwrite failed: {}", result.all_text());
+
+    let got = client
+        .call_tool("agent_get", serde_json::json!({"file_stem": "rust-qa"}))
+        .await;
+    let g: serde_json::Value = serde_json::from_str(&got.all_text()).expect("json");
+    assert_eq!(g["body"].as_str().unwrap(), "rewritten body");
+}
+
+#[cfg(feature = "mutations")]
+#[tokio::test]
+async fn agent_write_if_not_exists_blocks_overwrite() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with_mutations(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "agent_write",
+            serde_json::json!({
+                "file_stem": "rust-qa",
+                "body": "shouldn't land",
+                "if_not_exists": true,
+            }),
+        )
+        .await;
+    assert!(
+        result.is_error,
+        "expected write_new conflict error; got {}",
+        result.all_text()
+    );
+    assert!(
+        result.all_text().to_lowercase().contains("already exists"),
+        "expected 'already exists' message; got {}",
+        result.all_text()
+    );
+
+    // Original body should still be there.
+    let got = client
+        .call_tool("agent_get", serde_json::json!({"file_stem": "rust-qa"}))
+        .await;
+    let g: serde_json::Value = serde_json::from_str(&got.all_text()).expect("json");
+    assert_eq!(g["body"].as_str().unwrap(), "You are a Rust quality gate.");
+}
+
+#[cfg(feature = "mutations")]
+#[tokio::test]
+async fn agent_write_rejects_path_traversal() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let router = build_router(cfg_with_mutations(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "agent_write",
+            serde_json::json!({
+                "file_stem": "../escape",
+                "body": "nope",
+            }),
+        )
+        .await;
+    assert!(result.is_error);
+    assert!(
+        result.all_text().to_lowercase().contains("file_stem"),
+        "expected file_stem rejection; got {}",
+        result.all_text()
+    );
+}
+
+#[cfg(feature = "mutations")]
+#[tokio::test]
+async fn agent_delete_removes_file() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with_mutations(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("agent_delete", serde_json::json!({"file_stem": "rust-qa"}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    assert_eq!(v["status"].as_str().unwrap(), "deleted");
+
+    let got = client
+        .call_tool("agent_get", serde_json::json!({"file_stem": "rust-qa"}))
+        .await;
+    assert!(got.is_error, "agent_get should fail after delete");
+}
+
+#[cfg(feature = "mutations")]
+#[tokio::test]
+async fn agent_delete_unknown_stem_errors() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with_mutations(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("agent_delete", serde_json::json!({"file_stem": "nope"}))
+        .await;
+    assert!(result.is_error);
+}
+
+// ---------------------------------------------------------------
 // Live #[ignore] test -- reads the user's real ~/.claude/agents/.
 // Run with: cargo test -p claude-server --features artifacts -- --ignored
 // ---------------------------------------------------------------

--- a/crates/claude-server/tests/artifacts_surface.rs
+++ b/crates/claude-server/tests/artifacts_surface.rs
@@ -1,0 +1,215 @@
+//! Integration tests for the `artifacts` Cargo feature: read-only
+//! tools and resources backed by `claude_wrapper::artifacts` reading
+//! `~/.claude/agents/<file_stem>.md`.
+//!
+//! Most tests point a tempdir at the server via
+//! `ServerConfig::agents_root` and seed it with synthetic markdown.
+//! One live test (`#[ignore]`) reads the user's real
+//! `~/.claude/agents/`.
+
+#![cfg(feature = "artifacts")]
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use claude_server::{ServerConfig, build_router, registered_tools};
+use tower_mcp::TestClient;
+
+fn write_agent(dir: &Path, file_stem: &str, contents: &str) -> PathBuf {
+    let path = dir.join(format!("{file_stem}.md"));
+    let mut f = fs::File::create(&path).expect("create md");
+    f.write_all(contents.as_bytes()).expect("write md");
+    path
+}
+
+fn fixture_root() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_agent(
+        tmp.path(),
+        "rust-qa",
+        "---\nname: rust-qa\ndescription: Rust quality gate\ntools: Read, Grep, Bash\nmodel: sonnet\n---\n\nYou are a Rust quality gate.\n",
+    );
+    write_agent(
+        tmp.path(),
+        "minimal",
+        "---\nname: minimal\ndescription: Minimal agent\n---\nBody here.\n",
+    );
+    write_agent(
+        tmp.path(),
+        "weird",
+        "---\nname: weird\ndescription: has extras\ncustom_key: custom_value\n---\nbody\n",
+    );
+    tmp
+}
+
+fn cfg_with(root: &Path) -> ServerConfig {
+    ServerConfig {
+        agents_root: Some(root.to_path_buf()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn registered_tools_includes_artifacts_surface() {
+    let tmp = fixture_root();
+    let tools = registered_tools(cfg_with(tmp.path())).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    for expected in ["agent_list", "agent_get"] {
+        assert!(
+            names.contains(&expected),
+            "missing artifacts tool {expected} in {names:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn agent_list_returns_synthetic_agents_sorted() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client.call_tool("agent_list", serde_json::json!({})).await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    let stems: Vec<&str> = v["agents"]
+        .as_array()
+        .expect("agents array")
+        .iter()
+        .map(|a| a["file_stem"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(stems, ["minimal", "rust-qa", "weird"]);
+}
+
+#[tokio::test]
+async fn agent_list_carries_typed_metadata() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client.call_tool("agent_list", serde_json::json!({})).await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    let agents = v["agents"].as_array().expect("agents");
+    let rust_qa = agents
+        .iter()
+        .find(|a| a["file_stem"] == "rust-qa")
+        .expect("rust-qa entry");
+    assert_eq!(rust_qa["name"].as_str().unwrap(), "rust-qa");
+    assert_eq!(
+        rust_qa["description"].as_str().unwrap(),
+        "Rust quality gate"
+    );
+    let tools: Vec<&str> = rust_qa["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t.as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(tools, ["Read", "Grep", "Bash"]);
+    assert_eq!(rust_qa["model"].as_str().unwrap(), "sonnet");
+    assert!(rust_qa["size_bytes"].as_u64().unwrap() > 0);
+}
+
+#[tokio::test]
+async fn agent_get_returns_full_record_with_body_and_extras() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("agent_get", serde_json::json!({"file_stem": "weird"}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    assert_eq!(v["file_stem"].as_str().unwrap(), "weird");
+    assert_eq!(v["name"].as_str().unwrap(), "weird");
+    assert_eq!(v["body"].as_str().unwrap(), "body");
+    assert_eq!(v["extra"]["custom_key"].as_str().unwrap(), "custom_value");
+}
+
+#[tokio::test]
+async fn agent_get_unknown_stem_errors() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("agent_get", serde_json::json!({"file_stem": "nope"}))
+        .await;
+    assert!(
+        result.is_error,
+        "expected is_error=true for unknown stem; got {}",
+        result.all_text()
+    );
+}
+
+#[tokio::test]
+async fn agents_resource_lists_synthetic_agents() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://agents").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    let stems: Vec<&str> = v["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| a["file_stem"].as_str().unwrap_or_default())
+        .collect();
+    assert!(stems.contains(&"rust-qa"));
+    assert!(stems.contains(&"minimal"));
+}
+
+#[tokio::test]
+async fn agent_detail_template_returns_full_record() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://agents/rust-qa").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    assert_eq!(v["file_stem"].as_str().unwrap(), "rust-qa");
+    assert_eq!(v["body"].as_str().unwrap(), "You are a Rust quality gate.");
+}
+
+// ---------------------------------------------------------------
+// Live #[ignore] test -- reads the user's real ~/.claude/agents/.
+// Run with: cargo test -p claude-server --features artifacts -- --ignored
+// ---------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "reads the user's real ~/.claude/agents; may be empty in CI"]
+async fn live_agent_list_works_against_real_home() {
+    let router = build_router(ServerConfig::default()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client.call_tool("agent_list", serde_json::json!({})).await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    assert!(v["agents"].is_array(), "agents array missing");
+}

--- a/crates/claude-server/tests/async_turns.rs
+++ b/crates/claude-server/tests/async_turns.rs
@@ -16,6 +16,44 @@ fn cfg() -> ServerConfig {
 }
 
 #[tokio::test]
+async fn turn_get_unknown_id_errors() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+    let r = client
+        .call_tool("turn_get", serde_json::json!({"turn_id": "turn_nope"}))
+        .await;
+    let text = r.all_text();
+    assert!(
+        text.contains("no turn with id"),
+        "expected unknown-turn error, got {text}"
+    );
+}
+
+#[tokio::test]
+async fn turn_cancel_unknown_id_is_a_noop() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+    let r = client
+        .call_tool("turn_cancel", serde_json::json!({"turn_id": "turn_nope"}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&r.all_text()).expect("json");
+    assert_eq!(v["ok"], serde_json::json!(true));
+    assert_eq!(v["existed"], serde_json::json!(false));
+}
+
+#[tokio::test]
+async fn turn_list_starts_empty() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+    let r = client.call_tool("turn_list", serde_json::json!({})).await;
+    let v: serde_json::Value = serde_json::from_str(&r.all_text()).expect("json");
+    assert_eq!(v["turns"].as_array().map(|a| a.len()), Some(0));
+}
+
+#[tokio::test]
 async fn chat_send_unknown_chat_errors_synchronously() {
     let router = build_router(cfg()).expect("router built");
     let mut client = TestClient::from_router(router);
@@ -87,6 +125,127 @@ async fn live_chat_send_returns_turn_id_immediately() {
     // Until then we just let the turn finish in the background by
     // sleeping briefly so the worker can publish before close.
     tokio::time::sleep(std::time::Duration::from_secs(8)).await;
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chat_send_then_turn_wait_settles() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let open = client
+        .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text()).expect("open json");
+    let chat_id = body["chat_id"].as_str().unwrap().to_string();
+
+    // Fire async.
+    let fire = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id.clone(),
+                "prompt": "Reply with exactly the word WAITED and nothing else.",
+            }),
+        )
+        .await;
+    let fbody: serde_json::Value = serde_json::from_str(&fire.all_text()).expect("fire json");
+    let turn_id = fbody["turn_id"].as_str().unwrap().to_string();
+
+    // turn_get right away: should be running.
+    let pre = client
+        .call_tool("turn_get", serde_json::json!({"turn_id": turn_id.clone()}))
+        .await;
+    let pre_v: serde_json::Value = serde_json::from_str(&pre.all_text()).expect("get json");
+    assert_eq!(
+        pre_v["status"],
+        serde_json::json!("running"),
+        "pre: {pre_v}"
+    );
+
+    // Wait with a generous timeout.
+    let waited = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id.clone(), "timeout_secs": 30.0}),
+        )
+        .await;
+    let wv: serde_json::Value = serde_json::from_str(&waited.all_text()).expect("wait json");
+    eprintln!("settled: {wv}");
+    assert_eq!(wv["status"], serde_json::json!("done"));
+    let result_text = wv["result"]["result"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        result_text.contains("WAITED"),
+        "expected WAITED, got {result_text:?}"
+    );
+
+    // turn_list should show the settled turn.
+    let list = client.call_tool("turn_list", serde_json::json!({})).await;
+    let lv: serde_json::Value = serde_json::from_str(&list.all_text()).expect("list json");
+    let turns = lv["turns"].as_array().expect("array");
+    assert!(turns.iter().any(|t| t["turn_id"] == turn_id));
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_turn_wait_timeout_then_settle() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let open = client
+        .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+        .await;
+    let chat_id = serde_json::from_str::<serde_json::Value>(&open.all_text()).unwrap()["chat_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let fire = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id.clone(),
+                "prompt": "Reply with the word ECHO.",
+            }),
+        )
+        .await;
+    let turn_id = serde_json::from_str::<serde_json::Value>(&fire.all_text()).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Tight 50ms timeout -- a real haiku turn is at least ~1s.
+    let early = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id.clone(), "timeout_secs": 0.05}),
+        )
+        .await;
+    let ev: serde_json::Value = serde_json::from_str(&early.all_text()).expect("json");
+    assert_eq!(ev["status"], serde_json::json!("timeout"), "ev: {ev}");
+
+    // Now wait properly.
+    let settled = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id, "timeout_secs": 30.0}),
+        )
+        .await;
+    let sv: serde_json::Value = serde_json::from_str(&settled.all_text()).expect("json");
+    assert_eq!(sv["status"], serde_json::json!("done"));
 
     let _ = client
         .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))

--- a/crates/claude-server/tests/async_turns.rs
+++ b/crates/claude-server/tests/async_turns.rs
@@ -1,0 +1,157 @@
+//! Async-turn flow tests.
+//!
+//! Until step 4 lands the `turn_get` / `turn_wait` / `turn_cancel`
+//! tools, these tests exercise the new async `chat_send` over MCP
+//! and reach into the library's TurnRegistry via the test client's
+//! shared state. The wire test for the full turn lifecycle happens
+//! once those tools exist.
+//!
+//! Live tests gated `#[ignore]`. Run with `--ignored`.
+
+use claude_server::{ServerConfig, build_router};
+use tower_mcp::TestClient;
+
+fn cfg() -> ServerConfig {
+    ServerConfig::default()
+}
+
+#[tokio::test]
+async fn chat_send_unknown_chat_errors_synchronously() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // We never call chat_open, so this chat_id is invalid. The
+    // async tool should reject before promising a turn_id rather
+    // than fire-and-forget into a guaranteed-to-fail turn.
+    let result = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": "chat_does_not_exist",
+                "prompt": "hi",
+            }),
+        )
+        .await;
+    let text = result.all_text();
+    assert!(
+        text.contains("no chat with id"),
+        "expected error envelope, got {text}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chat_send_returns_turn_id_immediately() {
+    use std::time::Instant;
+
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let open = client
+        .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text()).expect("open json");
+    let chat_id = body["chat_id"].as_str().unwrap().to_string();
+
+    // The async fire should return in well under a second. A real
+    // haiku turn takes 1-5+ seconds; if we're seeing that on the
+    // fire path, the tool is blocking instead of spawning.
+    let started = Instant::now();
+    let fire = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id.clone(),
+                "prompt": "Reply with exactly the word ASYNC and nothing else.",
+            }),
+        )
+        .await;
+    let fired_in = started.elapsed();
+    eprintln!("chat_send returned in {fired_in:?}");
+    let fbody: serde_json::Value = serde_json::from_str(&fire.all_text()).expect("fire json");
+    let turn_id = fbody["turn_id"].as_str().expect("turn_id").to_string();
+    eprintln!("turn_id: {turn_id}");
+    assert_eq!(fbody["chat_id"].as_str(), Some(chat_id.as_str()));
+
+    // 500ms is plenty -- spawn + Conversation::lock should be sub-ms.
+    // If we see >500ms we're almost certainly blocking on the actual
+    // claude turn.
+    assert!(
+        fired_in < std::time::Duration::from_millis(500),
+        "chat_send blocked for {fired_in:?}; should fire-and-return"
+    );
+
+    // Once step 4 lands `turn_wait` we'll await completion here.
+    // Until then we just let the turn finish in the background by
+    // sleeping briefly so the worker can publish before close.
+    tokio::time::sleep(std::time::Duration::from_secs(8)).await;
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_two_chats_run_in_parallel() {
+    use std::time::Instant;
+
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    async fn open_one(client: &mut TestClient) -> String {
+        let body = client
+            .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+            .await;
+        let v: serde_json::Value = serde_json::from_str(&body.all_text()).expect("open json");
+        v["chat_id"].as_str().unwrap().to_string()
+    }
+
+    let chat_a = open_one(&mut client).await;
+    let chat_b = open_one(&mut client).await;
+
+    // Fire two async sends back to back. If they truly run in
+    // parallel, the second fire returns almost immediately --
+    // it's a different chat with its own Conversation mutex.
+    let started = Instant::now();
+    let _ = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_a.clone(),
+                "prompt": "Reply with exactly the word AAA and nothing else.",
+            }),
+        )
+        .await;
+    let after_first = started.elapsed();
+    let _ = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_b.clone(),
+                "prompt": "Reply with exactly the word BBB and nothing else.",
+            }),
+        )
+        .await;
+    let after_second = started.elapsed();
+    eprintln!("first fire: {after_first:?}, both fires: {after_second:?}");
+
+    // Both fires combined should still be under a second.
+    assert!(
+        after_second < std::time::Duration::from_millis(1500),
+        "second chat's fire blocked behind first; total {after_second:?}"
+    );
+
+    // Let the turns run in the background.
+    tokio::time::sleep(std::time::Duration::from_secs(8)).await;
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_a}))
+        .await;
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_b}))
+        .await;
+}

--- a/crates/claude-server/tests/async_turns.rs
+++ b/crates/claude-server/tests/async_turns.rs
@@ -254,6 +254,46 @@ async fn live_turn_wait_timeout_then_settle() {
 
 #[tokio::test]
 #[ignore = "spawns real claude binary"]
+async fn live_claude_query_async_loop() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let fire = client
+        .call_tool(
+            "claude_query",
+            serde_json::json!({
+                "prompt": "Reply with exactly the word QUERIED.",
+                "model": "haiku",
+            }),
+        )
+        .await;
+    let fbody: serde_json::Value = serde_json::from_str(&fire.all_text()).expect("fire json");
+    let turn_id = fbody["turn_id"].as_str().expect("turn_id").to_string();
+    eprintln!("claude_query fired turn: {turn_id}");
+
+    let waited = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id.clone(), "timeout_secs": 30.0}),
+        )
+        .await;
+    let wv: serde_json::Value = serde_json::from_str(&waited.all_text()).expect("wait json");
+    eprintln!("settled: {wv}");
+    assert_eq!(wv["status"], serde_json::json!("done"));
+    let r = wv["result"]["result"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(r.contains("QUERIED"), "expected QUERIED, got {r:?}");
+    assert!(
+        wv["chat_id"].is_null(),
+        "single-shot turn should have null chat_id, got {wv}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
 async fn live_two_chats_run_in_parallel() {
     use std::time::Instant;
 

--- a/crates/claude-server/tests/chat_flow.rs
+++ b/crates/claude-server/tests/chat_flow.rs
@@ -81,6 +81,33 @@ async fn chat_open_schema_exposes_resume_fields() {
 }
 
 #[tokio::test]
+async fn chat_open_schema_exposes_agent_fields() {
+    // Wired through after wrapper PR #595 (typed --agent / --agents
+    // builders). Both fields should be discoverable so a coordinator
+    // agent can pin a chat to a known persona without out-of-band
+    // knowledge of CLI flag names.
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let tools = client.list_tools().await;
+    let chat_open = tools
+        .iter()
+        .find(|t| t["name"].as_str() == Some("chat_open"))
+        .expect("chat_open in tools/list");
+    let props = chat_open["inputSchema"]["properties"]
+        .as_object()
+        .expect("input schema properties");
+    for field in ["agent", "agents_json"] {
+        assert!(
+            props.contains_key(field),
+            "chat_open schema should expose {field}; got {:?}",
+            props.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
+#[tokio::test]
 async fn chat_close_unknown_id_is_a_noop() {
     let router = build_router(cfg()).expect("router built");
     let mut client = TestClient::from_router(router);

--- a/crates/claude-server/tests/chat_flow.rs
+++ b/crates/claude-server/tests/chat_flow.rs
@@ -94,6 +94,7 @@ async fn chat_budget_returns_null_when_no_budget() {
     );
 }
 
+#[cfg(feature = "sync-agent-turns")]
 #[tokio::test]
 #[ignore = "spawns real claude binary"]
 async fn live_chat_open_send_close_roundtrip() {
@@ -187,6 +188,7 @@ async fn live_chat_open_send_close_roundtrip() {
     );
 }
 
+#[cfg(feature = "sync-agent-turns")]
 #[tokio::test]
 #[ignore = "spawns real claude binary"]
 async fn live_chat_budget_tracks_spend() {
@@ -249,6 +251,7 @@ async fn live_chat_budget_tracks_spend() {
         .await;
 }
 
+#[cfg(feature = "sync-agent-turns")]
 #[tokio::test]
 #[ignore = "spawns real claude binary"]
 async fn live_chat_send_stream_sync_emits_progress() {

--- a/crates/claude-server/tests/chat_flow.rs
+++ b/crates/claude-server/tests/chat_flow.rs
@@ -55,6 +55,32 @@ async fn chat_open_schema_exposes_working_dir() {
 }
 
 #[tokio::test]
+async fn chat_open_schema_exposes_resume_fields() {
+    // P0 from the Finestra-direction plan: hosts upgrade a passive
+    // on-disk session to a live duplex chat. Both `resume` and
+    // `continue_session` should be discoverable via tools/list.
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let tools = client.list_tools().await;
+    let chat_open = tools
+        .iter()
+        .find(|t| t["name"].as_str() == Some("chat_open"))
+        .expect("chat_open in tools/list");
+    let props = chat_open["inputSchema"]["properties"]
+        .as_object()
+        .expect("input schema properties");
+    for field in ["resume", "continue_session"] {
+        assert!(
+            props.contains_key(field),
+            "chat_open schema should expose {field}; got {:?}",
+            props.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
+#[tokio::test]
 async fn chat_close_unknown_id_is_a_noop() {
     let router = build_router(cfg()).expect("router built");
     let mut client = TestClient::from_router(router);
@@ -419,5 +445,119 @@ async fn live_chat_send_stream_sync_emits_progress() {
 
     let _ = client
         .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chat_open_resume_continues_prior_conversation() {
+    // P0 demo, all in one process: open chat A, plant a recallable
+    // fact, capture its session_id, close. Open chat B with
+    // resume = that session_id and ask the model to recall -- it
+    // should pick up the prior context rather than starting fresh.
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // Chat A: plant a fact.
+    let open_a = client
+        .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+        .await;
+    let body_a: serde_json::Value = serde_json::from_str(&open_a.all_text()).expect("open A json");
+    let chat_a = body_a["chat_id"].as_str().unwrap().to_string();
+
+    // Natural-sounding turn -- "remember the secret word X" reads as
+    // a prompt-injection test and gets refused; just having a normal
+    // exchange works fine.
+    let send_a = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_a.clone(),
+                "prompt": "Pick a fruit -- not a common one. Reply with just the fruit name, no explanation.",
+            }),
+        )
+        .await;
+    let turn_a = serde_json::from_str::<serde_json::Value>(&send_a.all_text()).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let waited_a = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_a, "timeout_secs": 30.0}),
+        )
+        .await;
+    let wv_a: serde_json::Value = serde_json::from_str(&waited_a.all_text()).expect("wait A json");
+    assert_eq!(wv_a["status"], serde_json::json!("done"));
+    let session_id = wv_a["result"]["session_id"]
+        .as_str()
+        .expect("session_id present")
+        .to_string();
+    let picked_fruit = wv_a["result"]["result"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    eprintln!("session {session_id} picked: {picked_fruit:?}");
+
+    // Close A; the duplex process exits. The on-disk JSONL remains
+    // and the session_id is what `--resume` keys on.
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_a}))
+        .await;
+
+    // Chat B: resume the same session_id, ask a recall question.
+    let open_b = client
+        .call_tool(
+            "chat_open",
+            serde_json::json!({"model": "haiku", "resume": session_id}),
+        )
+        .await;
+    let body_b: serde_json::Value = serde_json::from_str(&open_b.all_text()).expect("open B json");
+    let chat_b = body_b["chat_id"].as_str().unwrap().to_string();
+
+    let send_b = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_b.clone(),
+                "prompt": "What fruit did you just pick? Reply with just the fruit name.",
+            }),
+        )
+        .await;
+    let turn_b = serde_json::from_str::<serde_json::Value>(&send_b.all_text()).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let waited_b = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_b, "timeout_secs": 30.0}),
+        )
+        .await;
+    let wv_b: serde_json::Value = serde_json::from_str(&waited_b.all_text()).expect("wait B json");
+    eprintln!("resumed reply: {wv_b}");
+    assert_eq!(wv_b["status"], serde_json::json!("done"));
+    let recall = wv_b["result"]["result"]
+        .as_str()
+        .unwrap_or_default()
+        .to_lowercase();
+    let expected = picked_fruit.trim().to_lowercase();
+    // Strongest assertion: same session_id across both opens proves
+    // --resume took effect at the CLI level. The recall check is a
+    // belt-and-suspenders semantic check that the conversation
+    // history actually flowed through.
+    assert_eq!(
+        wv_b["result"]["session_id"].as_str(),
+        Some(session_id.as_str()),
+        "resumed session should keep the same session_id"
+    );
+    assert!(
+        recall.contains(&expected),
+        "expected the resumed turn to recall the picked fruit `{expected}`; got {recall:?}"
+    );
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_b}))
         .await;
 }

--- a/crates/claude-server/tests/chat_flow.rs
+++ b/crates/claude-server/tests/chat_flow.rs
@@ -115,7 +115,7 @@ async fn live_chat_open_send_close_roundtrip() {
     // Send a turn.
     let sent = client
         .call_tool(
-            "chat_send",
+            "chat_send_sync",
             serde_json::json!({
                 "chat_id": chat_id,
                 "prompt": "Reply with exactly the word ALPHA and nothing else.",
@@ -132,7 +132,7 @@ async fn live_chat_open_send_close_roundtrip() {
     // Send a second turn -- the assistant should remember the first.
     let sent2 = client
         .call_tool(
-            "chat_send",
+            "chat_send_sync",
             serde_json::json!({
                 "chat_id": chat_id,
                 "prompt": "What word did I just ask you to reply with?",
@@ -219,7 +219,7 @@ async fn live_chat_budget_tracks_spend() {
     // Send a turn.
     let _ = client
         .call_tool(
-            "chat_send",
+            "chat_send_sync",
             serde_json::json!({
                 "chat_id": chat_id.clone(),
                 "prompt": "Reply with the single word BUDGET.",
@@ -251,7 +251,7 @@ async fn live_chat_budget_tracks_spend() {
 
 #[tokio::test]
 #[ignore = "spawns real claude binary"]
-async fn live_chat_send_stream_emits_progress() {
+async fn live_chat_send_stream_sync_emits_progress() {
     use tower_mcp::context::ServerNotification;
 
     let router = build_router(cfg()).expect("router built");
@@ -274,7 +274,7 @@ async fn live_chat_send_stream_emits_progress() {
         .send_request(
             "tools/call",
             Some(serde_json::json!({
-                "name": "chat_send_stream",
+                "name": "chat_send_stream_sync",
                 "arguments": {
                     "chat_id": chat_id.clone(),
                     "prompt": "Reply with one short sentence describing the color blue.",

--- a/crates/claude-server/tests/chat_flow.rs
+++ b/crates/claude-server/tests/chat_flow.rs
@@ -1,0 +1,314 @@
+//! Chat-surface flow tests.
+//!
+//! In-process tests verify the surface exists and that the empty
+//! `chat_list` / `claude://chats` resource round-trips cleanly --
+//! anything beyond that needs a real `claude` and is gated behind
+//! `#[ignore]`.
+//!
+//! Run live tests with: `cargo test -p claude-server --test chat_flow -- --ignored`.
+
+use claude_server::{ServerConfig, build_router};
+use tower_mcp::TestClient;
+
+fn cfg() -> ServerConfig {
+    ServerConfig::default()
+}
+
+#[tokio::test]
+async fn chat_list_starts_empty() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client.call_tool("chat_list", serde_json::json!({})).await;
+    let text = result.all_text();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    assert_eq!(
+        v["chats"].as_array().map(|a| a.len()),
+        Some(0),
+        "body: {text}"
+    );
+}
+
+#[tokio::test]
+async fn chat_close_unknown_id_is_a_noop() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "chat_close",
+            serde_json::json!({"chat_id": "chat_does_not_exist"}),
+        )
+        .await;
+    let text = result.all_text();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    assert_eq!(v["ok"], serde_json::json!(true), "body: {text}");
+    assert_eq!(v["existed"], serde_json::json!(false), "body: {text}");
+}
+
+#[tokio::test]
+async fn chats_resource_round_trips_empty() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client.read_resource("claude://chats").await;
+    let text = result
+        .contents
+        .first()
+        .and_then(|c| c.text.clone())
+        .unwrap_or_default();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json resource body");
+    assert_eq!(
+        v["chats"].as_array().map(|a| a.len()),
+        Some(0),
+        "body: {text}"
+    );
+}
+
+// ---------------------------------------------------------------
+// Live #[ignore] tests -- exercise a real `claude` binary.
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn chat_budget_returns_null_when_no_budget() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // Need a chat to query, but spawning real claude needs --ignored.
+    // Instead, check chat_budget on a non-existent id surfaces an error.
+    let result = client
+        .call_tool(
+            "chat_budget",
+            serde_json::json!({"chat_id": "chat_not_real"}),
+        )
+        .await;
+    let text = result.all_text();
+    // Either an MCP error envelope or our internal error message; both are fine.
+    assert!(
+        text.contains("no chat with id") || text.contains("not_real"),
+        "expected unknown-chat error, got {text}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chat_open_send_close_roundtrip() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // Open a chat with haiku to keep cost down.
+    let open = client
+        .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text()).expect("chat_open json");
+    let chat_id = body["chat_id"]
+        .as_str()
+        .expect("chat_id present")
+        .to_string();
+    eprintln!("opened chat: {chat_id}");
+
+    // Send a turn.
+    let sent = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id,
+                "prompt": "Reply with exactly the word ALPHA and nothing else.",
+            }),
+        )
+        .await;
+    let sent_body: serde_json::Value =
+        serde_json::from_str(&sent.all_text()).expect("chat_send json");
+    eprintln!("turn 1: {sent_body}");
+    let r1 = sent_body["result"].as_str().unwrap_or_default();
+    assert!(r1.contains("ALPHA"), "expected ALPHA, got {r1:?}");
+    assert_eq!(sent_body["total_turns"], serde_json::json!(1));
+
+    // Send a second turn -- the assistant should remember the first.
+    let sent2 = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id,
+                "prompt": "What word did I just ask you to reply with?",
+            }),
+        )
+        .await;
+    let sent2_body: serde_json::Value =
+        serde_json::from_str(&sent2.all_text()).expect("chat_send json");
+    eprintln!("turn 2: {sent2_body}");
+    let r2 = sent2_body["result"].as_str().unwrap_or_default();
+    assert!(
+        r2.to_uppercase().contains("ALPHA"),
+        "expected ALPHA recall, got {r2:?}"
+    );
+    assert_eq!(sent2_body["total_turns"], serde_json::json!(2));
+
+    // History should have two entries.
+    let history = client
+        .call_tool("chat_history", serde_json::json!({"chat_id": chat_id}))
+        .await;
+    let hbody: serde_json::Value = serde_json::from_str(&history.all_text()).expect("history json");
+    assert_eq!(
+        hbody["total_turns"],
+        serde_json::json!(2),
+        "history: {hbody}"
+    );
+    assert_eq!(hbody["turns"].as_array().map(|a| a.len()), Some(2));
+
+    // chat_list should show this chat with 2 turns.
+    let list = client.call_tool("chat_list", serde_json::json!({})).await;
+    let lbody: serde_json::Value = serde_json::from_str(&list.all_text()).expect("list json");
+    let chats = lbody["chats"].as_array().expect("array");
+    assert!(
+        chats.iter().any(|c| c["chat_id"] == chat_id),
+        "list: {lbody}"
+    );
+
+    // Close.
+    let close = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+    let cbody: serde_json::Value = serde_json::from_str(&close.all_text()).expect("close json");
+    assert_eq!(cbody["existed"], serde_json::json!(true));
+
+    // After close, list should be empty again.
+    let list2 = client.call_tool("chat_list", serde_json::json!({})).await;
+    let lbody2: serde_json::Value = serde_json::from_str(&list2.all_text()).expect("list json");
+    assert_eq!(
+        lbody2["chats"].as_array().map(|a| a.len()),
+        Some(0),
+        "post-close list: {lbody2}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chat_budget_tracks_spend() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // Open with a generous ceiling so we don't actually trip it.
+    let open = client
+        .call_tool(
+            "chat_open",
+            serde_json::json!({"model": "haiku", "max_cost_usd": 1.0}),
+        )
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text()).expect("open json");
+    let chat_id = body["chat_id"].as_str().unwrap().to_string();
+
+    // Pre-turn: budget shows 0 spent, $1 max, $1 remaining.
+    let pre = client
+        .call_tool(
+            "chat_budget",
+            serde_json::json!({"chat_id": chat_id.clone()}),
+        )
+        .await;
+    let pbody: serde_json::Value = serde_json::from_str(&pre.all_text()).expect("budget json");
+    eprintln!("pre-turn budget: {pbody}");
+    assert_eq!(pbody["budget"]["max_usd"], serde_json::json!(1.0));
+    assert_eq!(pbody["budget"]["total_usd"], serde_json::json!(0.0));
+
+    // Send a turn.
+    let _ = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id.clone(),
+                "prompt": "Reply with the single word BUDGET.",
+            }),
+        )
+        .await;
+
+    // Post-turn: total_usd > 0, remaining < max.
+    let post = client
+        .call_tool(
+            "chat_budget",
+            serde_json::json!({"chat_id": chat_id.clone()}),
+        )
+        .await;
+    let postbody: serde_json::Value = serde_json::from_str(&post.all_text()).expect("budget json");
+    eprintln!("post-turn budget: {postbody}");
+    let total = postbody["budget"]["total_usd"].as_f64().unwrap_or(0.0);
+    let remaining = postbody["budget"]["remaining_usd"].as_f64().unwrap_or(0.0);
+    assert!(total > 0.0, "expected nonzero spend, got {total}");
+    assert!(
+        (total + remaining - 1.0).abs() < 1e-6,
+        "total + remaining should equal max_usd; total={total} remaining={remaining}"
+    );
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chat_send_stream_emits_progress() {
+    use tower_mcp::context::ServerNotification;
+
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let open = client
+        .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text()).expect("open json");
+    let chat_id = body["chat_id"].as_str().unwrap().to_string();
+
+    // Drain any startup noise so we only count notifications from the stream call.
+    let _ = client.drain_notifications();
+
+    // tower-mcp's Context::report_progress is a no-op unless the client
+    // included a `progressToken` in `_meta`. Call via send_request so we
+    // can supply one.
+    let raw = client
+        .send_request(
+            "tools/call",
+            Some(serde_json::json!({
+                "name": "chat_send_stream",
+                "arguments": {
+                    "chat_id": chat_id.clone(),
+                    "prompt": "Reply with one short sentence describing the color blue.",
+                },
+                "_meta": {"progressToken": "stream-test-1"},
+            })),
+        )
+        .await;
+    let result: tower_mcp::CallToolResult = serde_json::from_value(raw).expect("CallToolResult");
+    let text = result.all_text();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("stream return json");
+    assert!(v["result"].is_string(), "missing result: {text}");
+
+    let notifications = client.drain_notifications();
+    let progress_count = notifications
+        .iter()
+        .filter(|n| matches!(n, ServerNotification::Progress(_)))
+        .count();
+    eprintln!(
+        "got {progress_count} progress notifications (of {} total)",
+        notifications.len()
+    );
+    for n in &notifications {
+        if let ServerNotification::Progress(p) = n {
+            eprintln!("  progress: {p:?}");
+        }
+    }
+    assert!(
+        progress_count > 0,
+        "expected at least one progress event during the stream turn (got {} total notifications)",
+        notifications.len()
+    );
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+}

--- a/crates/claude-server/tests/chat_flow.rs
+++ b/crates/claude-server/tests/chat_flow.rs
@@ -31,6 +31,30 @@ async fn chat_list_starts_empty() {
 }
 
 #[tokio::test]
+async fn chat_open_schema_exposes_working_dir() {
+    // Schema discovery: clients should see `working_dir` as an
+    // optional field on chat_open so per-chat project routing is
+    // discoverable through tools/list.
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let tools = client.list_tools().await;
+    let chat_open = tools
+        .iter()
+        .find(|t| t["name"].as_str() == Some("chat_open"))
+        .expect("chat_open in tools/list");
+    let props = chat_open["inputSchema"]["properties"]
+        .as_object()
+        .expect("input schema properties");
+    assert!(
+        props.contains_key("working_dir"),
+        "chat_open schema should expose working_dir; got {:?}",
+        props.keys().collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
 async fn chat_close_unknown_id_is_a_noop() {
     let router = build_router(cfg()).expect("router built");
     let mut client = TestClient::from_router(router);

--- a/crates/claude-server/tests/chat_flow.rs
+++ b/crates/claude-server/tests/chat_flow.rs
@@ -49,6 +49,29 @@ async fn chat_close_unknown_id_is_a_noop() {
 }
 
 #[tokio::test]
+async fn chats_id_template_unknown_id_errors() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // The template handler errors when the chat_id doesn't exist;
+    // tower-mcp surfaces that as a JSON-RPC error. send_request
+    // doesn't panic on errors (read_resource does), so we use it
+    // here.
+    let err = client
+        .send_request_expect_error(
+            "resources/read",
+            Some(serde_json::json!({"uri": "claude://chats/chat_not_real"})),
+        )
+        .await;
+    let msg = err["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("no chat with id"),
+        "expected unknown-chat error, got {err}"
+    );
+}
+
+#[tokio::test]
 async fn chats_resource_round_trips_empty() {
     let router = build_router(cfg()).expect("router built");
     let mut client = TestClient::from_router(router);
@@ -189,6 +212,65 @@ async fn live_chat_open_send_close_roundtrip() {
 }
 
 #[cfg(feature = "sync-agent-turns")]
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chats_id_template_returns_history() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // Open a chat and run one turn so the template has history.
+    let open = client
+        .call_tool(
+            "chat_open",
+            serde_json::json!({"model": "haiku", "max_cost_usd": 0.5}),
+        )
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text()).expect("open json");
+    let chat_id = body["chat_id"].as_str().unwrap().to_string();
+
+    let fire = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id.clone(),
+                "prompt": "Reply with the word TEMPLATE.",
+            }),
+        )
+        .await;
+    let turn_id = serde_json::from_str::<serde_json::Value>(&fire.all_text()).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let _ = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id, "timeout_secs": 30.0}),
+        )
+        .await;
+
+    // Now read claude://chats/<id> via the template.
+    let uri = format!("claude://chats/{chat_id}");
+    let result = client.read_resource(&uri).await;
+    let text = result
+        .contents
+        .first()
+        .and_then(|c| c.text.clone())
+        .unwrap_or_default();
+    eprintln!("template body: {text}");
+    let v: serde_json::Value = serde_json::from_str(&text).expect("template json");
+    assert_eq!(v["chat_id"].as_str(), Some(chat_id.as_str()));
+    assert!(v["session_id"].is_string(), "session_id missing: {text}");
+    assert_eq!(v["total_turns"], serde_json::json!(1));
+    assert!(v["budget"]["max_usd"].as_f64() == Some(0.5));
+    let turns = v["turns"].as_array().expect("turns array");
+    assert_eq!(turns.len(), 1);
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+}
+
 #[tokio::test]
 #[ignore = "spawns real claude binary"]
 async fn live_chat_budget_tracks_spend() {

--- a/crates/claude-server/tests/history_surface.rs
+++ b/crates/claude-server/tests/history_surface.rs
@@ -1,0 +1,305 @@
+//! Integration tests for the `history` Cargo feature: tools and
+//! resources backed by `claude_wrapper::history` reading
+//! `~/.claude/projects/<slug>/<session_id>.jsonl`.
+//!
+//! Most tests point a tempdir at the server via
+//! `ServerConfig::history_root` and seed it with synthetic JSONL.
+//! One live test (`#[ignore]`) reads the user's real
+//! `~/.claude/projects/`.
+
+#![cfg(feature = "history")]
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use claude_server::{ServerConfig, build_router, registered_tools};
+use tower_mcp::TestClient;
+
+fn write_session(dir: &Path, session_id: &str, lines: &[&str]) -> PathBuf {
+    let path = dir.join(format!("{session_id}.jsonl"));
+    let mut f = fs::File::create(&path).expect("create jsonl");
+    for line in lines {
+        writeln!(f, "{line}").unwrap();
+    }
+    path
+}
+
+fn fixture_root() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let a = tmp.path().join("-Users-josh-Code-projA");
+    fs::create_dir_all(&a).unwrap();
+    write_session(
+        &a,
+        "session-aaa",
+        &[
+            r#"{"type":"user","uuid":"u1","timestamp":"2026-01-01T00:00:00Z","cwd":"/Users/josh/Code/projA","gitBranch":"main","message":{"role":"user","content":"hello"}}"#,
+            r#"{"type":"assistant","uuid":"a1","timestamp":"2026-01-01T00:00:01Z","message":{"role":"assistant","content":"hi"}}"#,
+            r#"{"type":"ai-title","title":"hello world"}"#,
+        ],
+    );
+    write_session(
+        &a,
+        "session-bbb",
+        &[
+            r#"{"type":"user","uuid":"u2","timestamp":"2026-01-02T00:00:00Z","message":{"role":"user","content":"second"}}"#,
+        ],
+    );
+    let b = tmp.path().join("-private-tmp-projB");
+    fs::create_dir_all(&b).unwrap();
+    write_session(
+        &b,
+        "session-ccc",
+        &[
+            r#"{"type":"user","uuid":"u3","timestamp":"2026-02-01T00:00:00Z","message":{"role":"user","content":"x"}}"#,
+            r#"{"type":"assistant","uuid":"a3","timestamp":"2026-02-01T00:00:01Z","message":{"role":"assistant","content":"y"}}"#,
+        ],
+    );
+    tmp
+}
+
+fn cfg_with(root: &Path) -> ServerConfig {
+    ServerConfig {
+        history_root: Some(root.to_path_buf()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn registered_tools_includes_history_surface() {
+    let tmp = fixture_root();
+    let tools = registered_tools(cfg_with(tmp.path())).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    for expected in [
+        "claude_project_list",
+        "claude_session_list",
+        "claude_session_get",
+    ] {
+        assert!(
+            names.contains(&expected),
+            "missing history tool {expected} in {names:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn project_list_returns_synthetic_projects() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_project_list", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    let slugs: Vec<&str> = v["projects"]
+        .as_array()
+        .expect("projects array")
+        .iter()
+        .map(|p| p["slug"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(slugs, ["-Users-josh-Code-projA", "-private-tmp-projB"]);
+    let counts: Vec<u64> = v["projects"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["session_count"].as_u64().unwrap_or(0))
+        .collect();
+    assert_eq!(counts, [2, 1]);
+}
+
+#[tokio::test]
+async fn session_list_with_filter_returns_only_one_project() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "claude_session_list",
+            serde_json::json!({"project_slug": "-private-tmp-projB"}),
+        )
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    let ids: Vec<&str> = v["sessions"]
+        .as_array()
+        .expect("sessions")
+        .iter()
+        .map(|s| s["session_id"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(ids, ["session-ccc"]);
+}
+
+#[tokio::test]
+async fn session_list_no_filter_returns_union() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_session_list", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    let ids: Vec<&str> = v["sessions"]
+        .as_array()
+        .expect("sessions")
+        .iter()
+        .map(|s| s["session_id"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(ids.len(), 3);
+    for id in ["session-aaa", "session-bbb", "session-ccc"] {
+        assert!(ids.contains(&id), "missing {id} in {ids:?}");
+    }
+}
+
+#[tokio::test]
+async fn session_get_returns_typed_entries_in_order() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "claude_session_get",
+            serde_json::json!({"session_id": "session-aaa"}),
+        )
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    assert_eq!(v["session_id"].as_str().unwrap(), "session-aaa");
+    let entries = v["entries"].as_array().expect("entries");
+    assert_eq!(entries.len(), 3, "expected 3 entries: {entries:?}");
+    assert_eq!(entries[0]["kind"].as_str().unwrap(), "user");
+    assert_eq!(entries[1]["kind"].as_str().unwrap(), "assistant");
+    assert_eq!(entries[2]["kind"].as_str().unwrap(), "other");
+    assert_eq!(entries[2]["type_tag"].as_str().unwrap(), "ai-title");
+}
+
+#[tokio::test]
+async fn session_get_unknown_id_errors() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "claude_session_get",
+            serde_json::json!({"session_id": "session-nope"}),
+        )
+        .await;
+    assert!(
+        result.is_error,
+        "expected is_error=true for unknown id; got {}",
+        result.all_text()
+    );
+}
+
+#[tokio::test]
+async fn projects_resource_lists_synthetic_projects() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://projects").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    let slugs: Vec<&str> = v["projects"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["slug"].as_str().unwrap_or_default())
+        .collect();
+    assert!(slugs.contains(&"-Users-josh-Code-projA"));
+    assert!(slugs.contains(&"-private-tmp-projB"));
+}
+
+#[tokio::test]
+async fn project_detail_template_returns_session_list() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client
+        .read_resource("claude://projects/-Users-josh-Code-projA")
+        .await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    assert_eq!(
+        v["project_slug"].as_str().unwrap(),
+        "-Users-josh-Code-projA"
+    );
+    let ids: Vec<&str> = v["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["session_id"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(ids.len(), 2);
+}
+
+#[tokio::test]
+async fn session_detail_template_returns_entries() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://sessions/session-ccc").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    assert_eq!(v["session_id"].as_str().unwrap(), "session-ccc");
+    let entries = v["entries"].as_array().expect("entries");
+    assert!(entries.len() >= 2);
+}
+
+// ---------------------------------------------------------------
+// Live #[ignore] tests -- read the user's real ~/.claude/projects/.
+// Run with: cargo test -p claude-server --features history -- --ignored
+// ---------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "reads the user's real ~/.claude/projects; may be empty in CI"]
+async fn live_project_list_works_against_real_home() {
+    let router = build_router(ServerConfig::default()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_project_list", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    assert!(v["projects"].is_array(), "projects array missing");
+}

--- a/crates/claude-server/tests/http_transport.rs
+++ b/crates/claude-server/tests/http_transport.rs
@@ -1,0 +1,210 @@
+//! HTTP transport smoke tests.
+//!
+//! These drive the axum `Router` returned by
+//! [`tower_mcp::HttpTransport::into_router`] in-process via
+//! [`tower::ServiceExt::oneshot`] -- no socket, no port, no listener.
+//! That keeps the test fast and CI-friendly while exercising the
+//! exact same code path real callers would hit over HTTP.
+//!
+//! No live `claude` invocations here -- the transport is the unit
+//! under test, not the agent.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use claude_server::{ServerConfig, build_router};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tower::ServiceExt;
+use tower_mcp::HttpTransport;
+
+fn cfg() -> ServerConfig {
+    ServerConfig::default()
+}
+
+async fn read_body(resp: axum::http::Response<Body>) -> Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("body is JSON")
+}
+
+fn jsonrpc_request(method: &str, id: u64, params: Value) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+    })
+}
+
+async fn post_jsonrpc(
+    app: &mut axum::Router,
+    body: Value,
+    extra_headers: &[(&str, &str)],
+) -> axum::http::Response<Body> {
+    let mut req = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::ACCEPT, "application/json, text/event-stream");
+    for (k, v) in extra_headers {
+        req = req.header(*k, *v);
+    }
+    let req = req.body(Body::from(body.to_string())).expect("build req");
+    app.clone().oneshot(req).await.expect("oneshot")
+}
+
+#[tokio::test]
+async fn http_initialize_then_tools_list_returns_known_tools() {
+    let router = build_router(cfg()).expect("router built");
+    let mut app = HttpTransport::new(router).into_router();
+
+    // initialize
+    let init_body = jsonrpc_request(
+        "initialize",
+        1,
+        serde_json::json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "http-test", "version": "0.0.1"},
+        }),
+    );
+    let resp = post_jsonrpc(&mut app, init_body, &[]).await;
+    assert_eq!(resp.status(), StatusCode::OK, "initialize status");
+    // Capture the session id the transport assigns so subsequent
+    // requests are routed to the same session.
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .map(|v| v.to_str().expect("ascii").to_string());
+
+    let v = read_body(resp).await;
+    assert!(v["result"]["protocolVersion"].as_str().is_some());
+
+    // initialized notification (required by the lifecycle)
+    let initialized = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+    });
+    let mut headers: Vec<(&str, &str)> = vec![];
+    if let Some(ref sid) = session_id {
+        headers.push(("mcp-session-id", sid));
+    }
+    let _ = post_jsonrpc(&mut app, initialized, &headers).await;
+
+    // tools/list
+    let list_body = jsonrpc_request("tools/list", 2, serde_json::json!({}));
+    let resp = post_jsonrpc(&mut app, list_body, &headers).await;
+    assert_eq!(resp.status(), StatusCode::OK, "tools/list status");
+    let v = read_body(resp).await;
+    let tools = v["result"]["tools"].as_array().expect("tools array");
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+    for expected in [
+        "claude_version",
+        "claude_query",
+        "chat_open",
+        "chat_send",
+        "turn_get",
+        "turn_wait",
+    ] {
+        assert!(names.contains(&expected), "missing {expected} in {names:?}");
+    }
+}
+
+#[tokio::test]
+async fn http_bearer_layer_rejects_missing_token() {
+    use axum::middleware;
+    let router = build_router(cfg()).expect("router built");
+    let mut app = HttpTransport::new(router).into_router();
+    async fn guard(
+        req: axum::extract::Request,
+        next: axum::middleware::Next,
+    ) -> Result<axum::response::Response, axum::http::StatusCode> {
+        let header = req
+            .headers()
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.strip_prefix("Bearer "));
+        match header {
+            Some("secret") => Ok(next.run(req).await),
+            _ => Err(axum::http::StatusCode::UNAUTHORIZED),
+        }
+    }
+    app = app.layer(middleware::from_fn(guard));
+
+    // No auth header: 401.
+    let init_no_auth = jsonrpc_request(
+        "initialize",
+        1,
+        serde_json::json!({"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "x", "version": "0"}}),
+    );
+    let resp = post_jsonrpc(&mut app, init_no_auth.clone(), &[]).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "no token => 401");
+
+    // Wrong token: 401.
+    let resp = post_jsonrpc(
+        &mut app,
+        init_no_auth.clone(),
+        &[("authorization", "Bearer wrong")],
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "bad token => 401");
+
+    // Correct token: 200.
+    let resp = post_jsonrpc(
+        &mut app,
+        init_no_auth,
+        &[("authorization", "Bearer secret")],
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK, "good token => 200");
+}
+
+#[tokio::test]
+async fn http_call_tool_claude_version_returns_envelope() {
+    let router = build_router(cfg()).expect("router built");
+    let mut app = HttpTransport::new(router).into_router();
+
+    // initialize
+    let init = jsonrpc_request(
+        "initialize",
+        1,
+        serde_json::json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "http-test", "version": "0.0.1"},
+        }),
+    );
+    let resp = post_jsonrpc(&mut app, init, &[]).await;
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .map(|v| v.to_str().expect("ascii").to_string())
+        .expect("session id assigned");
+    let _ = read_body(resp).await;
+    let _ = post_jsonrpc(
+        &mut app,
+        serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        &[("mcp-session-id", &session_id)],
+    )
+    .await;
+
+    // tools/call
+    let body = jsonrpc_request(
+        "tools/call",
+        3,
+        serde_json::json!({"name": "claude_version", "arguments": {}}),
+    );
+    let resp = post_jsonrpc(&mut app, body, &[("mcp-session-id", &session_id)]).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = read_body(resp).await;
+    let content = v["result"]["content"].as_array().expect("content");
+    let text = content
+        .iter()
+        .filter_map(|c| c["text"].as_str())
+        .collect::<String>();
+    assert!(text.contains("claude-server"), "body text: {text}");
+}

--- a/crates/claude-server/tests/jobs_surface.rs
+++ b/crates/claude-server/tests/jobs_surface.rs
@@ -1,0 +1,238 @@
+//! Integration tests for the `jobs` Cargo feature: read-only tools
+//! and resources backed by `claude_wrapper::jobs` reading
+//! `~/.claude/jobs/<short_id>/state.json` + `timeline.jsonl`.
+//!
+//! Most tests point a tempdir at the server via
+//! `ServerConfig::jobs_root` and seed it with synthetic state.json
+//! files. One live test (`#[ignore]`) reads the user's real
+//! `~/.claude/jobs/`.
+
+#![cfg(feature = "jobs")]
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use claude_server::{ServerConfig, build_router, registered_tools};
+use tower_mcp::TestClient;
+
+fn write_job(root: &Path, short_id: &str, state_json: &str, timeline_lines: &[&str]) {
+    let dir = root.join(short_id);
+    fs::create_dir_all(&dir).expect("mkdir job dir");
+    fs::write(dir.join("state.json"), state_json).expect("write state.json");
+    if !timeline_lines.is_empty() {
+        let mut f = fs::File::create(dir.join("timeline.jsonl")).expect("create timeline");
+        for line in timeline_lines {
+            writeln!(f, "{line}").unwrap();
+        }
+    }
+}
+
+fn fixture_root() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_job(
+        tmp.path(),
+        "aaaaaaaa",
+        r#"{"state":"done","detail":"42","intent":"meaning of life",
+             "sessionId":"sess-aaa","linkScanPath":"/p/sess-aaa.jsonl",
+             "cwd":"/work","createdAt":"2026-05-15T01:00:00Z",
+             "updatedAt":"2026-05-15T01:01:00Z","name":"meaning",
+             "backend":"daemon","cliVersion":"2.1.143"}"#,
+        &[
+            r#"{"at":"2026-05-15T01:00:30Z","state":"running","detail":"thinking"}"#,
+            r#"{"at":"2026-05-15T01:00:55Z","state":"done","detail":"42","text":"the answer is 42"}"#,
+        ],
+    );
+    write_job(
+        tmp.path(),
+        "bbbbbbbb",
+        r#"{"state":"running","intent":"compute primes","sessionId":"sess-bbb"}"#,
+        &[],
+    );
+    tmp
+}
+
+fn cfg_with(root: &Path) -> ServerConfig {
+    ServerConfig {
+        jobs_root: Some(root.to_path_buf()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn registered_tools_includes_jobs_surface() {
+    let tmp = fixture_root();
+    let tools = registered_tools(cfg_with(tmp.path())).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    for expected in ["claude_job_list", "claude_job_get"] {
+        assert!(
+            names.contains(&expected),
+            "missing jobs tool {expected} in {names:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn job_list_returns_synthetic_jobs_sorted() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_job_list", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    let ids: Vec<&str> = v["jobs"]
+        .as_array()
+        .expect("jobs array")
+        .iter()
+        .map(|j| j["short_id"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(ids, ["aaaaaaaa", "bbbbbbbb"]);
+}
+
+#[tokio::test]
+async fn job_list_carries_typed_metadata() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_job_list", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    let job = v["jobs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|j| j["short_id"] == "aaaaaaaa")
+        .expect("aaaaaaaa entry");
+    assert_eq!(job["state"].as_str().unwrap(), "done");
+    assert_eq!(job["intent"].as_str().unwrap(), "meaning of life");
+    assert_eq!(job["session_id"].as_str().unwrap(), "sess-aaa");
+    assert_eq!(job["session_path"].as_str().unwrap(), "/p/sess-aaa.jsonl");
+    assert_eq!(job["cwd"].as_str().unwrap(), "/work");
+    assert_eq!(job["name"].as_str().unwrap(), "meaning");
+    assert_eq!(job["backend"].as_str().unwrap(), "daemon");
+    assert_eq!(job["cli_version"].as_str().unwrap(), "2.1.143");
+}
+
+#[tokio::test]
+async fn job_get_returns_full_record_with_timeline() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "claude_job_get",
+            serde_json::json!({"short_id": "aaaaaaaa"}),
+        )
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    assert_eq!(v["summary"]["short_id"].as_str().unwrap(), "aaaaaaaa");
+    assert_eq!(v["summary"]["state"].as_str().unwrap(), "done");
+
+    let timeline = v["timeline"].as_array().expect("timeline array");
+    assert_eq!(timeline.len(), 2);
+    assert_eq!(timeline[0]["state"].as_str().unwrap(), "running");
+    assert_eq!(timeline[1]["state"].as_str().unwrap(), "done");
+    assert_eq!(timeline[1]["text"].as_str().unwrap(), "the answer is 42");
+
+    // raw_state preserved for forward-compat drilling.
+    assert!(v["raw_state"].is_object());
+    assert_eq!(
+        v["raw_state"]["intent"].as_str().unwrap(),
+        "meaning of life"
+    );
+}
+
+#[tokio::test]
+async fn job_get_unknown_short_id_errors() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_job_get", serde_json::json!({"short_id": "nope"}))
+        .await;
+    assert!(
+        result.is_error,
+        "expected error for unknown short_id; got {}",
+        result.all_text()
+    );
+}
+
+#[tokio::test]
+async fn jobs_resource_lists_synthetic_jobs() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://jobs").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    let ids: Vec<&str> = v["jobs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|j| j["short_id"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(ids, ["aaaaaaaa", "bbbbbbbb"]);
+}
+
+#[tokio::test]
+async fn job_detail_template_returns_full_record() {
+    let tmp = fixture_root();
+    let router = build_router(cfg_with(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://jobs/aaaaaaaa").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    assert_eq!(v["summary"]["short_id"].as_str().unwrap(), "aaaaaaaa");
+    assert_eq!(v["timeline"].as_array().unwrap().len(), 2);
+}
+
+// ---------------------------------------------------------------
+// Live #[ignore] test against the user's real ~/.claude/jobs/.
+// Run with: cargo test -p claude-server --features jobs -- --ignored
+// ---------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "reads the user's real ~/.claude/jobs; may be empty in CI"]
+async fn live_job_list_works_against_real_home() {
+    let router = build_router(ServerConfig::default()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_job_list", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    assert!(v["jobs"].is_array(), "jobs array missing");
+}

--- a/crates/claude-server/tests/metrics.rs
+++ b/crates/claude-server/tests/metrics.rs
@@ -1,0 +1,104 @@
+//! Metrics counter + tool/resource surface tests.
+//!
+//! Counter logic exercised directly against [`crate::turns::Metrics`]
+//! via the registry-test path; tool/resource shape exercised through
+//! [`tower_mcp::TestClient`].
+
+use claude_server::{ServerConfig, build_router};
+use tower_mcp::TestClient;
+
+fn cfg() -> ServerConfig {
+    ServerConfig::default()
+}
+
+#[tokio::test]
+async fn metrics_summary_starts_zero() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let r = client
+        .call_tool("metrics_summary", serde_json::json!({}))
+        .await;
+    let text = r.all_text();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json");
+    assert_eq!(v["turns_fired"], serde_json::json!(0));
+    assert_eq!(v["turns_done"], serde_json::json!(0));
+    assert_eq!(v["turns_failed"], serde_json::json!(0));
+    assert_eq!(v["turns_cancelled"], serde_json::json!(0));
+    assert_eq!(v["in_flight"], serde_json::json!(0));
+    assert_eq!(v["total_cost_usd"], serde_json::json!(0.0));
+}
+
+#[tokio::test]
+async fn metrics_resource_starts_zero() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let r = client.read_resource("claude://metrics").await;
+    let text = r
+        .contents
+        .first()
+        .and_then(|c| c.text.clone())
+        .unwrap_or_default();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json");
+    assert_eq!(v["turns_fired"], serde_json::json!(0));
+    assert_eq!(v["in_flight"], serde_json::json!(0));
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_metrics_increment_through_full_turn() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    // Fire one async claude_query and let it settle.
+    let fire = client
+        .call_tool(
+            "claude_query",
+            serde_json::json!({
+                "prompt": "Reply with the word METRIC.",
+                "model": "haiku",
+            }),
+        )
+        .await;
+    let turn_id = serde_json::from_str::<serde_json::Value>(&fire.all_text()).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // While running, in_flight should be 1.
+    let mid = client
+        .call_tool("metrics_summary", serde_json::json!({}))
+        .await;
+    let mv: serde_json::Value = serde_json::from_str(&mid.all_text()).expect("json");
+    eprintln!("mid: {mv}");
+    assert_eq!(mv["turns_fired"], serde_json::json!(1));
+    // in_flight could already be 0 if the turn was very fast; both ok
+    let in_flight = mv["in_flight"].as_i64().unwrap_or(-1);
+    assert!(
+        (0..=1).contains(&in_flight),
+        "in_flight should be 0 or 1 mid-turn, got {in_flight}"
+    );
+
+    let _ = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id, "timeout_secs": 30.0}),
+        )
+        .await;
+
+    // After settle: in_flight back to 0, turns_done == 1, cost > 0.
+    let post = client
+        .call_tool("metrics_summary", serde_json::json!({}))
+        .await;
+    let pv: serde_json::Value = serde_json::from_str(&post.all_text()).expect("json");
+    eprintln!("post: {pv}");
+    assert_eq!(pv["turns_fired"], serde_json::json!(1));
+    assert_eq!(pv["turns_done"], serde_json::json!(1));
+    assert_eq!(pv["in_flight"], serde_json::json!(0));
+    let cost = pv["total_cost_usd"].as_f64().unwrap_or(0.0);
+    assert!(cost > 0.0, "expected nonzero cumulative cost, got {cost}");
+}

--- a/crates/claude-server/tests/mutations_gate.rs
+++ b/crates/claude-server/tests/mutations_gate.rs
@@ -1,0 +1,66 @@
+//! Mutating-tool gating tests. We deliberately do NOT live-test the
+//! actual mutations here -- they would alter the user's claude
+//! installation (MCP servers, plugins, marketplaces). The gating is
+//! the contract: with `policy.allow_mutations = false` the model
+//! literally cannot discover them.
+
+use claude_server::{ServerConfig, ServerPolicy, registered_tools};
+
+fn cfg_with_policy(allow: bool) -> ServerConfig {
+    ServerConfig {
+        policy: ServerPolicy {
+            allow_mutations: allow,
+        },
+        ..Default::default()
+    }
+}
+
+const MUTATING_TOOLS: &[&str] = &[
+    "claude_mcp_add",
+    "claude_mcp_add_json",
+    "claude_mcp_remove",
+    "claude_plugin_install",
+    "claude_plugin_uninstall",
+    "claude_plugin_enable",
+    "claude_plugin_disable",
+    "claude_plugin_update",
+    "claude_marketplace_add",
+    "claude_marketplace_remove",
+    "claude_marketplace_update",
+];
+
+#[test]
+fn mutations_off_omits_all_mutating_tools() {
+    let tools = registered_tools(cfg_with_policy(false)).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    for forbidden in MUTATING_TOOLS {
+        assert!(
+            !names.contains(forbidden),
+            "tool {forbidden} should NOT be registered with allow_mutations=false; got {names:?}"
+        );
+    }
+}
+
+#[test]
+fn mutations_on_registers_all_mutating_tools() {
+    let tools = registered_tools(cfg_with_policy(true)).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    for expected in MUTATING_TOOLS {
+        assert!(
+            names.contains(expected),
+            "tool {expected} should be registered with allow_mutations=true; got {names:?}"
+        );
+    }
+}
+
+#[test]
+fn mutations_default_is_off() {
+    let tools = registered_tools(ServerConfig::default()).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    for forbidden in MUTATING_TOOLS {
+        assert!(
+            !names.contains(forbidden),
+            "default policy should not register {forbidden}; got {names:?}"
+        );
+    }
+}

--- a/crates/claude-server/tests/mutations_gate.rs
+++ b/crates/claude-server/tests/mutations_gate.rs
@@ -28,6 +28,7 @@ const MUTATING_TOOLS: &[&str] = &[
     "claude_mcp_remove",
     "claude_plugin_install",
     "claude_plugin_uninstall",
+    "claude_plugin_prune",
     "claude_plugin_enable",
     "claude_plugin_disable",
     "claude_plugin_update",

--- a/crates/claude-server/tests/mutations_gate.rs
+++ b/crates/claude-server/tests/mutations_gate.rs
@@ -3,6 +3,13 @@
 //! installation (MCP servers, plugins, marketplaces). The gating is
 //! the contract: with `policy.allow_mutations = false` the model
 //! literally cannot discover them.
+//!
+//! Only meaningful when the `mutations` Cargo feature is enabled.
+//! Without it the mutations module isn't compiled at all -- the
+//! "off" assertions still hold trivially, but `mutations_on_...`
+//! has no path that registers tools to assert against.
+
+#![cfg(feature = "mutations")]
 
 use claude_server::{ServerConfig, ServerPolicy, registered_tools};
 

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -36,6 +36,7 @@ fn registered_tools_includes_core_l2_surface() {
         "claude_doctor",
         // L2.5 chat
         "chat_open",
+        "chat_send",
         "chat_send_sync",
         "chat_send_stream_sync",
         "chat_list",

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -48,6 +48,8 @@ fn registered_tools_includes_core_l2_surface() {
         "turn_wait",
         "turn_cancel",
         "turn_list",
+        // Slash-command tools (always-on)
+        "chat_compact",
     ];
     #[cfg(feature = "sync-agent-turns")]
     expected.extend([

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -44,6 +44,11 @@ fn registered_tools_includes_core_l2_surface() {
         "chat_interrupt",
         "chat_budget",
         "chat_close",
+        // Turn registry
+        "turn_get",
+        "turn_wait",
+        "turn_cancel",
+        "turn_list",
     ] {
         assert!(
             names.contains(&expected),

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -34,6 +34,7 @@ fn registered_tools_includes_core_l2_surface() {
         "claude_marketplace_list",
         "claude_auto_mode_config",
         "claude_auto_mode_defaults",
+        "claude_auto_mode_critique",
         "claude_doctor",
         // L2.5 chat (always-on)
         "chat_open",

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -1,0 +1,191 @@
+//! End-to-end smoke tests for the registered MCP surface. These run
+//! the router in-process via [`tower_mcp::TestClient`] -- no
+//! subprocess, no network, no `claude` binary required for tests
+//! that don't actually call out.
+//!
+//! Tests that hit a real `claude` binary are gated behind `#[ignore]`
+//! so they don't run by default; run with
+//! `cargo test -p claude-server -- --ignored`.
+
+use claude_server::{ServerConfig, build_router, registered_tools};
+use tower_mcp::TestClient;
+
+fn cfg() -> ServerConfig {
+    ServerConfig::default()
+}
+
+#[test]
+fn registered_tools_includes_core_l2_surface() {
+    let tools = registered_tools(cfg()).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+
+    for expected in [
+        // L2 passthrough
+        "claude_version",
+        "claude_cli_version",
+        "claude_query",
+        "claude_agents",
+        "claude_auth_status",
+        "claude_mcp_list",
+        "claude_mcp_get",
+        "claude_plugin_list",
+        "claude_plugin_validate",
+        "claude_marketplace_list",
+        "claude_auto_mode_config",
+        "claude_auto_mode_defaults",
+        "claude_doctor",
+        // L2.5 chat
+        "chat_open",
+        "chat_send",
+        "chat_send_stream",
+        "chat_list",
+        "chat_history",
+        "chat_interrupt",
+        "chat_budget",
+        "chat_close",
+    ] {
+        assert!(
+            names.contains(&expected),
+            "missing tool {expected} in {names:?}"
+        );
+    }
+}
+
+#[test]
+fn registered_tools_returns_sorted_unique_names() {
+    let tools = registered_tools(cfg()).expect("config built");
+    let names: Vec<String> = tools.iter().map(|t| t.name.clone()).collect();
+
+    let mut sorted = names.clone();
+    sorted.sort();
+    assert_eq!(names, sorted, "tools should come back sorted by name");
+
+    let mut deduped = names.clone();
+    deduped.dedup();
+    assert_eq!(names.len(), deduped.len(), "tool names should be unique");
+}
+
+#[tokio::test]
+async fn router_tools_list_matches_registered_tools() {
+    let registered = registered_tools(cfg()).expect("config built");
+    let router = build_router(cfg()).expect("router built");
+
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+    let listed = client.list_tools().await;
+
+    let mut listed_names: Vec<String> = listed
+        .iter()
+        .map(|t| t["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    let mut registered_names: Vec<String> = registered.iter().map(|t| t.name.clone()).collect();
+    listed_names.sort();
+    registered_names.sort();
+
+    assert_eq!(listed_names, registered_names);
+}
+
+#[tokio::test]
+async fn claude_version_returns_crate_metadata() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_version", serde_json::json!({}))
+        .await;
+    let text = result.all_text();
+    assert!(text.contains("claude-server"), "result: {text}");
+    assert!(text.contains(env!("CARGO_PKG_VERSION")), "result: {text}");
+}
+
+#[tokio::test]
+async fn resources_list_contains_config_and_tools() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let resources = client.list_resources().await;
+    let uris: Vec<&str> = resources
+        .iter()
+        .map(|r| r["uri"].as_str().unwrap_or_default())
+        .collect();
+    assert!(uris.contains(&"claude://config"), "uris: {uris:?}");
+    assert!(uris.contains(&"claude://tools"), "uris: {uris:?}");
+    assert!(uris.contains(&"claude://chats"), "uris: {uris:?}");
+}
+
+#[tokio::test]
+async fn prompts_list_contains_describe_server() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let prompts = client.list_prompts().await;
+    let names: Vec<&str> = prompts
+        .iter()
+        .map(|p| p["name"].as_str().unwrap_or_default())
+        .collect();
+    assert!(names.contains(&"describe_server"), "names: {names:?}");
+}
+
+// ---------------------------------------------------------------
+// Live #[ignore] tests -- exercise the real `claude` binary on PATH.
+// Run with: cargo test -p claude-server -- --ignored
+// ---------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "spawns real claude binary; run with --ignored"]
+async fn live_claude_cli_version_returns_three_numbers() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_cli_version", serde_json::json!({}))
+        .await;
+    let text = result.all_text();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    assert!(v["major"].is_u64(), "major: {text}");
+    assert!(v["minor"].is_u64(), "minor: {text}");
+    assert!(v["patch"].is_u64(), "patch: {text}");
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary; run with --ignored"]
+async fn live_claude_query_simple_prompt() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "claude_query",
+            serde_json::json!({
+                "prompt": "Reply with exactly the word OK and nothing else.",
+                "model": "haiku",
+            }),
+        )
+        .await;
+    let text = result.all_text();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    assert!(v["result"].is_string(), "result missing: {text}");
+    assert!(v["session_id"].is_string(), "session_id missing: {text}");
+    let r = v["result"].as_str().unwrap_or_default();
+    assert!(r.contains("OK"), "expected OK in result, got {r:?}");
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary; run with --ignored"]
+async fn live_claude_mcp_list_returns_output() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_mcp_list", serde_json::json!({}))
+        .await;
+    let text = result.all_text();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    assert!(v["exit_code"].is_number(), "exit_code missing: {text}");
+}

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -173,6 +173,93 @@ async fn config_resource_includes_auth_strategy() {
 }
 
 #[tokio::test]
+async fn config_resource_includes_cli_version_block() {
+    // The server bakes in a tested_cli_version_range; the
+    // claude://config resource exposes it under cli_version.
+    // Status is best-effort -- absent if the binary fetch fails
+    // (e.g., no `claude` on PATH in CI). Range should always be
+    // present.
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://config").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("config json");
+    assert!(
+        v["cli_version"].is_object(),
+        "cli_version block missing: {v}"
+    );
+    let range = &v["cli_version"]["tested_range"];
+    assert!(range.is_object(), "tested_range missing: {v}");
+    assert!(range["min"]["major"].is_number());
+    assert!(range["max"]["major"].is_number());
+}
+
+// ---------------------------------------------------------------
+// Live #[ignore] tests for the tested-cli-range surface.
+// Run with: cargo test -p claude-server -- --ignored
+// ---------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "spawns real claude --version"]
+async fn live_config_resource_status_classifies_real_cli() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://config").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("config json");
+    let status = &v["cli_version"]["status"];
+    assert!(status.is_object(), "live status missing: {v}");
+    let kind = status["status"].as_str().unwrap_or("");
+    assert!(
+        matches!(kind, "tested" | "newer_untested" | "older_than_minimum"),
+        "unknown status kind {kind:?}: {v}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude doctor; can be slow (3+ minutes)"]
+async fn live_doctor_includes_cli_version_status_field() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_doctor", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json");
+    assert!(
+        v["cli_version_status"].is_object(),
+        "doctor missing cli_version_status: {v}"
+    );
+    assert!(
+        v["tested_cli_version_range"].is_object(),
+        "doctor missing tested_cli_version_range: {v}"
+    );
+}
+
+#[tokio::test]
 async fn claude_version_returns_crate_metadata() {
     let router = build_router(cfg()).expect("router built");
     let mut client = TestClient::from_router(router);

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -23,6 +23,7 @@ fn registered_tools_includes_core_l2_surface() {
         // L2 passthrough
         "claude_version",
         "claude_cli_version",
+        "claude_query",
         "claude_query_sync",
         "claude_agents",
         "claude_auth_status",

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -27,6 +27,7 @@ fn registered_tools_includes_core_l2_surface() {
         "claude_query",
         "claude_agents",
         "claude_auth_status",
+        "claude_auth_strategy",
         "claude_mcp_list",
         "claude_mcp_get",
         "claude_plugin_list",
@@ -117,6 +118,59 @@ async fn router_tools_list_matches_registered_tools() {
     registered_names.sort();
 
     assert_eq!(listed_names, registered_names);
+}
+
+#[tokio::test]
+async fn claude_auth_strategy_returns_summary_shape() {
+    // Doesn't assert a specific strategy -- the test environment may
+    // have any of them set. Just shape: the keys exist and `strategy`
+    // is one of the documented values.
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("claude_auth_strategy", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json body");
+    let strat = v["strategy"].as_str().expect("strategy string");
+    assert!(
+        matches!(
+            strat,
+            "bedrock" | "vertex" | "api_key" | "oauth_token" | "subscription"
+        ),
+        "unknown strategy {strat:?}"
+    );
+    for key in [
+        "has_anthropic_api_key",
+        "has_oauth_token",
+        "bedrock_enabled",
+        "vertex_enabled",
+    ] {
+        assert!(v[key].is_boolean(), "missing/non-bool {key}: {v}");
+    }
+}
+
+#[tokio::test]
+async fn config_resource_includes_auth_strategy() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://config").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("config json");
+    assert!(v["auth"].is_object(), "auth block missing: {v}");
+    assert!(v["auth"]["strategy"].is_string());
 }
 
 #[tokio::test]

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -150,7 +150,7 @@ async fn resources_list_contains_config_and_tools() {
 }
 
 #[tokio::test]
-async fn prompts_list_contains_describe_server() {
+async fn prompts_list_contains_describe_server_and_usage_guide() {
     let router = build_router(cfg()).expect("router built");
     let mut client = TestClient::from_router(router);
     client.initialize().await;
@@ -160,7 +160,56 @@ async fn prompts_list_contains_describe_server() {
         .iter()
         .map(|p| p["name"].as_str().unwrap_or_default())
         .collect();
-    assert!(names.contains(&"describe_server"), "names: {names:?}");
+    for expected in ["describe_server", "usage_guide"] {
+        assert!(
+            names.contains(&expected),
+            "missing prompt {expected} in {names:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn usage_guide_prompt_returns_handbook() {
+    // The usage_guide prompt is the agent-facing handbook. Sanity-
+    // check shape (substantial body, mentions the design rules and
+    // the most important tools/resources) so a fresh agent that
+    // requests it gets useful onboarding context, not a stub.
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .get_prompt("usage_guide", std::collections::HashMap::new())
+        .await;
+    let text: String = result
+        .messages
+        .iter()
+        .filter_map(|m| {
+            serde_json::to_value(&m.content).ok().and_then(|v| {
+                v.get("text")
+                    .and_then(|t| t.as_str())
+                    .map(|s| s.to_string())
+            })
+        })
+        .collect();
+    assert!(
+        text.len() > 1000,
+        "usage_guide should be substantial; got {} bytes",
+        text.len()
+    );
+    for needle in [
+        "async-by-default",
+        "chat_send",
+        "claude_query",
+        "turn_wait",
+        "claude://chats",
+        "max_cost_usd",
+    ] {
+        assert!(
+            text.to_lowercase().contains(&needle.to_lowercase()),
+            "usage_guide should mention {needle}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -25,7 +25,6 @@ fn registered_tools_includes_core_l2_surface() {
         "claude_version",
         "claude_cli_version",
         "claude_query",
-        "claude_agents",
         "claude_auth_status",
         "claude_auth_strategy",
         "claude_mcp_list",

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -50,6 +50,8 @@ fn registered_tools_includes_core_l2_surface() {
         "turn_list",
         // Slash-command tools (always-on)
         "chat_compact",
+        // Observability (always-on)
+        "metrics_summary",
     ];
     #[cfg(feature = "sync-agent-turns")]
     expected.extend([

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -23,7 +23,7 @@ fn registered_tools_includes_core_l2_surface() {
         // L2 passthrough
         "claude_version",
         "claude_cli_version",
-        "claude_query",
+        "claude_query_sync",
         "claude_agents",
         "claude_auth_status",
         "claude_mcp_list",
@@ -36,8 +36,8 @@ fn registered_tools_includes_core_l2_surface() {
         "claude_doctor",
         // L2.5 chat
         "chat_open",
-        "chat_send",
-        "chat_send_stream",
+        "chat_send_sync",
+        "chat_send_stream_sync",
         "chat_list",
         "chat_history",
         "chat_interrupt",
@@ -153,14 +153,14 @@ async fn live_claude_cli_version_returns_three_numbers() {
 
 #[tokio::test]
 #[ignore = "spawns real claude binary; run with --ignored"]
-async fn live_claude_query_simple_prompt() {
+async fn live_claude_query_sync_simple_prompt() {
     let router = build_router(cfg()).expect("router built");
     let mut client = TestClient::from_router(router);
     client.initialize().await;
 
     let result = client
         .call_tool(
-            "claude_query",
+            "claude_query_sync",
             serde_json::json!({
                 "prompt": "Reply with exactly the word OK and nothing else.",
                 "model": "haiku",

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -19,12 +19,12 @@ fn registered_tools_includes_core_l2_surface() {
     let tools = registered_tools(cfg()).expect("config built");
     let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
 
-    for expected in [
-        // L2 passthrough
+    #[cfg_attr(not(feature = "sync-agent-turns"), allow(unused_mut))]
+    let mut expected: Vec<&str> = vec![
+        // L2 passthrough (always-on)
         "claude_version",
         "claude_cli_version",
         "claude_query",
-        "claude_query_sync",
         "claude_agents",
         "claude_auth_status",
         "claude_mcp_list",
@@ -35,25 +35,47 @@ fn registered_tools_includes_core_l2_surface() {
         "claude_auto_mode_config",
         "claude_auto_mode_defaults",
         "claude_doctor",
-        // L2.5 chat
+        // L2.5 chat (always-on)
         "chat_open",
         "chat_send",
-        "chat_send_sync",
-        "chat_send_stream_sync",
         "chat_list",
         "chat_history",
         "chat_interrupt",
         "chat_budget",
         "chat_close",
-        // Turn registry
+        // Turn registry (always-on)
         "turn_get",
         "turn_wait",
         "turn_cancel",
         "turn_list",
-    ] {
+    ];
+    #[cfg(feature = "sync-agent-turns")]
+    expected.extend([
+        "claude_query_sync",
+        "chat_send_sync",
+        "chat_send_stream_sync",
+    ]);
+    for expected in expected {
         assert!(
             names.contains(&expected),
             "missing tool {expected} in {names:?}"
+        );
+    }
+}
+
+#[cfg(not(feature = "sync-agent-turns"))]
+#[test]
+fn registered_tools_omits_sync_agent_turn_tools_when_feature_off() {
+    let tools = registered_tools(cfg()).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    for forbidden in [
+        "claude_query_sync",
+        "chat_send_sync",
+        "chat_send_stream_sync",
+    ] {
+        assert!(
+            !names.contains(&forbidden),
+            "tool {forbidden} should NOT be registered with sync-agent-turns disabled; got {names:?}"
         );
     }
 }
@@ -158,6 +180,7 @@ async fn live_claude_cli_version_returns_three_numbers() {
     assert!(v["patch"].is_u64(), "patch: {text}");
 }
 
+#[cfg(feature = "sync-agent-turns")]
 #[tokio::test]
 #[ignore = "spawns real claude binary; run with --ignored"]
 async fn live_claude_query_sync_simple_prompt() {

--- a/crates/claude-server/tests/registered_surface.rs
+++ b/crates/claude-server/tests/registered_surface.rs
@@ -30,6 +30,7 @@ fn registered_tools_includes_core_l2_surface() {
         "claude_mcp_list",
         "claude_mcp_get",
         "claude_plugin_list",
+        "claude_plugin_details",
         "claude_plugin_validate",
         "claude_marketplace_list",
         "claude_auto_mode_config",

--- a/crates/claude-server/tests/resource_updates.rs
+++ b/crates/claude-server/tests/resource_updates.rs
@@ -1,0 +1,163 @@
+//! Tests for `notifications/resources/updated` firing on
+//! `claude://chats/{id}` after a turn settles.
+//!
+//! Approach: build the router with our own notification channel
+//! (via `build_router_with_notification_sender`), drive tools via
+//! `TestClient::from_router`, and drain notifications from the rx
+//! we own. TestClient overrides the router-internal sender, but
+//! ServerState's notifier is the channel we set up at build time
+//! (independent of TestClient's), so chat-worker firings land in
+//! our rx as expected.
+
+use claude_server::{ServerConfig, build_router_with_notification_sender, notification_channel};
+use tower_mcp::TestClient;
+use tower_mcp::context::{NotificationReceiver, ServerNotification};
+
+fn cfg() -> ServerConfig {
+    ServerConfig::default()
+}
+
+fn drain(rx: &mut NotificationReceiver) -> Vec<ServerNotification> {
+    let mut out = Vec::new();
+    while let Ok(n) = rx.try_recv() {
+        out.push(n);
+    }
+    out
+}
+
+#[tokio::test]
+async fn build_router_with_notification_sender_does_not_panic() {
+    // Smoke: the new entry point builds a working router.
+    let (tx, _rx) = notification_channel(256);
+    let router = build_router_with_notification_sender(cfg(), tx).expect("router built");
+    let mut client = TestClient::from_router(router);
+    let _ = client.initialize().await;
+    let tools = client.list_tools().await;
+    assert!(!tools.is_empty());
+}
+
+#[tokio::test]
+async fn unknown_chat_id_does_not_fire_resource_update() {
+    // chat_send to a non-existent chat fails synchronously without
+    // registering a turn -- nothing should hit the notifier.
+    let (tx, mut rx) = notification_channel(256);
+    let router = build_router_with_notification_sender(cfg(), tx).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+    let _ = drain(&mut rx); // clear any startup notifications
+
+    let _ = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({"chat_id": "nope", "prompt": "hi"}),
+        )
+        .await;
+
+    let notifs = drain(&mut rx);
+    let updates: Vec<&ServerNotification> = notifs
+        .iter()
+        .filter(|n| matches!(n, ServerNotification::ResourceUpdated { .. }))
+        .collect();
+    assert!(
+        updates.is_empty(),
+        "no resource updates should fire for unknown chat; got {updates:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chat_send_fires_resource_update_for_chats_id() {
+    let (tx, mut rx) = notification_channel(256);
+    let router = build_router_with_notification_sender(cfg(), tx).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let open = client
+        .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text()).expect("open json");
+    let chat_id = body["chat_id"].as_str().unwrap().to_string();
+
+    // Drain any startup / chat_open list-changed notifications.
+    let _ = drain(&mut rx);
+
+    let fire = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id.clone(),
+                "prompt": "Reply with the word UPDATED.",
+            }),
+        )
+        .await;
+    let turn_id = serde_json::from_str::<serde_json::Value>(&fire.all_text()).unwrap()["turn_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Wait for the turn to settle.
+    let _ = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id, "timeout_secs": 30.0}),
+        )
+        .await;
+
+    let notifs = drain(&mut rx);
+    eprintln!("got {} notifications", notifs.len());
+    let expected_uri = format!("claude://chats/{chat_id}");
+    let saw_update = notifs.iter().any(|n| {
+        matches!(
+            n,
+            ServerNotification::ResourceUpdated { uri } if uri == &expected_uri
+        )
+    });
+    assert!(
+        saw_update,
+        "expected ResourceUpdated for {expected_uri}; got {notifs:?}"
+    );
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chat_open_and_close_fire_list_changed() {
+    let (tx, mut rx) = notification_channel(256);
+    let router = build_router_with_notification_sender(cfg(), tx).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+    let _ = drain(&mut rx);
+
+    let open = client
+        .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text()).expect("open json");
+    let chat_id = body["chat_id"].as_str().unwrap().to_string();
+
+    let after_open = drain(&mut rx);
+    let opens = after_open
+        .iter()
+        .filter(|n| matches!(n, ServerNotification::ResourcesListChanged))
+        .count();
+    assert!(
+        opens >= 1,
+        "expected ResourcesListChanged from chat_open; got {after_open:?}"
+    );
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+
+    let after_close = drain(&mut rx);
+    let closes = after_close
+        .iter()
+        .filter(|n| matches!(n, ServerNotification::ResourcesListChanged))
+        .count();
+    assert!(
+        closes >= 1,
+        "expected ResourcesListChanged from chat_close; got {after_close:?}"
+    );
+}

--- a/crates/claude-server/tests/slash_commands.rs
+++ b/crates/claude-server/tests/slash_commands.rs
@@ -1,0 +1,102 @@
+//! Slash-command tests. The interesting question is "does the
+//! slash command actually take effect when written to a stream-json
+//! input session?" Most assertions are necessarily soft because we
+//! don't fully control what `claude` does with `/compact` etc.
+//!
+//! Live tests gated `#[ignore]`. Run with `--ignored`.
+
+use claude_server::{ServerConfig, build_router};
+use tower_mcp::TestClient;
+
+fn cfg() -> ServerConfig {
+    ServerConfig::default()
+}
+
+#[tokio::test]
+async fn chat_compact_unknown_chat_errors_synchronously() {
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "chat_compact",
+            serde_json::json!({"chat_id": "chat_does_not_exist"}),
+        )
+        .await;
+    let text = result.all_text();
+    assert!(
+        text.contains("no chat with id"),
+        "expected unknown-chat error, got {text}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn live_chat_compact_settles_to_terminal() {
+    // We can't reliably assert what /compact returns -- claude's
+    // compaction prompt produces variable output. We CAN assert
+    // that the slash command is accepted by the stream-json input
+    // mode at all: the turn settles to a terminal status (not
+    // running, not failed-with-protocol-error).
+
+    let router = build_router(cfg()).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let open = client
+        .call_tool("chat_open", serde_json::json!({"model": "haiku"}))
+        .await;
+    let body: serde_json::Value = serde_json::from_str(&open.all_text()).expect("open json");
+    let chat_id = body["chat_id"].as_str().unwrap().to_string();
+
+    // Seed a turn so there's something to compact.
+    let _ = client
+        .call_tool(
+            "chat_send",
+            serde_json::json!({
+                "chat_id": chat_id.clone(),
+                "prompt": "Reply with the word SEED.",
+            }),
+        )
+        .await;
+    // Wait for the seed turn to settle so /compact has history.
+    let _ = client.call_tool("turn_list", serde_json::json!({})).await;
+
+    let fire = client
+        .call_tool(
+            "chat_compact",
+            serde_json::json!({"chat_id": chat_id.clone()}),
+        )
+        .await;
+    let fbody: serde_json::Value =
+        serde_json::from_str(&fire.all_text()).expect("compact fire json");
+    let turn_id = fbody["turn_id"].as_str().expect("turn_id").to_string();
+
+    let waited = client
+        .call_tool(
+            "turn_wait",
+            serde_json::json!({"turn_id": turn_id.clone(), "timeout_secs": 60.0}),
+        )
+        .await;
+    let wv: serde_json::Value = serde_json::from_str(&waited.all_text()).expect("wait json");
+    eprintln!("compact settled: {wv}");
+    let status = wv["status"].as_str().unwrap_or_default();
+    // We accept any terminal status -- if /compact isn't supported
+    // through stream-json on this CLI version we want the test to
+    // log that loudly rather than green-pass silently.
+    assert!(
+        ["done", "failed", "cancelled"].contains(&status),
+        "expected terminal status, got {status}"
+    );
+    if status == "failed" {
+        eprintln!(
+            "/compact failed: {}",
+            wv["error"].as_str().unwrap_or("<no error>")
+        );
+    }
+
+    let _ = client
+        .call_tool("chat_close", serde_json::json!({"chat_id": chat_id}))
+        .await;
+}

--- a/crates/claude-server/tests/surfaces_runtime_gate.rs
+++ b/crates/claude-server/tests/surfaces_runtime_gate.rs
@@ -1,0 +1,234 @@
+//! Runtime surface gate tests. Verifies that the `[surfaces]`
+//! ServerConfig block correctly disables individual surfaces
+//! without recompiling, layered on top of the existing Cargo
+//! feature gates.
+
+#![cfg(feature = "full")]
+
+use claude_server::config::SurfacesConfig;
+use claude_server::{ServerConfig, registered_tools};
+
+fn cfg_with_surfaces(surfaces: SurfacesConfig) -> ServerConfig {
+    ServerConfig {
+        surfaces,
+        ..Default::default()
+    }
+}
+
+fn tool_names(cfg: ServerConfig) -> Vec<String> {
+    registered_tools(cfg)
+        .expect("registered")
+        .into_iter()
+        .map(|t| t.name)
+        .collect()
+}
+
+#[test]
+fn default_surfaces_all_on() {
+    let names = tool_names(ServerConfig::default());
+    for expected in [
+        "claude_query",
+        "chat_open",
+        "turn_get",
+        "metrics_summary",
+        "agent_list",
+        "claude_job_list",
+        "worktree_list",
+        "claude_project_list",
+    ] {
+        assert!(
+            names.contains(&expected.to_string()),
+            "missing {expected} from default surface; got {names:?}"
+        );
+    }
+}
+
+#[test]
+fn disable_artifacts_drops_agent_tools() {
+    let surfaces = SurfacesConfig {
+        enable_artifacts: false,
+        ..Default::default()
+    };
+    let names = tool_names(cfg_with_surfaces(surfaces));
+    for forbidden in ["agent_list", "agent_get"] {
+        assert!(
+            !names.contains(&forbidden.to_string()),
+            "{forbidden} leaked through disabled artifacts gate; got {names:?}"
+        );
+    }
+    // sibling surfaces stay
+    assert!(names.contains(&"claude_query".to_string()));
+    assert!(names.contains(&"chat_open".to_string()));
+}
+
+#[test]
+fn disable_jobs_drops_job_tools() {
+    let surfaces = SurfacesConfig {
+        enable_jobs: false,
+        ..Default::default()
+    };
+    let names = tool_names(cfg_with_surfaces(surfaces));
+    for forbidden in ["claude_job_list", "claude_job_get"] {
+        assert!(
+            !names.contains(&forbidden.to_string()),
+            "{forbidden} leaked"
+        );
+    }
+}
+
+#[test]
+fn disable_history_drops_session_tools() {
+    let surfaces = SurfacesConfig {
+        enable_history: false,
+        ..Default::default()
+    };
+    let names = tool_names(cfg_with_surfaces(surfaces));
+    for forbidden in [
+        "claude_project_list",
+        "claude_session_list",
+        "claude_session_get",
+    ] {
+        assert!(
+            !names.contains(&forbidden.to_string()),
+            "{forbidden} leaked"
+        );
+    }
+}
+
+#[test]
+fn disable_worktrees_drops_worktree_tool() {
+    let surfaces = SurfacesConfig {
+        enable_worktrees: false,
+        ..Default::default()
+    };
+    let names = tool_names(cfg_with_surfaces(surfaces));
+    assert!(!names.contains(&"worktree_list".to_string()), "leaked");
+}
+
+#[test]
+fn disable_chat_drops_chat_and_turn_tools() {
+    let surfaces = SurfacesConfig {
+        enable_chat: false,
+        ..Default::default()
+    };
+    let names = tool_names(cfg_with_surfaces(surfaces));
+    for forbidden in [
+        "chat_open",
+        "chat_send",
+        "chat_list",
+        "chat_close",
+        "turn_get",
+        "turn_wait",
+        "turn_cancel",
+        "turn_list",
+    ] {
+        assert!(
+            !names.contains(&forbidden.to_string()),
+            "{forbidden} leaked through disabled chat gate"
+        );
+    }
+    // sibling surfaces stay
+    assert!(names.contains(&"claude_query".to_string()));
+}
+
+#[test]
+fn disable_core_drops_claude_passthrough_tools() {
+    let surfaces = SurfacesConfig {
+        enable_core: false,
+        ..Default::default()
+    };
+    let names = tool_names(cfg_with_surfaces(surfaces));
+    for forbidden in ["claude_query", "claude_cli_version", "claude_doctor"] {
+        assert!(
+            !names.contains(&forbidden.to_string()),
+            "{forbidden} leaked"
+        );
+    }
+}
+
+#[test]
+fn mutations_runtime_gate_requires_both_policy_and_surfaces() {
+    use claude_server::ServerPolicy;
+
+    // policy=true but surfaces.enable_mutations=false -> no muts
+    let cfg = ServerConfig {
+        policy: ServerPolicy {
+            allow_mutations: true,
+        },
+        surfaces: SurfacesConfig {
+            enable_mutations: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let names = tool_names(cfg);
+    assert!(
+        !names.contains(&"claude_plugin_install".to_string()),
+        "mutating tool leaked when surfaces.enable_mutations = false; got {names:?}"
+    );
+
+    // surfaces=true but policy=false -> no muts
+    let cfg = ServerConfig {
+        policy: ServerPolicy {
+            allow_mutations: false,
+        },
+        surfaces: SurfacesConfig {
+            enable_mutations: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let names = tool_names(cfg);
+    assert!(!names.contains(&"claude_plugin_install".to_string()));
+
+    // both true -> muts appear
+    let cfg = ServerConfig {
+        policy: ServerPolicy {
+            allow_mutations: true,
+        },
+        surfaces: SurfacesConfig {
+            enable_mutations: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let names = tool_names(cfg);
+    assert!(
+        names.contains(&"claude_plugin_install".to_string()),
+        "mutating tools should register with both gates open; got {names:?}"
+    );
+}
+
+#[test]
+fn agent_mutating_tools_need_artifacts_and_mutations_and_policy() {
+    use claude_server::ServerPolicy;
+
+    // artifacts off -> no agent_write even if mutations on
+    let cfg = ServerConfig {
+        policy: ServerPolicy {
+            allow_mutations: true,
+        },
+        surfaces: SurfacesConfig {
+            enable_artifacts: false,
+            enable_mutations: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let names = tool_names(cfg);
+    assert!(!names.contains(&"agent_write".to_string()));
+
+    // all three on -> agent_write/delete appear
+    let cfg = ServerConfig {
+        policy: ServerPolicy {
+            allow_mutations: true,
+        },
+        surfaces: SurfacesConfig::default(),
+        ..Default::default()
+    };
+    let names = tool_names(cfg);
+    assert!(
+        names.contains(&"agent_write".to_string()),
+        "agent_write missing when all gates open; got {names:?}"
+    );
+}

--- a/crates/claude-server/tests/worktrees_surface.rs
+++ b/crates/claude-server/tests/worktrees_surface.rs
@@ -1,0 +1,207 @@
+//! Integration tests for the `worktrees` Cargo feature: read-only
+//! tool and resource backed by `claude_wrapper::worktrees`.
+//!
+//! Tests build small synthetic git repos in tempdirs (`git init` +
+//! `git worktree add`) and point the server at them via
+//! `ServerConfig::worktrees_root`. One live test (`#[ignore]`)
+//! reads worktrees for the actual repo this lives in.
+
+#![cfg(feature = "worktrees")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use claude_server::{ServerConfig, build_router, registered_tools};
+use tower_mcp::TestClient;
+
+/// Initialize a fresh git repo at `dir` with one commit on `main`.
+/// Sets a deterministic identity so the commit succeeds in CI.
+fn git_init_with_one_commit(dir: &Path) {
+    let must = |args: &[&str]| {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .expect("git invocation");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    must(&["init", "-b", "main"]);
+    must(&["config", "user.email", "test@example.com"]);
+    must(&["config", "user.name", "Test"]);
+    must(&["config", "commit.gpgsign", "false"]);
+    std::fs::write(dir.join("README.md"), "hello\n").expect("write README");
+    must(&["add", "README.md"]);
+    must(&["commit", "-m", "initial"]);
+}
+
+/// Add a worktree at `path` checking out a fresh branch `branch`.
+fn git_worktree_add(repo: &Path, path: &Path, branch: &str) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            path.to_str().expect("utf8 path"),
+        ])
+        .output()
+        .expect("git worktree add");
+    assert!(
+        out.status.success(),
+        "git worktree add failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Build a fixture repo at `<tempdir>/repo` with one extra worktree
+/// at `<tempdir>/wt-feature-x` on branch `feature-x`. Returns the
+/// tempdir handle (kept alive for fixture lifetime).
+fn fixture_repo() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    let extra = tmp.path().join("wt-feature-x");
+    std::fs::create_dir_all(&repo).expect("mkdir");
+    git_init_with_one_commit(&repo);
+    git_worktree_add(&repo, &extra, "feature-x");
+    (tmp, repo, extra)
+}
+
+fn cfg_for_repo(repo: &Path) -> ServerConfig {
+    ServerConfig {
+        worktrees_root: Some(repo.to_path_buf()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn registered_tools_includes_worktrees_surface() {
+    let (_tmp, repo, _extra) = fixture_repo();
+    let tools = registered_tools(cfg_for_repo(&repo)).expect("config built");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    assert!(
+        names.contains(&"worktree_list"),
+        "missing worktree_list in {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn worktree_list_returns_main_and_extra() {
+    let (_tmp, repo, _extra) = fixture_repo();
+    let router = build_router(cfg_for_repo(&repo)).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("worktree_list", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json body");
+    let wts = v["worktrees"].as_array().expect("worktrees array");
+    assert_eq!(wts.len(), 2, "expected main + 1 extra; got {wts:?}");
+
+    // First entry is the main worktree.
+    assert_eq!(wts[0]["is_main"].as_bool(), Some(true));
+    assert_eq!(wts[0]["branch"].as_str(), Some("main"));
+    assert!(!wts[0]["path"].as_str().unwrap_or("").is_empty());
+
+    // Second entry is the feature-x worktree.
+    assert_eq!(wts[1]["is_main"].as_bool(), Some(false));
+    assert_eq!(wts[1]["branch"].as_str(), Some("feature-x"));
+    assert!(wts[1]["head"].is_string());
+}
+
+#[tokio::test]
+async fn worktree_list_accepts_explicit_repo_path_override() {
+    let (_tmp, repo, _extra) = fixture_repo();
+    // Server config points at a different (empty) repo, but the
+    // explicit repo_path argument wins.
+    let other = tempfile::tempdir().expect("tempdir");
+    let cfg = ServerConfig {
+        worktrees_root: Some(other.path().to_path_buf()),
+        ..Default::default()
+    };
+    let router = build_router(cfg).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool(
+            "worktree_list",
+            serde_json::json!({"repo_path": repo.to_str().unwrap()}),
+        )
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json body");
+    assert_eq!(v["worktrees"].as_array().map(Vec::len), Some(2));
+}
+
+#[tokio::test]
+async fn worktree_list_errors_for_non_git_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let router = build_router(cfg_for_repo(tmp.path())).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("worktree_list", serde_json::json!({}))
+        .await;
+    assert!(
+        result.is_error,
+        "expected error for non-git path; got {}",
+        result.all_text()
+    );
+}
+
+#[tokio::test]
+async fn worktrees_resource_returns_same_shape() {
+    let (_tmp, repo, _extra) = fixture_repo();
+    let router = build_router(cfg_for_repo(&repo)).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let body = client.read_resource("claude://worktrees").await;
+    let text = body
+        .contents
+        .iter()
+        .filter_map(|c| serde_json::to_value(c).ok())
+        .filter_map(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect::<String>();
+    let v: serde_json::Value = serde_json::from_str(&text).expect("json body");
+    let wts = v["worktrees"].as_array().expect("worktrees array");
+    assert_eq!(wts.len(), 2);
+    assert_eq!(wts[0]["is_main"].as_bool(), Some(true));
+}
+
+// ---------------------------------------------------------------
+// Live #[ignore] test -- runs against the actual repo this lives in.
+// Run with: cargo test -p claude-server --features worktrees -- --ignored
+// ---------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "uses the real git repo this test lives in"]
+async fn live_worktree_list_against_this_repo() {
+    let cfg = ServerConfig {
+        worktrees_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR"))),
+        ..Default::default()
+    };
+    let router = build_router(cfg).expect("router built");
+    let mut client = TestClient::from_router(router);
+    client.initialize().await;
+
+    let result = client
+        .call_tool("worktree_list", serde_json::json!({}))
+        .await;
+    let v: serde_json::Value = serde_json::from_str(&result.all_text()).expect("json body");
+    let wts = v["worktrees"].as_array().expect("worktrees array");
+    assert!(!wts.is_empty(), "at least the main worktree must exist");
+    assert_eq!(wts[0]["is_main"].as_bool(), Some(true));
+}

--- a/crates/claude-server/tests/wrapper_smoke.rs
+++ b/crates/claude-server/tests/wrapper_smoke.rs
@@ -1,0 +1,47 @@
+//! Live wrapper smoke tests -- isolate wrapper-vs-server issues.
+//! Run with `cargo test -p claude-server --test wrapper_smoke -- --ignored`.
+
+use claude_wrapper::{Claude, ClaudeCommand, QueryCommand};
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn wrapper_execute_returns_text_stdout() {
+    let claude = Claude::builder().build().expect("claude");
+    let q = QueryCommand::new("Reply with exactly OK").model("haiku");
+    let out = q.execute(&claude).await.expect("execute");
+    eprintln!("raw stdout: <<<{}>>>", out.stdout);
+    eprintln!("raw stderr: <<<{}>>>", out.stderr);
+    eprintln!("exit: {}", out.exit_code);
+    assert!(out.success, "non-zero exit: {}", out.exit_code);
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn wrapper_execute_json_parses() {
+    let claude = Claude::builder().build().expect("claude");
+    let q = QueryCommand::new("Reply with exactly OK").model("haiku");
+    let result = q.execute_json(&claude).await;
+    eprintln!("execute_json: {result:?}");
+    let parsed = result.expect("execute_json");
+    eprintln!("result: {:?}", parsed.result);
+    eprintln!("session_id: {:?}", parsed.session_id);
+    eprintln!("cost_usd: {:?}", parsed.cost_usd);
+    assert!(!parsed.session_id.is_empty(), "missing session id");
+}
+
+#[tokio::test]
+#[ignore = "spawns real claude binary"]
+async fn wrapper_execute_with_output_format_arg() {
+    // Drive execute() (not execute_json) with the exact arg set
+    // execute_json would build, so we can capture stdout verbatim.
+    use claude_wrapper::OutputFormat;
+    let claude = Claude::builder().build().expect("claude");
+    let q = QueryCommand::new("Reply with exactly OK")
+        .model("haiku")
+        .output_format(OutputFormat::Json);
+    let out = q.execute(&claude).await.expect("execute");
+    eprintln!("stdout: <<<{}>>>", out.stdout);
+    eprintln!("stderr: <<<{}>>>", out.stderr);
+    eprintln!("exit: {}", out.exit_code);
+    assert!(out.success);
+}


### PR DESCRIPTION
## Summary

Adds `crates/claude-server`, a Cargo workspace member that exposes the Claude Code CLI as an MCP server via [tower-mcp](https://crates.io/crates/tower-mcp). Library-first design; the included `examples/server.rs` is one demonstration of how to wire the router to a transport. `publish = false` -- consumed as a path dep until it stabilizes.

Standalone addition. **No code changes to `claude-wrapper`** -- the published crate is unaffected.

Draft because the surface is still in active iteration (slash-command family, artifacts sidecar, etc.); opening now to get CI feedback per push and a review surface for what's already substantial.

## Why

Three concrete use cases drove the design:

1. **HTTP service** -- `claude-server serve-http` on a port; full claude access from any MCP client. \"Claude as a service on your machine.\"
2. **Embedded in another CLI** -- depend on `claude-server` as a library; `router.call(req).await` with no transport. The server is a function.
3. **Backbone for a management UI** (Finestra-style) -- UIs subscribe to `claude://chats/{id}` and friends instead of reimplementing chat/session bookkeeping per app.

Same router, three deployment shapes. Library-first means a consumer pays only for what they use.

## Layering

- **L0** Claude Code CLI (the binary)
- **L1** `claude-wrapper` -- typed Rust API over the CLI
- **L2** `claude-server` -- 1:1ish MCP interface to the wrapper, via tower-mcp

L2 itself has three sub-surfaces by intent:

| Surface | Intent |
|---|---|
| **Core** (`src/core.rs`) -- always on | 1:1 mirror of every `claude` subcommand except interactive (no `-p`) mode |
| **Chat** (`src/chat/`) -- always on | Duplex sidecar: long-lived `claude` subprocesses via `DuplexSession`, accounting via `Conversation`, async turn lifecycle |
| **Mutations** (`src/mutations.rs`) -- gated | CLI subcommands that change user/project/local state; only registered with `policy.allow_mutations = true` |
| Artifacts (planned, not yet wired) | Direct CRUD over `~/.claude/skills/`, `~/.claude/agents/`, plugin manifests |

## Design rules baked in

1. **Async by default for agent turns.** The bare-named `claude_query` and `chat_send` return `turn_id` immediately; sync variants are explicit `_sync` suffixes. Reason: an LLM caller picks the obvious-named tool, and if obvious means sync, the host sits watching a spinner.
2. **Sync agent-turn tools behind a Cargo feature** (`sync-agent-turns`, default-on). `default-features = false` strips them entirely so the model can't discover them at all.
3. **Mutations require explicit opt-in** at runtime. `policy.allow_mutations = false` (default) means the model can't see mutating tools via `tools/list`.
4. **Server as a function.** `build_router(cfg)` returns a `tower::Service` -- embed it (`router.call(req).await`), wrap it in stdio, wrap it in HTTP, all with the same router.

## Surface

**28 tools** with default features and no mutations enabled (39 with mutations on, 25 in strict mode without sync variants). **4 resources, 1 template, 1 prompt.**

```
CORE -- 1:1 CLI passthrough (always on)
  claude_version, claude_cli_version
  claude_query (async), claude_query_sync
  claude_agents, claude_auth_status
  claude_mcp_list, claude_mcp_get
  claude_plugin_list, claude_plugin_validate
  claude_marketplace_list
  claude_auto_mode_config, claude_auto_mode_defaults
  claude_auto_mode_critique (async)
  claude_doctor

CHAT -- duplex sidecar (always on)
  chat_open (model, system_prompt, max_cost_usd, worktree, ...)
  chat_send (async), chat_send_sync, chat_send_stream_sync
  chat_list, chat_history, chat_interrupt, chat_budget, chat_close
  chat_compact (slash command via stream-json)

TURN REGISTRY -- async lifecycle (always on)
  turn_get, turn_wait, turn_cancel, turn_list

OBSERVABILITY (always on)
  metrics_summary

MUTATIONS -- gated by policy.allow_mutations (11 tools)
  claude_mcp_add, claude_mcp_add_json, claude_mcp_remove
  claude_plugin_install/uninstall/enable/disable/update
  claude_marketplace_add/remove/update

RESOURCES
  claude://config       sanitized server config
  claude://tools        registered tool list (introspection)
  claude://chats        live view of all open chats
  claude://metrics      process counters

RESOURCE TEMPLATES
  claude://chats/{id}   per-chat detail (history, budget, cost, session)

PROMPTS
  describe_server       bootstrap helper
```

## Notification subscriptions

Workers fire `notifications/resources/updated` for `claude://chats/{id}` after each turn settles, and `notifications/resources/list_changed` on `chat_open` / `chat_close`. UIs subscribe instead of polling.

Wired through `build_router_with_notification_sender(cfg, tx)` (companion to `build_router(cfg)`). The example uses it for both stdio and HTTP. HTTP support landed via tower-mcp 0.10.1's new `HttpTransport::with_notifications` (joshrotenberg/tower-mcp#801, motivated by this work).

## Tests

40+ tests across 9 files; all pass on both feature configs:

- `tests/registered_surface.rs` -- tool/resource/prompt enumeration, sorted+unique invariants
- `tests/chat_flow.rs` -- chat lifecycle, history, budget, resource template
- `tests/async_turns.rs` -- fire-and-poll, turn_wait timeout, parallel chats
- `tests/slash_commands.rs` -- chat_compact end-to-end
- `tests/resource_updates.rs` -- notification firing, ResourcesListChanged
- `tests/metrics.rs` -- counters increment through full turns
- `tests/http_transport.rs` -- HTTP lifecycle in-process via `tower::ServiceExt`
- `tests/mutations_gate.rs` -- gating contract
- `tests/wrapper_smoke.rs` -- catches wrapper-side issues we hit during development

Live tests gated `#[ignore]`; run with `cargo test -p claude-server -- --ignored`.

## Three deployment shapes

```rust
// 1. Embed (no transport)
let router = claude_server::build_router(Default::default())?;
let response = router.call(request).await;

// 2. Stdio
let mut transport = StdioTransport::new(router).layer(McpTracingLayer::new());
transport.run().await?;

// 3. HTTP
let app = HttpTransport::with_notifications(router, notif_rx)
    .layer(McpTracingLayer::new())
    .into_router();
axum::serve(listener, app).await?;
```

`examples/server.rs` is the canonical demo with stdio + http subcommands, optional bearer auth on the HTTP path.

## Known limitations / future work (not blocking)

- **Slash command family is one tool deep** (`chat_compact`). `/clear`, `/model`, `/memory` could follow once we know the pattern is solid (it is per the live test).
- **Residual wrapper-vs-MCP gaps** (tracked separately): `claude_auth_logout`, `claude_mcp_add_from_desktop`, `claude_mcp_reset_project_choices`, `claude_plugin_tag` -- niche or interactive flows.
- **Artifacts surface** isn't wired yet -- direct CRUD over `~/.claude/skills/` etc. Captured as future work.
- **`little buddy (lb)`** -- thin CLI over claude-server demonstrating use case 2. Sketched, not built.

## Test plan

- [x] `cargo build --workspace` (default + `--no-default-features` for claude-server)
- [x] `cargo test --workspace` (40+ tests pass on both configs)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (default + strict)
- [x] `cargo fmt --all -- --check`
- [x] Live smoke: 2-turn chat with recall, parallel chats, async claude_query, chat_compact, metrics-mid-turn, claude://chats/{id} read, notification subscription
- [x] HTTP path verified in-process; live socket test deferred

## Commit history

Linear; first three are scaffolding, rest are surface adds. Cosmetic if you prefer to squash on merge.

```
2b931cc feat(server): HTTP transport now fans out resource update notifications
8528fed feat(server): notifications/resources/updated for claude://chats/{id}
253b2d1 feat(server): wire claude_auto_mode_critique (async agent turn)
d1e51af feat(server): observability -- tracing spans + metrics counters
2e6799b feat(server): mutating CLI tools gated by policy.allow_mutations
a4f844e feat(server): claude://chats/{id} resource template
9724045 feat(server): chat_compact slash-command tool
baffb3b feat(server): HTTP transport via tower-mcp + axum
7334e3a feat(server): gate sync agent-turn tools behind sync-agent-turns feature
afbd8c6 feat(server): TTL eviction sweeper for the turn registry
8bbf164 feat(server): async claude_query + worktree on chat_open
15e9074 feat(server): turn_get / turn_wait / turn_cancel / turn_list tools
472b2d2 feat(server): async chat_send (fires turn, returns turn_id)
1bd85a5 feat(server): turn registry for async agent-turn tracking
eeb3b6e refactor(server): rename sync agent-turn tools with explicit _sync suffix
4c400a1 feat(server): add claude-server workspace crate (core + chat MCP surfaces)
```