### PR TITLE
feat: typed worktree builder + slash command helpers

### DIFF
--- a/crates/claude-wrapper/src/duplex.rs
+++ b/crates/claude-wrapper/src/duplex.rs
@@ -307,6 +307,8 @@ pub struct DuplexOptions {
     append_system_prompt: Option<String>,
     resume: Option<String>,
     continue_session: bool,
+    worktree: bool,
+    worktree_name: Option<String>,
     additional_args: Vec<String>,
     subscriber_capacity: Option<usize>,
     on_permission: Option<PermissionHandler>,
@@ -365,6 +367,25 @@ impl DuplexOptions {
     #[must_use]
     pub fn continue_session(mut self) -> Self {
         self.continue_session = true;
+        self
+    }
+
+    /// Run this session in a fresh git worktree (`--worktree [name]`).
+    ///
+    /// `name` is the optional worktree name (the CLI auto-generates
+    /// one if omitted). Calling this method always enables the
+    /// worktree flag, with or without a name.
+    ///
+    /// Use case: an agent host wants the chat's writes isolated from
+    /// the current working tree -- the chat opens with a fresh
+    /// worktree, mutations land there, and the host can inspect or
+    /// merge later.
+    #[must_use]
+    pub fn worktree(mut self, name: Option<impl Into<String>>) -> Self {
+        self.worktree = true;
+        if let Some(n) = name {
+            self.worktree_name = Some(n.into());
+        }
         self
     }
 
@@ -436,6 +457,12 @@ impl DuplexOptions {
         }
         if self.continue_session {
             args.push("--continue".to_string());
+        }
+        if self.worktree {
+            args.push("--worktree".to_string());
+            if let Some(n) = self.worktree_name {
+                args.push(n);
+            }
         }
         if self.on_permission.is_some() {
             args.push("--permission-prompt-tool".to_string());
@@ -1353,6 +1380,52 @@ mod tests {
     fn into_args_omits_continue_by_default() {
         let args = DuplexOptions::default().into_args();
         assert!(!args.iter().any(|a| a == "--continue"));
+    }
+
+    #[test]
+    fn into_args_includes_worktree_flag_without_name() {
+        let args = DuplexOptions::default().worktree(None::<&str>).into_args();
+        assert!(args.iter().any(|a| a == "--worktree"));
+        // No name means no positional follows --worktree.
+        let pos = args.iter().position(|a| a == "--worktree").unwrap();
+        assert!(
+            args.get(pos + 1).is_none_or(|a| a.starts_with("--")),
+            "--worktree without a name should not be followed by a positional; got {args:?}"
+        );
+    }
+
+    #[test]
+    fn into_args_includes_worktree_flag_with_name() {
+        let args = DuplexOptions::default()
+            .worktree(Some("agent-xyz"))
+            .into_args();
+        let pos = args.iter().position(|a| a == "--worktree").unwrap();
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("agent-xyz"));
+    }
+
+    #[test]
+    fn into_args_omits_worktree_by_default() {
+        let args = DuplexOptions::default().into_args();
+        assert!(
+            !args.iter().any(|a| a == "--worktree"),
+            "--worktree should not appear without an explicit worktree(...) call; got {args:?}"
+        );
+    }
+
+    #[test]
+    fn worktree_lands_before_additional_args() {
+        // Same `--` ordering bug class as resume.
+        let args = DuplexOptions::default()
+            .worktree(Some("foo"))
+            .arg("--")
+            .arg("trailing")
+            .into_args();
+        let wt_pos = args.iter().position(|a| a == "--worktree").unwrap();
+        let dash_dash_pos = args.iter().position(|a| a == "--").unwrap();
+        assert!(
+            wt_pos < dash_dash_pos,
+            "--worktree must precede `--` separator; got {args:?}"
+        );
     }
 
     #[test]

--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -304,6 +304,7 @@ pub mod mcp_config;
 pub mod retry;
 #[cfg(all(feature = "json", feature = "async"))]
 pub mod session;
+pub mod slash;
 pub mod streaming;
 pub mod tool_pattern;
 pub mod types;

--- a/crates/claude-wrapper/src/slash.rs
+++ b/crates/claude-wrapper/src/slash.rs
@@ -1,0 +1,71 @@
+//! Helpers for building Claude Code's slash-command strings.
+//!
+//! The interactive CLI exposes commands like `/compact`, `/clear`,
+//! `/model` that the user types mid-conversation. In stream-json
+//! input mode the same `/foo args` strings are passed through as
+//! turn prompts -- the CLI interprets them, the model doesn't see
+//! them as user prompts.
+//!
+//! Hosts wrapping a duplex session as a chat (MCP servers, IDE
+//! backends, agent runtimes) need to construct these strings
+//! safely, especially when forwarding optional user instructions.
+//! These helpers keep the CLI's slash syntax in one place rather
+//! than having every caller hand-roll `format!("/compact {}", ...)`.
+//!
+//! # Example
+//!
+//! ```
+//! use claude_wrapper::slash;
+//!
+//! assert_eq!(slash::compact(None), "/compact");
+//! assert_eq!(slash::compact(Some("focus on auth bug")), "/compact focus on auth bug");
+//! ```
+
+/// Build the prompt string for `/compact`.
+///
+/// Pass `Some(instructions)` to mirror the CLI's
+/// `/compact <instructions>` form (the trailing text steers the
+/// summarizer); pass `None` for a default compaction. Empty or
+/// whitespace-only `instructions` collapse to the bare form.
+pub fn compact(instructions: Option<&str>) -> String {
+    match instructions {
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                "/compact".to_string()
+            } else {
+                format!("/compact {trimmed}")
+            }
+        }
+        None => "/compact".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_without_instructions_is_bare() {
+        assert_eq!(compact(None), "/compact");
+    }
+
+    #[test]
+    fn compact_with_instructions_appends_them() {
+        assert_eq!(
+            compact(Some("focus on the auth bug")),
+            "/compact focus on the auth bug"
+        );
+    }
+
+    #[test]
+    fn compact_trims_surrounding_whitespace() {
+        assert_eq!(compact(Some("   keep tests   ")), "/compact keep tests");
+    }
+
+    #[test]
+    fn compact_empty_string_collapses_to_bare() {
+        assert_eq!(compact(Some("")), "/compact");
+        assert_eq!(compact(Some("   ")), "/compact");
+    }
+}


### PR DESCRIPTION
## Summary

Two small wrapper-side additions that close boundary leaks where hosts (claude-server today) were reaching into raw CLI flag strings to express duplex features.

### `DuplexOptions::worktree(name: Option<&str>)`

Single builder method for `--worktree [name]`. Replaces the pattern of calling `.arg(\"--worktree\")` plus an optional second `.arg(name)`. Same `--` ordering protection as `resume` / `continue_session`: the worktree args land before any caller-injected `additional_args`.

### `claude_wrapper::slash` module

New module with `compact(instructions: Option<&str>) -> String`. Builds the `/compact` prompt string the CLI interprets in stream-json input mode. Trims whitespace; empty / whitespace-only instructions collapse to the bare form. The module is the natural home for future helpers (`/clear`, `/model`, etc.) so callers don't reinvent the slash syntax each time.

## Why

Both replace small but real \"server pokes raw CLI knowledge\" patterns in claude-server, restoring the rule that the wrapper is authoritative for CLI shape. Wrapper-side typed APIs mean the next host (or the same host in a year) doesn't drift the syntax.

## Test plan

- [x] 8 new unit tests (4 worktree ordering + presence + absence, 4 slash::compact)
- [x] Existing 244 lib tests + 68 doctests still green
- [x] `cargo build` (default, no-default-features+json, all-features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all`