### PR TITLE
feat: typed auth errors -- classify CLI failures at exec time

### DIFF
--- a/crates/claude-wrapper/src/auth.rs
+++ b/crates/claude-wrapper/src/auth.rs
@@ -93,6 +93,141 @@ pub struct AuthSummary {
     pub vertex_enabled: bool,
 }
 
+/// Best-effort classification of an auth-related CLI failure.
+///
+/// Returned by [`classify_failure`]. Hosts can use it to surface a
+/// cleaner message ("run `claude login`") instead of dumping CLI
+/// stderr, or to skip retry policies on errors that won't resolve
+/// on their own.
+///
+/// Conservative on purpose: false positives turn legitimate non-auth
+/// failures into "auth error" surprises, so the classifier prefers
+/// to miss an auth error than to misclassify a non-auth one. Use
+/// [`AuthErrorKind::Other`] only when stronger signals (HTTP status
+/// strings, the literal word "auth") fire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthErrorKind {
+    /// No credentials at all -- the user has not run `claude login`
+    /// and has no env auth set. Fix: run `claude login` or set one
+    /// of the env vars listed in [`AuthStrategy`].
+    NotAuthenticated,
+    /// Stored OAuth/session credentials existed but are expired.
+    /// Fix: re-run `claude login`.
+    Expired,
+    /// Credentials were presented but rejected. Most often a wrong
+    /// or revoked `ANTHROPIC_API_KEY`, or an `CLAUDE_CODE_OAUTH_TOKEN`
+    /// that no longer maps to a valid session.
+    InvalidCredentials,
+    /// Authenticated but the request was rejected for rate limit /
+    /// quota / billing reasons. Different remediation: wait, top up,
+    /// or switch keys -- not "log in again."
+    RateLimit,
+    /// Bedrock or Vertex provider error (cloud creds missing or
+    /// rejected). Distinct because the fix lives in the cloud
+    /// provider's auth, not in `claude login`.
+    ProviderError,
+    /// Looked auth-shaped (HTTP 401/403, the word "auth", etc.) but
+    /// didn't match any of the more specific patterns. Useful for
+    /// callers that want "is this an auth thing?" without needing
+    /// to know the exact subcategory.
+    Other,
+}
+
+impl AuthErrorKind {
+    /// Stable string label, useful for logs and protocol payloads.
+    /// Matches the `serde_json` representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotAuthenticated => "not_authenticated",
+            Self::Expired => "expired",
+            Self::InvalidCredentials => "invalid_credentials",
+            Self::RateLimit => "rate_limit",
+            Self::ProviderError => "provider_error",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// Inspect a failed `claude` invocation and decide whether it looks
+/// auth-shaped. Returns `Some(kind)` only when the patterns are
+/// confident enough to risk relabeling.
+///
+/// `exit_code`, `stdout`, and `stderr` come from the CLI's exit; the
+/// classifier matches against the lowercased concatenation. The
+/// patterns are intentionally narrow:
+///
+/// - "not authenticated" / "claude login" / "no credentials" / "no auth"
+///   -> [`AuthErrorKind::NotAuthenticated`]
+/// - "expired" / "session has expired" / "token expired" -> [`AuthErrorKind::Expired`]
+/// - "invalid api key" / "invalid token" / "401" / "unauthorized" / "403"
+///   / "forbidden" -> [`AuthErrorKind::InvalidCredentials`]
+/// - "rate limit" / "quota" / "too many requests" / "429" -> [`AuthErrorKind::RateLimit`]
+/// - "bedrock" or "vertex" present alongside an auth signal -> [`AuthErrorKind::ProviderError`]
+/// - bare "auth" / "credential" hit with nothing more specific -> [`AuthErrorKind::Other`]
+pub fn classify_failure(_exit_code: i32, stdout: &str, stderr: &str) -> Option<AuthErrorKind> {
+    let combined = format!("{stdout}\n{stderr}").to_ascii_lowercase();
+
+    // Provider hits (Bedrock / Vertex) take precedence when the
+    // failure mentions them alongside an auth signal -- the fix is
+    // different (cloud creds, not `claude login`).
+    let mentions_provider = combined.contains("bedrock") || combined.contains("vertex");
+    let mentions_auth_signal = combined.contains("auth")
+        || combined.contains("credential")
+        || combined.contains("401")
+        || combined.contains("403")
+        || combined.contains("forbidden")
+        || combined.contains("unauthorized");
+    if mentions_provider && mentions_auth_signal {
+        return Some(AuthErrorKind::ProviderError);
+    }
+
+    if combined.contains("rate limit")
+        || combined.contains("too many requests")
+        || combined.contains("429")
+        || combined.contains("quota")
+    {
+        return Some(AuthErrorKind::RateLimit);
+    }
+
+    if combined.contains("expired")
+        || combined.contains("session has expired")
+        || combined.contains("token expired")
+    {
+        return Some(AuthErrorKind::Expired);
+    }
+
+    if combined.contains("invalid api key")
+        || combined.contains("invalid token")
+        || combined.contains("401")
+        || combined.contains("unauthorized")
+        || combined.contains("403")
+        || combined.contains("forbidden")
+    {
+        return Some(AuthErrorKind::InvalidCredentials);
+    }
+
+    if combined.contains("not authenticated")
+        || combined.contains("claude login")
+        || combined.contains("no credentials")
+        || combined.contains("no auth")
+    {
+        return Some(AuthErrorKind::NotAuthenticated);
+    }
+
+    // Last-resort bucket: a bare "auth" or "credential" mention
+    // without specifics. Conservative: only fires when the word is
+    // present in stderr (where these errors typically land) so we
+    // don't catch `--allowed-tools auth_helper` or similar.
+    if stderr.to_ascii_lowercase().contains("auth")
+        || stderr.to_ascii_lowercase().contains("credential")
+    {
+        return Some(AuthErrorKind::Other);
+    }
+
+    None
+}
+
 /// Detect the active auth strategy from the current process
 /// environment. Cheap; no subprocess, no filesystem reads.
 pub fn detect() -> AuthSummary {
@@ -257,6 +392,139 @@ mod tests {
             let s = detect_from(&env(&[("CLAUDE_CODE_USE_BEDROCK", v)]));
             assert_eq!(s.strategy, AuthStrategy::Subscription, "value {v:?}");
             assert!(!s.bedrock_enabled, "value {v:?}");
+        }
+    }
+
+    // -- classify_failure ---------------------------------------------
+
+    #[test]
+    fn classify_returns_none_for_unrelated_failure() {
+        assert_eq!(classify_failure(1, "no match found", ""), None);
+        assert_eq!(
+            classify_failure(2, "", "syntax error near unexpected token"),
+            None
+        );
+    }
+
+    #[test]
+    fn classify_not_authenticated_from_stderr_hint() {
+        assert_eq!(
+            classify_failure(1, "", "Not authenticated. Run `claude login` to sign in."),
+            Some(AuthErrorKind::NotAuthenticated)
+        );
+        assert_eq!(
+            classify_failure(1, "", "no credentials configured"),
+            Some(AuthErrorKind::NotAuthenticated)
+        );
+    }
+
+    #[test]
+    fn classify_expired_session() {
+        assert_eq!(
+            classify_failure(1, "", "Your session has expired. Please log in again."),
+            Some(AuthErrorKind::Expired)
+        );
+        assert_eq!(
+            classify_failure(1, "", "token expired at 2025-01-01T00:00:00Z"),
+            Some(AuthErrorKind::Expired)
+        );
+    }
+
+    #[test]
+    fn classify_invalid_api_key() {
+        assert_eq!(
+            classify_failure(1, "", "Invalid API key. Check ANTHROPIC_API_KEY."),
+            Some(AuthErrorKind::InvalidCredentials)
+        );
+        assert_eq!(
+            classify_failure(1, "", "HTTP 401 Unauthorized"),
+            Some(AuthErrorKind::InvalidCredentials)
+        );
+        assert_eq!(
+            classify_failure(1, "", "403 Forbidden"),
+            Some(AuthErrorKind::InvalidCredentials)
+        );
+    }
+
+    #[test]
+    fn classify_rate_limit_takes_precedence_over_invalid_creds() {
+        // Some API responses include "401-like" wording in their rate
+        // limit messages; rate_limit should win.
+        assert_eq!(
+            classify_failure(1, "", "Rate limit exceeded. Please wait."),
+            Some(AuthErrorKind::RateLimit)
+        );
+        assert_eq!(
+            classify_failure(1, "", "HTTP 429 Too Many Requests"),
+            Some(AuthErrorKind::RateLimit)
+        );
+        assert_eq!(
+            classify_failure(1, "", "quota exceeded for this account"),
+            Some(AuthErrorKind::RateLimit)
+        );
+    }
+
+    #[test]
+    fn classify_provider_error_when_bedrock_plus_auth_signal() {
+        assert_eq!(
+            classify_failure(
+                1,
+                "",
+                "Bedrock auth failed: AWS credentials not found in chain"
+            ),
+            Some(AuthErrorKind::ProviderError)
+        );
+        assert_eq!(
+            classify_failure(
+                1,
+                "",
+                "Vertex unauthorized -- check GOOGLE_APPLICATION_CREDENTIALS"
+            ),
+            Some(AuthErrorKind::ProviderError)
+        );
+    }
+
+    #[test]
+    fn classify_falls_back_to_other_for_bare_auth_mention() {
+        assert_eq!(
+            classify_failure(1, "", "auth subsystem returned an unexpected error"),
+            Some(AuthErrorKind::Other)
+        );
+    }
+
+    #[test]
+    fn classify_does_not_match_auth_in_stdout_only() {
+        // The fallback "Other" bucket only fires on stderr -- otherwise
+        // a CLI that just happened to print "--allowed-tools auth_helper"
+        // would be misclassified.
+        assert_eq!(
+            classify_failure(0, "auth_helper enabled, all clear", ""),
+            None
+        );
+    }
+
+    #[test]
+    fn classify_examines_stdout_for_specific_patterns() {
+        // Specific patterns work in either stream -- some CLIs print
+        // their auth diagnostics to stdout.
+        assert_eq!(
+            classify_failure(1, "Invalid API key", ""),
+            Some(AuthErrorKind::InvalidCredentials)
+        );
+    }
+
+    #[test]
+    fn auth_error_kind_as_str_matches_serde_repr() {
+        for k in [
+            AuthErrorKind::NotAuthenticated,
+            AuthErrorKind::Expired,
+            AuthErrorKind::InvalidCredentials,
+            AuthErrorKind::RateLimit,
+            AuthErrorKind::ProviderError,
+            AuthErrorKind::Other,
+        ] {
+            let json = serde_json::to_string(&k).expect("serialize");
+            assert_eq!(json, format!("\"{}\"", k.as_str()));
         }
     }
 

--- a/crates/claude-wrapper/src/error.rs
+++ b/crates/claude-wrapper/src/error.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use crate::auth::AuthErrorKind;
+
 /// Errors returned by claude-wrapper operations.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -105,6 +107,96 @@ pub enum Error {
         /// Human-readable description of what went wrong.
         message: String,
     },
+
+    /// A `claude` invocation failed and looked auth-shaped to the
+    /// classifier. Hosts can match on this variant to trigger a
+    /// re-auth flow, surface a clean message, or skip retries.
+    /// `kind` carries the best-effort subcategory; `message` is the
+    /// stderr (or stdout fallback) the classifier matched against.
+    ///
+    /// Raised at exec time when [`crate::auth::classify_failure`]
+    /// returns `Some(_)` for a CLI failure that would otherwise
+    /// have been [`Error::CommandFailed`]. Cases the classifier
+    /// missed remain `CommandFailed`; call
+    /// [`Error::auth_kind`] for opt-in inspection of those.
+    #[error("auth error ({kind:?}): {command} (exit code {exit_code}): {message}")]
+    Auth {
+        /// Best-effort classification.
+        kind: AuthErrorKind,
+        /// The full command line that failed.
+        command: String,
+        /// Process exit code.
+        exit_code: i32,
+        /// Human-readable message extracted from stderr (or stdout).
+        message: String,
+    },
+}
+
+impl Error {
+    /// Construct an [`Error`] from a CLI failure. Runs the
+    /// auth-error classifier; if it matches, returns
+    /// [`Error::Auth`]. Otherwise returns [`Error::CommandFailed`]
+    /// unchanged.
+    ///
+    /// This is the canonical entry point for raising failures from
+    /// `exec.rs`-shaped sites -- replacing direct construction of
+    /// `CommandFailed` ensures every consumer benefits from typed
+    /// auth errors automatically.
+    pub fn from_command_failure(
+        command: String,
+        exit_code: i32,
+        stdout: String,
+        stderr: String,
+        working_dir: Option<PathBuf>,
+    ) -> Self {
+        if let Some(kind) = crate::auth::classify_failure(exit_code, &stdout, &stderr) {
+            // Prefer stderr for the human-facing message; fall back
+            // to stdout when stderr is empty (some CLIs send all
+            // diagnostics to stdout).
+            let message = if !stderr.trim().is_empty() {
+                stderr.trim().to_string()
+            } else {
+                stdout.trim().to_string()
+            };
+            Self::Auth {
+                kind,
+                command,
+                exit_code,
+                message,
+            }
+        } else {
+            Self::CommandFailed {
+                command,
+                exit_code,
+                stdout,
+                stderr,
+                working_dir,
+            }
+        }
+    }
+
+    /// Inspect whether this error is auth-shaped. Returns
+    /// `Some(kind)` for [`Error::Auth`] (the auto-typed path) and
+    /// also re-runs [`crate::auth::classify_failure`] on
+    /// [`Error::CommandFailed`] for cases the constructor missed.
+    /// Returns `None` for everything else (`Io`, `Timeout`, etc.).
+    ///
+    /// Most consumers should match on [`Error::Auth`] directly --
+    /// this method is the escape hatch for low-confidence
+    /// classifier patterns the constructor was too conservative
+    /// about.
+    pub fn auth_kind(&self) -> Option<AuthErrorKind> {
+        match self {
+            Self::Auth { kind, .. } => Some(*kind),
+            Self::CommandFailed {
+                exit_code,
+                stdout,
+                stderr,
+                ..
+            } => crate::auth::classify_failure(*exit_code, stdout, stderr),
+            _ => None,
+        }
+    }
 }
 
 impl From<std::io::Error> for Error {
@@ -199,5 +291,78 @@ mod tests {
         let s = e.to_string();
         assert!(s.contains("spawn failed"));
         assert!(s.contains("/work"));
+    }
+
+    // -- from_command_failure / auth_kind ---------------------------
+
+    #[test]
+    fn from_command_failure_unrelated_stderr_yields_command_failed() {
+        let e = Error::from_command_failure(
+            "claude --print".into(),
+            1,
+            String::new(),
+            "syntax error".into(),
+            None,
+        );
+        assert!(matches!(e, Error::CommandFailed { .. }));
+        assert_eq!(e.auth_kind(), None);
+    }
+
+    #[test]
+    fn from_command_failure_auth_stderr_yields_auth_variant() {
+        let e = Error::from_command_failure(
+            "claude --print".into(),
+            1,
+            String::new(),
+            "Not authenticated. Run `claude login`.".into(),
+            None,
+        );
+        match &e {
+            Error::Auth { kind, message, .. } => {
+                assert_eq!(*kind, AuthErrorKind::NotAuthenticated);
+                assert!(message.contains("Not authenticated"));
+            }
+            other => panic!("expected Auth, got {other:?}"),
+        }
+        assert_eq!(e.auth_kind(), Some(AuthErrorKind::NotAuthenticated));
+    }
+
+    #[test]
+    fn from_command_failure_uses_stdout_message_when_stderr_empty() {
+        let e = Error::from_command_failure(
+            "claude --print".into(),
+            1,
+            "Invalid API key".into(),
+            String::new(),
+            None,
+        );
+        match &e {
+            Error::Auth { message, kind, .. } => {
+                assert_eq!(*kind, AuthErrorKind::InvalidCredentials);
+                assert_eq!(message, "Invalid API key");
+            }
+            other => panic!("expected Auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn auth_kind_inspects_command_failed_for_missed_classifications() {
+        // The constructor would have caught this, but a hand-built
+        // CommandFailed (e.g. constructed by older code or by a
+        // caller not going through the helper) is still inspectable.
+        let e = Error::CommandFailed {
+            command: "claude --print".into(),
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "401 Unauthorized".into(),
+            working_dir: None,
+        };
+        assert_eq!(e.auth_kind(), Some(AuthErrorKind::InvalidCredentials));
+    }
+
+    #[test]
+    fn auth_kind_returns_none_for_non_command_errors() {
+        assert_eq!(Error::NotFound.auth_kind(), None);
+        assert_eq!(Error::Timeout { timeout_seconds: 5 }.auth_kind(), None);
     }
 }

--- a/crates/claude-wrapper/src/exec.rs
+++ b/crates/claude-wrapper/src/exec.rs
@@ -140,13 +140,13 @@ async fn run_internal(
     let exit_code = output.status.code().unwrap_or(-1);
 
     if !output.status.success() {
-        return Err(Error::CommandFailed {
-            command: format!("{} {}", binary.display(), args.join(" ")),
+        return Err(Error::from_command_failure(
+            format!("{} {}", binary.display(), args.join(" ")),
             exit_code,
             stdout,
             stderr,
-            working_dir: working_dir.map(|p| p.to_path_buf()),
-        });
+            working_dir.map(|p| p.to_path_buf()),
+        ));
     }
 
     Ok(CommandOutput {
@@ -216,13 +216,13 @@ async fn run_with_timeout(
             let exit_code = status.code().unwrap_or(-1);
 
             if !status.success() {
-                return Err(Error::CommandFailed {
-                    command: format!("{} {}", binary.display(), args.join(" ")),
+                return Err(Error::from_command_failure(
+                    format!("{} {}", binary.display(), args.join(" ")),
                     exit_code,
                     stdout,
                     stderr,
-                    working_dir: working_dir.map(|p| p.to_path_buf()),
-                });
+                    working_dir.map(|p| p.to_path_buf()),
+                ));
             }
 
             Ok(CommandOutput {
@@ -380,13 +380,13 @@ fn run_internal_sync(
     let exit_code = output.status.code().unwrap_or(-1);
 
     if !output.status.success() {
-        return Err(Error::CommandFailed {
-            command: format!("{} {}", binary.display(), args.join(" ")),
+        return Err(Error::from_command_failure(
+            format!("{} {}", binary.display(), args.join(" ")),
             exit_code,
             stdout,
             stderr,
-            working_dir: working_dir.map(|p| p.to_path_buf()),
-        });
+            working_dir.map(|p| p.to_path_buf()),
+        ));
     }
 
     Ok(CommandOutput {
@@ -458,13 +458,13 @@ fn run_with_timeout_sync(
             let exit_code = status.code().unwrap_or(-1);
 
             if !status.success() {
-                return Err(Error::CommandFailed {
-                    command: format!("{} {}", binary.display(), args.join(" ")),
+                return Err(Error::from_command_failure(
+                    format!("{} {}", binary.display(), args.join(" ")),
                     exit_code,
                     stdout,
                     stderr,
-                    working_dir: working_dir.map(|p| p.to_path_buf()),
-                });
+                    working_dir.map(|p| p.to_path_buf()),
+                ));
             }
 
             Ok(CommandOutput {


### PR DESCRIPTION
## Summary

CLI failures that look auth-shaped get auto-typed into a new `Error::Auth` variant at raise time. The rest stay as `Error::CommandFailed` and are still inspectable via the new `Error::auth_kind()` method as a fallback for low-confidence cases the classifier was too conservative to relabel.

Hosts can now:
- match on `Error::Auth` to surface \"run \`claude login\`\" instead of dumping CLI stderr
- skip retry policies on auth failures
- branch on `AuthErrorKind` for kind-specific remediation

## API additions

In `claude_wrapper::auth`:
```rust
pub enum AuthErrorKind {
    NotAuthenticated, Expired, InvalidCredentials,
    RateLimit, ProviderError, Other,
}
pub fn classify_failure(exit_code: i32, stdout: &str, stderr: &str) -> Option<AuthErrorKind>;
```

In `claude_wrapper::error`:
```rust
pub enum Error {
    // ...existing variants...
    Auth { kind: AuthErrorKind, command: String, exit_code: i32, message: String },
}

impl Error {
    pub fn from_command_failure(command, exit_code, stdout, stderr, working_dir) -> Self;
    pub fn auth_kind(&self) -> Option<AuthErrorKind>;
}
```

## Integration

`exec.rs` raise sites switched from direct `Error::CommandFailed { ... }` construction to `Error::from_command_failure(...)`. Three sites: async no-timeout, async with-timeout, sync mirror.

## Conservative on purpose

The classifier prefers false negatives over false positives so legitimate non-auth failures don't get mislabeled. The \"Other\" fallback only fires on bare \"auth\"/\"credential\" mentions in **stderr** specifically, avoiding misclassification when stdout happens to mention `--allowed-tools auth_helper` or similar.

Patterns it matches (lowercased, stdout+stderr):
- `not authenticated` / `claude login` / `no credentials` / `no auth` -> NotAuthenticated
- `expired` / `session has expired` / `token expired` -> Expired
- `invalid api key` / `invalid token` / `401` / `unauthorized` / `403` / `forbidden` -> InvalidCredentials
- `rate limit` / `too many requests` / `429` / `quota` -> RateLimit
- `bedrock` or `vertex` + auth signal -> ProviderError
- bare \`auth\`/\`credential\` in stderr only -> Other

## Note on allowed_codes

`run_claude_allow_exit_codes` matches `Error::CommandFailed` to convert known-good non-zero exits into `Ok`. Since auth failures now raise `Error::Auth` instead, they correctly bypass the allowed_codes path -- an auth failure is never an intentional non-zero exit.

## Test plan

- [x] 15 new unit tests (classifier patterns, constructor fork, auth_kind fallback, serde parity)
- [x] All 263 existing lib tests + 70 doctests still pass (now 278 + 70)
- [x] `cargo build` (default, no-default-features+json, all-features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all`