### PR TITLE
deprecate(agents): claude agents is now a TUI; AgentsCommand can't list

### DIFF
--- a/crates/claude-wrapper/src/command/agents.rs
+++ b/crates/claude-wrapper/src/command/agents.rs
@@ -7,28 +7,31 @@ use crate::error::Result;
 use crate::exec;
 use crate::exec::CommandOutput;
 
-/// List configured agents.
+/// **Deprecated.** Wraps `claude agents`, which as of Claude Code
+/// 2.1.143 is an interactive TUI for managing background agent
+/// sessions -- not a way to list user-defined subagent definitions.
+/// Calling `.execute()` non-interactively just emits
+/// `'claude agents' is not available in this environment.` to
+/// stderr and returns empty stdout.
 ///
-/// # Example
+/// Use [`crate::artifacts::AgentsRoot`] to enumerate / read /
+/// write user-level subagent definitions in `~/.claude/agents/`.
+/// There is no current non-interactive CLI surface for the
+/// background-session manager.
 ///
-/// ```no_run
-/// use claude_wrapper::{Claude, ClaudeCommand, AgentsCommand};
-///
-/// # async fn example() -> claude_wrapper::Result<()> {
-/// let claude = Claude::builder().build()?;
-/// let output = AgentsCommand::new()
-///     .setting_sources("user,project")
-///     .execute(&claude)
-///     .await?;
-/// println!("{}", output.stdout);
-/// # Ok(())
-/// # }
-/// ```
+/// Kept for back-compat; will be removed in a future major release.
+#[deprecated(
+    since = "0.10.0",
+    note = "`claude agents` is now an interactive TUI in Claude Code 2.1.143+ (background-session manager). \
+            For listing/reading/writing user subagents in `~/.claude/agents/`, use \
+            `claude_wrapper::artifacts::AgentsRoot`."
+)]
 #[derive(Debug, Clone, Default)]
 pub struct AgentsCommand {
     setting_sources: Option<String>,
 }
 
+#[allow(deprecated)]
 impl AgentsCommand {
     #[must_use]
     pub fn new() -> Self {
@@ -43,6 +46,7 @@ impl AgentsCommand {
     }
 }
 
+#[allow(deprecated)]
 impl ClaudeCommand for AgentsCommand {
     type Output = CommandOutput;
 
@@ -62,6 +66,7 @@ impl ClaudeCommand for AgentsCommand {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::command::ClaudeCommand;

--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -319,6 +319,7 @@ pub use budget::{BudgetBuilder, BudgetTracker};
 pub use command::ClaudeCommand;
 #[cfg(feature = "sync")]
 pub use command::ClaudeCommandSyncExt;
+#[allow(deprecated)]
 pub use command::agents::AgentsCommand;
 pub use command::auth::{
     AuthLoginCommand, AuthLogoutCommand, AuthStatusCommand, SetupTokenCommand,

--- a/crates/claude-wrapper/tests/fake_claude.rs
+++ b/crates/claude-wrapper/tests/fake_claude.rs
@@ -560,6 +560,12 @@ async fn doctor_executes() {
 }
 
 /// Verify that agents command executes through the fake binary.
+///
+/// `AgentsCommand` is deprecated (the real `claude agents` is now an
+/// interactive TUI as of 2.1.143), but the wrapper still constructs
+/// the same arg vector and the test verifies that arg vector lands
+/// on the fake binary correctly.
+#[allow(deprecated)]
 #[tokio::test]
 async fn agents_executes() {
     let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "[]")]);


### PR DESCRIPTION
## Summary

Claude Code 2.1.143 repurposed `claude agents` from a list-agents command into an interactive TUI for managing background agent sessions. Called non-interactively (as `AgentsCommand::execute` does) it just emits `'claude agents' is not available in this environment.` to stderr and exits 0 with empty stdout -- silently broken for any caller expecting structured agent metadata.

## What this does

- Marks `AgentsCommand` `#[deprecated]` with a note pointing at `claude_wrapper::artifacts::AgentsRoot`, which is the correct API for the user-level subagent definitions in `~/.claude/agents/<name>.md`.
- Adds `#[allow(deprecated)]` on internal call sites (impl blocks, existing `fake_claude` integration test, lib.rs re-export) so the wrapper itself keeps building under `-D warnings`.

## What this does NOT do

- Does not remove the struct -- back-compat for downstream consumers. Removal in a future major release.
- Does not add a typed wrapper for the new background-session manager. There is no non-interactive CLI surface for that yet; if/when one appears, that's a separate feature.

## Discovery

`~/.claude/agents/*.md` are still the canonical user-level subagent definitions; only the CLI subcommand semantics changed. The artifacts module (`AgentsRoot::list / get / write / delete` -- write/delete in flight in #592) covers the same intent the deprecated command was reaching for.

## Test plan

- [x] `cargo build` (default, no-default-features+json, all-features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p claude-wrapper --all-features --lib` (278 pass)
- [x] `cargo test -p claude-wrapper --doc --all-features` (69 pass; one example dropped from the AgentsCommand doc since the original was misleading)
- [x] `cargo fmt --all`