### PR TITLE
chore: release v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/claude-wrapper/CHANGELOG.md
+++ b/crates/claude-wrapper/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.10.0...v0.10.1) - 2026-05-30
+
+### Added
+
+- typed partial-message accessor on StreamEvent (closes #617) ([#620](https://github.com/joshrotenberg/claude-wrapper/pull/620))
+- add QueryCommand::worktree_named for explicit name (closes #616) ([#618](https://github.com/joshrotenberg/claude-wrapper/pull/618))
+
 ## [0.10.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.9.0...v0.10.0) - 2026-05-20
 
 ### Added

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.10.0 -> 0.10.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.10.0...v0.10.1) - 2026-05-30

### Added

- typed partial-message accessor on StreamEvent (closes #617) ([#620](https://github.com/joshrotenberg/claude-wrapper/pull/620))
- add QueryCommand::worktree_named for explicit name (closes #616) ([#618](https://github.com/joshrotenberg/claude-wrapper/pull/618))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).