### PR TITLE
feat: declare tested-against CLI range + runtime drift warning

### DIFF
--- a/crates/claude-wrapper/src/lib.rs
+++ b/crates/claude-wrapper/src/lib.rs
@@ -363,7 +363,7 @@ pub use retry::{BackoffStrategy, RetryPolicy};
 pub use session::Session;
 pub use tool_pattern::{PatternError, ToolPattern};
 pub use types::*;
-pub use version::{CliVersion, VersionParseError};
+pub use version::{CliVersion, CliVersionStatus, VersionParseError};
 
 /// The Claude CLI client. Holds shared configuration applied to all commands.
 ///
@@ -376,6 +376,7 @@ pub struct Claude {
     pub(crate) global_args: Vec<String>,
     pub(crate) timeout: Option<Duration>,
     pub(crate) retry_policy: Option<RetryPolicy>,
+    pub(crate) tested_cli_version_range: Option<(CliVersion, CliVersion)>,
 }
 
 impl Claude {
@@ -485,6 +486,70 @@ impl Claude {
             })
         }
     }
+
+    /// The tested-against `[min, max]` range declared at build time
+    /// via [`ClaudeBuilder::tested_cli_version_range`], if any.
+    #[must_use]
+    pub fn tested_cli_version_range(&self) -> Option<(CliVersion, CliVersion)> {
+        self.tested_cli_version_range
+    }
+
+    /// Classify the installed CLI against the declared
+    /// tested-against range. Logs a `tracing::warn!` when outside
+    /// the range; returns the typed status either way. If no range
+    /// was declared via [`ClaudeBuilder::tested_cli_version_range`],
+    /// returns [`CliVersionStatus::Tested`] -- callers that didn't
+    /// opt in get the silent-success path.
+    ///
+    /// Intended for one-shot use at startup, not on every command.
+    #[cfg(feature = "async")]
+    pub async fn cli_version_status(&self) -> Result<CliVersionStatus> {
+        let Some((min, max)) = self.tested_cli_version_range else {
+            return Ok(CliVersionStatus::Tested);
+        };
+        let found = self.cli_version().await?;
+        let status = found.status_within(&min, &max);
+        warn_on_drift(&status);
+        Ok(status)
+    }
+
+    /// Blocking mirror of [`Claude::cli_version_status`]. Requires
+    /// the `sync` feature.
+    #[cfg(feature = "sync")]
+    pub fn cli_version_status_sync(&self) -> Result<CliVersionStatus> {
+        let Some((min, max)) = self.tested_cli_version_range else {
+            return Ok(CliVersionStatus::Tested);
+        };
+        let found = self.cli_version_sync()?;
+        let status = found.status_within(&min, &max);
+        warn_on_drift(&status);
+        Ok(status)
+    }
+}
+
+#[allow(dead_code)] // unused with neither `async` nor `sync` feature
+fn warn_on_drift(status: &CliVersionStatus) {
+    match status {
+        CliVersionStatus::Tested => {}
+        CliVersionStatus::NewerUntested {
+            found, tested_max, ..
+        } => {
+            tracing::warn!(
+                found = %found,
+                tested_max = %tested_max,
+                "claude CLI is newer than the wrapper's tested-against range; \
+                 semantics may have drifted -- proceed with caution"
+            );
+        }
+        CliVersionStatus::OlderThanMinimum { found, minimum, .. } => {
+            tracing::warn!(
+                found = %found,
+                minimum = %minimum,
+                "claude CLI is older than the wrapper's declared minimum; \
+                 incorrect behavior is likely (missing flags, different shapes)"
+            );
+        }
+    }
 }
 
 /// Builder for creating a [`Claude`] client.
@@ -510,6 +575,7 @@ pub struct ClaudeBuilder {
     global_args: Vec<String>,
     timeout: Option<Duration>,
     retry_policy: Option<RetryPolicy>,
+    tested_cli_version_range: Option<(CliVersion, CliVersion)>,
 }
 
 impl ClaudeBuilder {
@@ -614,6 +680,44 @@ impl ClaudeBuilder {
         self
     }
 
+    /// Declare the inclusive `[min, max]` range of `claude` CLI
+    /// versions this client has been tested against.
+    ///
+    /// The wrapper does not enforce the range -- nothing errors when
+    /// it's set wrong. Use [`Claude::cli_version_status`] (or its
+    /// sync mirror) at startup to classify the actually-installed CLI
+    /// against this declaration; that call returns a typed
+    /// [`CliVersionStatus`] AND emits a `tracing::warn!` when
+    /// outside the range. Hosts (claude-server, application code)
+    /// can additionally surface the status to operators.
+    ///
+    /// # Why this exists
+    ///
+    /// CLI semantics drift across minor / patch releases (e.g.
+    /// `claude agents` was repurposed in 2.1.143). The min floor
+    /// lets us say "we know it's broken below this"; the max ceiling
+    /// lets us say "we haven't verified above this -- proceed but
+    /// expect surprises."
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use claude_wrapper::{Claude, CliVersion};
+    ///
+    /// # async fn example() -> claude_wrapper::Result<()> {
+    /// let claude = Claude::builder()
+    ///     .tested_cli_version_range(CliVersion::new(2, 1, 0), CliVersion::new(2, 1, 999))
+    ///     .build()?;
+    /// // Run once at startup to log a warning if the CLI is out of range.
+    /// let _status = claude.cli_version_status().await?;
+    /// # Ok(()) }
+    /// ```
+    #[must_use]
+    pub fn tested_cli_version_range(mut self, min: CliVersion, max: CliVersion) -> Self {
+        self.tested_cli_version_range = Some((min, max));
+        self
+    }
+
     /// Build the Claude client, resolving the binary path.
     pub fn build(self) -> Result<Claude> {
         let binary = match self.binary {
@@ -628,6 +732,7 @@ impl ClaudeBuilder {
             global_args: self.global_args,
             timeout: self.timeout,
             retry_policy: self.retry_policy,
+            tested_cli_version_range: self.tested_cli_version_range,
         })
     }
 }

--- a/crates/claude-wrapper/src/version.rs
+++ b/crates/claude-wrapper/src/version.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 /// let min: CliVersion = "2.1.0".parse().unwrap();
 /// assert!(v >= min);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub struct CliVersion {
     pub major: u32,
     pub minor: u32,
@@ -46,6 +46,70 @@ impl CliVersion {
     #[must_use]
     pub fn satisfies_minimum(&self, minimum: &CliVersion) -> bool {
         self >= minimum
+    }
+
+    /// Classify this version against a tested-against `[min, max]`
+    /// range (both inclusive).
+    ///
+    /// Use to decide whether a host should warn about CLI drift.
+    /// The minimum is the floor we've verified the wrapper still
+    /// works against; the maximum is the upper end of the
+    /// tested-against window. A version below the minimum is a hard
+    /// "we know this is broken"; a version above the maximum is a
+    /// soft "we haven't verified this; semantics may have drifted."
+    #[must_use]
+    pub fn status_within(&self, min: &CliVersion, max: &CliVersion) -> CliVersionStatus {
+        if self < min {
+            CliVersionStatus::OlderThanMinimum {
+                found: *self,
+                minimum: *min,
+            }
+        } else if self > max {
+            CliVersionStatus::NewerUntested {
+                found: *self,
+                tested_max: *max,
+            }
+        } else {
+            CliVersionStatus::Tested
+        }
+    }
+}
+
+/// Classification of an installed CLI version against a tested
+/// range. Returned by [`CliVersion::status_within`] and
+/// [`crate::Claude::cli_version_status`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum CliVersionStatus {
+    /// CLI version is within the tested-against range.
+    Tested,
+    /// CLI is newer than the wrapper's tested-against maximum.
+    /// Semantics may have drifted; the wrapper should still
+    /// generally work but unexpected behavior is possible.
+    NewerUntested {
+        /// The installed CLI version.
+        found: CliVersion,
+        /// Highest CLI version the wrapper has been tested against.
+        tested_max: CliVersion,
+    },
+    /// CLI is older than the declared minimum. The wrapper is
+    /// known to behave incorrectly against this version (missing
+    /// flags, different argument shapes).
+    OlderThanMinimum {
+        /// The installed CLI version.
+        found: CliVersion,
+        /// Lowest CLI version the wrapper supports.
+        minimum: CliVersion,
+    },
+}
+
+impl CliVersionStatus {
+    /// True only for [`CliVersionStatus::Tested`]. Useful for
+    /// callers branching on "should I run?" without pattern
+    /// matching every variant.
+    #[must_use]
+    pub fn is_tested(self) -> bool {
+        matches!(self, CliVersionStatus::Tested)
     }
 }
 
@@ -159,5 +223,73 @@ mod tests {
         assert!("not-a-version".parse::<CliVersion>().is_err());
         assert!("2.1".parse::<CliVersion>().is_err());
         assert!("2.1.x".parse::<CliVersion>().is_err());
+    }
+
+    // -- status_within ---------------------------------------------
+
+    #[test]
+    fn status_tested_at_min() {
+        let v = CliVersion::new(2, 1, 0);
+        let s = v.status_within(&CliVersion::new(2, 1, 0), &CliVersion::new(2, 1, 999));
+        assert_eq!(s, CliVersionStatus::Tested);
+        assert!(s.is_tested());
+    }
+
+    #[test]
+    fn status_tested_at_max() {
+        let v = CliVersion::new(2, 1, 999);
+        let s = v.status_within(&CliVersion::new(2, 1, 0), &CliVersion::new(2, 1, 999));
+        assert_eq!(s, CliVersionStatus::Tested);
+    }
+
+    #[test]
+    fn status_tested_in_middle() {
+        let v = CliVersion::new(2, 1, 143);
+        let s = v.status_within(&CliVersion::new(2, 1, 0), &CliVersion::new(2, 1, 999));
+        assert_eq!(s, CliVersionStatus::Tested);
+    }
+
+    #[test]
+    fn status_newer_untested_above_max() {
+        let v = CliVersion::new(2, 2, 0);
+        let s = v.status_within(&CliVersion::new(2, 1, 0), &CliVersion::new(2, 1, 999));
+        assert_eq!(
+            s,
+            CliVersionStatus::NewerUntested {
+                found: v,
+                tested_max: CliVersion::new(2, 1, 999),
+            }
+        );
+        assert!(!s.is_tested());
+    }
+
+    #[test]
+    fn status_older_than_minimum() {
+        let v = CliVersion::new(2, 0, 99);
+        let s = v.status_within(&CliVersion::new(2, 1, 0), &CliVersion::new(2, 1, 999));
+        assert_eq!(
+            s,
+            CliVersionStatus::OlderThanMinimum {
+                found: v,
+                minimum: CliVersion::new(2, 1, 0),
+            }
+        );
+        assert!(!s.is_tested());
+    }
+
+    #[test]
+    fn status_serializes_to_tagged_json() {
+        let s = CliVersionStatus::Tested;
+        assert_eq!(serde_json::to_string(&s).unwrap(), r#"{"status":"tested"}"#);
+
+        let s = CliVersionStatus::NewerUntested {
+            found: CliVersion::new(2, 2, 0),
+            tested_max: CliVersion::new(2, 1, 999),
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&s).unwrap()).expect("re-parse json");
+        assert_eq!(json["status"], "newer_untested");
+        assert_eq!(json["found"]["major"], 2);
+        assert_eq!(json["tested_max"]["minor"], 1);
     }
 }


### PR DESCRIPTION
## Summary

Adds a typed tested-against window so hosts can detect when the installed `claude` CLI has drifted outside the range the wrapper was verified against.

Triggered by the `claude agents` semantics change in 2.1.143 -- silent CLI drift broke us; we want it loud.

## API

```rust
impl ClaudeBuilder {
    pub fn tested_cli_version_range(self, min: CliVersion, max: CliVersion) -> Self;
}

impl Claude {
    pub fn tested_cli_version_range(&self) -> Option<(CliVersion, CliVersion)>;
    pub async fn cli_version_status(&self) -> Result<CliVersionStatus>;
    pub fn cli_version_status_sync(&self) -> Result<CliVersionStatus>; // sync feature
}

#[serde(tag = \"status\", rename_all = \"snake_case\")]
pub enum CliVersionStatus {
    Tested,
    NewerUntested { found, tested_max },
    OlderThanMinimum { found, minimum },
}
```

## Behavior

- **No range declared**: `cli_version_status()` returns `Tested` silently. Opt-in.
- **CLI in [min, max]**: returns `Tested`.
- **CLI > max**: returns `NewerUntested`, emits `tracing::warn!`. Wrapper does not error -- callers proceed.
- **CLI < min**: returns `OlderThanMinimum`, emits `tracing::warn!`. Same: wrapper does not error.

Intended for one-shot use at startup, not on every command.

## Why this shape

- **Wrapper doesn't enforce**: nothing errors when set wrong. We've never tried to be a runtime gate; this just gives hosts an actionable signal.
- **Typed status enum**: hosts can branch (\"this is API key + untested CLI -- be conservative\") and surface it to operators.
- **`serde::Serialize` on CliVersion + tagged status**: zero-cost for MCP / JSON hosts to ship through.
- **Tracing warn**: respects the host's logging setup; not a hardcoded eprintln.

## Test plan

- [x] 7 new unit tests on `CliVersion::status_within` (at-min, at-max, middle, above-max, below-min, is_tested helper, serde tagged shape)
- [x] All 304 existing lib tests + 70 doctests still pass (now 310 + 71)
- [x] `cargo build` (default, no-default-features+json, no-default-features+sync, all-features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all`

## Follow-ups

- #101: Server consumes this -- surface `cli_version_status` on `claude_doctor` tool + `claude://config` resource so coordinator agents get the typed status without out-of-band knowledge.
- #99 (CLI param audit) + #103 (help-output snapshot tests) provide complementary defenses against drift.