### PR TITLE
fix(history): anchor decoded_path on filesystem for hyphenated slugs (closes #607)

### DIFF
--- a/crates/claude-wrapper/src/command/query.rs
+++ b/crates/claude-wrapper/src/command/query.rs
@@ -74,6 +74,7 @@ pub struct QueryCommand {
     exclude_dynamic_system_prompt_sections: bool,
     name: Option<String>,
     from_pr: Option<String>,
+    prompt_via_stdin: bool,
 }
 
 impl QueryCommand {
@@ -126,6 +127,7 @@ impl QueryCommand {
             exclude_dynamic_system_prompt_sections: false,
             name: None,
             from_pr: None,
+            prompt_via_stdin: false,
         }
     }
 
@@ -625,7 +627,13 @@ impl QueryCommand {
     pub async fn execute_json(&self, claude: &Claude) -> Result<crate::types::QueryResult> {
         let args = self.build_args_with_forced_json();
 
-        let output = exec::run_claude_with_retry(claude, args, self.retry_policy.as_ref()).await?;
+        let output = if self.prompt_via_stdin {
+            // Retry is skipped for stdin mode: the stdin pipe is consumed
+            // after the first attempt and cannot be rewound.
+            exec::run_claude_with_stdin_prompt(claude, args, self.prompt.clone()).await?
+        } else {
+            exec::run_claude_with_retry(claude, args, self.retry_policy.as_ref()).await?
+        };
 
         serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::Json {
             message: format!("failed to parse query result: {e}"),
@@ -641,7 +649,13 @@ impl QueryCommand {
     /// impl so retries still fire on the sync path.
     #[cfg(feature = "sync")]
     pub fn execute_sync(&self, claude: &Claude) -> Result<CommandOutput> {
-        exec::run_claude_with_retry_sync(claude, self.args(), self.retry_policy.as_ref())
+        if self.prompt_via_stdin {
+            // Retry is skipped for stdin mode: the stdin pipe is consumed
+            // after the first attempt and cannot be rewound.
+            exec::run_claude_with_stdin_prompt_sync(claude, self.build_args(), self.prompt.clone())
+        } else {
+            exec::run_claude_with_retry_sync(claude, self.args(), self.retry_policy.as_ref())
+        }
     }
 
     /// Blocking mirror of [`QueryCommand::execute_json`].
@@ -649,12 +663,49 @@ impl QueryCommand {
     pub fn execute_json_sync(&self, claude: &Claude) -> Result<crate::types::QueryResult> {
         let args = self.build_args_with_forced_json();
 
-        let output = exec::run_claude_with_retry_sync(claude, args, self.retry_policy.as_ref())?;
+        let output = if self.prompt_via_stdin {
+            // Retry is skipped for stdin mode: the stdin pipe is consumed
+            // after the first attempt and cannot be rewound.
+            exec::run_claude_with_stdin_prompt_sync(claude, args, self.prompt.clone())?
+        } else {
+            exec::run_claude_with_retry_sync(claude, args, self.retry_policy.as_ref())?
+        };
 
         serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::Json {
             message: format!("failed to parse query result: {e}"),
             source: e,
         })
+    }
+
+    /// Route the prompt through stdin rather than argv.
+    ///
+    /// When set, the prompt body does not appear in the spawned
+    /// process's argument list (`ps`, `/proc/PID/cmdline`, APM
+    /// agents). Use this for any prompt that contains sensitive
+    /// content: private code, internal design notes, orchestrator
+    /// dispatch specs.
+    ///
+    /// Requires that `claude --print` read from stdin when no
+    /// positional prompt is supplied (verified as of claude 2.1.x).
+    ///
+    /// Note: retry is skipped when stdin mode is active -- the stdin
+    /// pipe is consumed after the first attempt and cannot be rewound.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use claude_wrapper::{Claude, ClaudeCommand, QueryCommand};
+    /// # async fn example() -> claude_wrapper::Result<()> {
+    /// let claude = Claude::builder().build()?;
+    /// let out = QueryCommand::new("my secret prompt")
+    ///     .prompt_via_stdin(true)
+    ///     .execute(&claude)
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    #[must_use]
+    pub fn prompt_via_stdin(mut self, value: bool) -> Self {
+        self.prompt_via_stdin = value;
+        self
     }
 
     /// Like [`Self::build_args`], but if `output_format` is unset on
@@ -881,8 +932,12 @@ impl QueryCommand {
         }
 
         // Separator to prevent flags like --allowed-tools from consuming the prompt.
-        args.push("--".to_string());
-        args.push(self.prompt.clone());
+        // When prompt_via_stdin is set, the prompt is sent via stdin after spawn
+        // rather than appearing in argv (avoids ps/APM/crash-dump leakage).
+        if !self.prompt_via_stdin {
+            args.push("--".to_string());
+            args.push(self.prompt.clone());
+        }
 
         args
     }
@@ -897,7 +952,14 @@ impl ClaudeCommand for QueryCommand {
 
     #[cfg(feature = "async")]
     async fn execute(&self, claude: &Claude) -> Result<CommandOutput> {
-        exec::run_claude_with_retry(claude, self.args(), self.retry_policy.as_ref()).await
+        if self.prompt_via_stdin {
+            // Retry is skipped for stdin mode: the stdin pipe is consumed
+            // after the first attempt and cannot be rewound.
+            let args = self.build_args(); // prompt not in args
+            exec::run_claude_with_stdin_prompt(claude, args, self.prompt.clone()).await
+        } else {
+            exec::run_claude_with_retry(claude, self.args(), self.retry_policy.as_ref()).await
+        }
     }
 }
 
@@ -932,6 +994,55 @@ mod tests {
         let cmd = QueryCommand::new("hello world");
         let args = cmd.args();
         assert_eq!(args, vec!["--print", "--", "hello world"]);
+    }
+
+    #[test]
+    fn prompt_via_stdin_omits_prompt_from_args() {
+        let cmd = QueryCommand::new("secret payload").prompt_via_stdin(true);
+        let args = cmd.args();
+        assert!(
+            !args.contains(&"secret payload".to_string()),
+            "prompt must not appear in args when prompt_via_stdin is set"
+        );
+        assert!(
+            !args.contains(&"--".to_string()),
+            "-- separator must be absent when prompt_via_stdin is set"
+        );
+    }
+
+    #[test]
+    fn prompt_via_stdin_false_keeps_prompt_in_args() {
+        let cmd = QueryCommand::new("visible prompt").prompt_via_stdin(false);
+        let args = cmd.args();
+        assert!(
+            args.contains(&"visible prompt".to_string()),
+            "prompt must still appear in args when prompt_via_stdin is false"
+        );
+        assert!(
+            args.contains(&"--".to_string()),
+            "-- separator must be present when prompt_via_stdin is false"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires a real claude binary"]
+    fn prompt_via_stdin_integration() {
+        // Verify round-trip: prompt sent via stdin produces a valid response.
+        // Run with: cargo test --lib -p claude-wrapper -- --ignored prompt_via_stdin_integration
+        use crate::{Claude, ClaudeCommand};
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let claude = Claude::builder().build().unwrap();
+            let out = QueryCommand::new("reply with: STDIN_OK")
+                .prompt_via_stdin(true)
+                .execute(&claude)
+                .await
+                .unwrap();
+            assert!(
+                !out.stdout.is_empty(),
+                "expected non-empty output from stdin-mode query"
+            );
+        });
     }
 
     #[test]

--- a/crates/claude-wrapper/src/exec.rs
+++ b/crates/claude-wrapper/src/exec.rs
@@ -45,6 +45,238 @@ pub async fn run_claude_with_retry(
     }
 }
 
+/// Run claude, writing `stdin_content` to the child's stdin rather than
+/// passing the prompt as argv.
+///
+/// stdin mode does not retry -- the stdin pipe is consumed after the first
+/// attempt and cannot be rewound for a subsequent try.
+#[cfg(feature = "async")]
+pub async fn run_claude_with_stdin_prompt(
+    claude: &Claude,
+    args: Vec<String>,
+    stdin_content: String,
+) -> Result<CommandOutput> {
+    run_claude_with_stdin_prompt_internal(claude, args, stdin_content).await
+}
+
+#[cfg(feature = "async")]
+async fn run_claude_with_stdin_prompt_internal(
+    claude: &Claude,
+    args: Vec<String>,
+    stdin_content: String,
+) -> Result<CommandOutput> {
+    let mut command_args = Vec::new();
+    command_args.extend(claude.global_args.clone());
+    command_args.extend(args);
+
+    debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command (stdin prompt)");
+
+    let binary = &claude.binary;
+    let env = &claude.env;
+    let working_dir = claude.working_dir.as_deref();
+
+    if let Some(timeout) = claude.timeout {
+        run_with_timeout_stdin(
+            binary,
+            &command_args,
+            env,
+            working_dir,
+            timeout,
+            stdin_content,
+        )
+        .await
+    } else {
+        run_internal_stdin(binary, &command_args, env, working_dir, stdin_content).await
+    }
+}
+
+#[cfg(feature = "async")]
+async fn run_internal_stdin(
+    binary: &std::path::Path,
+    args: &[String],
+    env: &std::collections::HashMap<String, String>,
+    working_dir: Option<&std::path::Path>,
+    stdin_content: String,
+) -> Result<CommandOutput> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut cmd = Command::new(binary);
+    cmd.args(args);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| Error::Io {
+        message: format!("failed to spawn claude: {e}"),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
+
+    // Write the prompt to stdin, then drop the handle so the child sees EOF.
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(stdin_content.as_bytes())
+            .await
+            .map_err(|e| Error::Io {
+                message: format!("failed to write to claude stdin: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })?;
+        // Drop stdin so the child sees EOF.
+    }
+
+    let mut stdout_handle = child.stdout.take().expect("stdout was piped");
+    let mut stderr_handle = child.stderr.take().expect("stderr was piped");
+
+    let (status, stdout_str, stderr_str) = tokio::join!(
+        child.wait(),
+        drain(&mut stdout_handle),
+        drain(&mut stderr_handle),
+    );
+
+    let status = status.map_err(|e| Error::Io {
+        message: "failed to wait for claude process".to_string(),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
+
+    let exit_code = status.code().unwrap_or(-1);
+
+    if !status.success() {
+        return Err(Error::from_command_failure(
+            format!("{} {}", binary.display(), args.join(" ")),
+            exit_code,
+            stdout_str,
+            stderr_str,
+            working_dir.map(|p| p.to_path_buf()),
+        ));
+    }
+
+    Ok(CommandOutput {
+        stdout: stdout_str,
+        stderr: stderr_str,
+        exit_code,
+        success: true,
+    })
+}
+
+#[cfg(feature = "async")]
+async fn run_with_timeout_stdin(
+    binary: &std::path::Path,
+    args: &[String],
+    env: &std::collections::HashMap<String, String>,
+    working_dir: Option<&std::path::Path>,
+    timeout: Duration,
+    stdin_content: String,
+) -> Result<CommandOutput> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut cmd = Command::new(binary);
+    cmd.args(args);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| Error::Io {
+        message: format!("failed to spawn claude: {e}"),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
+
+    // Write the prompt to stdin, then drop the handle so the child sees EOF.
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(stdin_content.as_bytes())
+            .await
+            .map_err(|e| Error::Io {
+                message: format!("failed to write to claude stdin: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })?;
+        // Drop stdin so the child sees EOF.
+    }
+
+    let mut stdout_handle = child.stdout.take().expect("stdout was piped");
+    let mut stderr_handle = child.stderr.take().expect("stderr was piped");
+
+    let wait_and_drain = async {
+        let (status, stdout_str, stderr_str) = tokio::join!(
+            child.wait(),
+            drain(&mut stdout_handle),
+            drain(&mut stderr_handle),
+        );
+        (status, stdout_str, stderr_str)
+    };
+
+    match tokio::time::timeout(timeout, wait_and_drain).await {
+        Ok((Ok(status), stdout, stderr)) => {
+            let exit_code = status.code().unwrap_or(-1);
+
+            if !status.success() {
+                return Err(Error::from_command_failure(
+                    format!("{} {}", binary.display(), args.join(" ")),
+                    exit_code,
+                    stdout,
+                    stderr,
+                    working_dir.map(|p| p.to_path_buf()),
+                ));
+            }
+
+            Ok(CommandOutput {
+                stdout,
+                stderr,
+                exit_code,
+                success: true,
+            })
+        }
+        Ok((Err(e), _stdout, _stderr)) => Err(Error::Io {
+            message: "failed to wait for claude process".to_string(),
+            source: e,
+            working_dir: working_dir.map(|p| p.to_path_buf()),
+        }),
+        Err(_) => {
+            let _ = child.kill().await;
+            let drain_budget = Duration::from_millis(200);
+            let stdout_str = tokio::time::timeout(drain_budget, drain(&mut stdout_handle))
+                .await
+                .unwrap_or_default();
+            let stderr_str = tokio::time::timeout(drain_budget, drain(&mut stderr_handle))
+                .await
+                .unwrap_or_default();
+            if !stdout_str.is_empty() || !stderr_str.is_empty() {
+                warn!(
+                    stdout = %stdout_str,
+                    stderr = %stderr_str,
+                    "partial output from timed-out process",
+                );
+            }
+            Err(Error::Timeout {
+                timeout_seconds: timeout.as_secs(),
+            })
+        }
+    }
+}
+
 #[cfg(feature = "async")]
 async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
     let mut command_args = Vec::new();
@@ -294,6 +526,225 @@ pub fn run_claude_with_retry_sync(
             crate::retry::with_retry_sync(policy, || run_claude_once_sync(claude, args.clone()))
         }
         None => run_claude_once_sync(claude, args),
+    }
+}
+
+/// Blocking mirror of [`run_claude_with_stdin_prompt`].
+///
+/// stdin mode does not retry -- the stdin pipe is consumed after the first
+/// attempt and cannot be rewound.
+#[cfg(feature = "sync")]
+pub fn run_claude_with_stdin_prompt_sync(
+    claude: &Claude,
+    args: Vec<String>,
+    stdin_content: String,
+) -> Result<CommandOutput> {
+    let mut command_args = Vec::new();
+    command_args.extend(claude.global_args.clone());
+    command_args.extend(args);
+
+    debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command (stdin prompt, sync)");
+
+    if let Some(timeout) = claude.timeout {
+        run_with_timeout_stdin_sync(
+            &claude.binary,
+            &command_args,
+            &claude.env,
+            claude.working_dir.as_deref(),
+            timeout,
+            stdin_content,
+        )
+    } else {
+        run_internal_stdin_sync(
+            &claude.binary,
+            &command_args,
+            &claude.env,
+            claude.working_dir.as_deref(),
+            stdin_content,
+        )
+    }
+}
+
+#[cfg(feature = "sync")]
+fn run_internal_stdin_sync(
+    binary: &std::path::Path,
+    args: &[String],
+    env: &std::collections::HashMap<String, String>,
+    working_dir: Option<&std::path::Path>,
+    stdin_content: String,
+) -> Result<CommandOutput> {
+    use std::io::Write;
+    use std::process::{Command as StdCommand, Stdio};
+
+    let mut cmd = StdCommand::new(binary);
+    cmd.args(args);
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| Error::Io {
+        message: format!("failed to spawn claude: {e}"),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
+
+    // Write the prompt to stdin, then drop the handle so the child sees EOF.
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(stdin_content.as_bytes())
+            .map_err(|e| Error::Io {
+                message: format!("failed to write to claude stdin: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })?;
+        stdin.flush().map_err(|e| Error::Io {
+            message: format!("failed to flush claude stdin: {e}"),
+            source: e,
+            working_dir: working_dir.map(|p| p.to_path_buf()),
+        })?;
+        // Drop stdin so the child sees EOF.
+    }
+
+    let output = child.wait_with_output().map_err(|e| Error::Io {
+        message: "failed to wait for claude process".to_string(),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    if !output.status.success() {
+        return Err(Error::from_command_failure(
+            format!("{} {}", binary.display(), args.join(" ")),
+            exit_code,
+            stdout,
+            stderr,
+            working_dir.map(|p| p.to_path_buf()),
+        ));
+    }
+
+    Ok(CommandOutput {
+        stdout,
+        stderr,
+        exit_code,
+        success: true,
+    })
+}
+
+#[cfg(feature = "sync")]
+fn run_with_timeout_stdin_sync(
+    binary: &std::path::Path,
+    args: &[String],
+    env: &std::collections::HashMap<String, String>,
+    working_dir: Option<&std::path::Path>,
+    timeout: Duration,
+    stdin_content: String,
+) -> Result<CommandOutput> {
+    use std::io::Write;
+    use std::process::{Command as StdCommand, Stdio};
+    use std::thread;
+    use wait_timeout::ChildExt;
+
+    let mut cmd = StdCommand::new(binary);
+    cmd.args(args);
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| Error::Io {
+        message: format!("failed to spawn claude: {e}"),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })?;
+
+    // Write the prompt to stdin, then drop the handle so the child sees EOF.
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(stdin_content.as_bytes())
+            .map_err(|e| Error::Io {
+                message: format!("failed to write to claude stdin: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })?;
+        stdin.flush().map_err(|e| Error::Io {
+            message: format!("failed to flush claude stdin: {e}"),
+            source: e,
+            working_dir: working_dir.map(|p| p.to_path_buf()),
+        })?;
+        // Drop stdin so the child sees EOF.
+    }
+
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let stderr = child.stderr.take().expect("stderr was piped");
+
+    let stdout_thread = thread::spawn(move || drain_sync(stdout));
+    let stderr_thread = thread::spawn(move || drain_sync(stderr));
+
+    match child.wait_timeout(timeout).map_err(|e| Error::Io {
+        message: "failed to wait for claude process".to_string(),
+        source: e,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    })? {
+        Some(status) => {
+            let stdout = stdout_thread.join().unwrap_or_default();
+            let stderr = stderr_thread.join().unwrap_or_default();
+            let exit_code = status.code().unwrap_or(-1);
+
+            if !status.success() {
+                return Err(Error::from_command_failure(
+                    format!("{} {}", binary.display(), args.join(" ")),
+                    exit_code,
+                    stdout,
+                    stderr,
+                    working_dir.map(|p| p.to_path_buf()),
+                ));
+            }
+
+            Ok(CommandOutput {
+                stdout,
+                stderr,
+                exit_code,
+                success: true,
+            })
+        }
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let (stdout_str, stderr_str) =
+                join_with_deadline(stdout_thread, stderr_thread, Duration::from_millis(200));
+            if !stdout_str.is_empty() || !stderr_str.is_empty() {
+                warn!(
+                    stdout = %stdout_str,
+                    stderr = %stderr_str,
+                    "partial output from timed-out process",
+                );
+            }
+            Err(Error::Timeout {
+                timeout_seconds: timeout.as_secs(),
+            })
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes `ProjectSummary::decoded_path` being incorrect for any project path containing a literal hyphen in a directory name. The current `decode_slug()` naively replaces every `-` with `/`, so a slug like `-Users-joshrotenberg-Code-active-rust-claude-wrapper` decodes to `/Users/joshrotenberg/Code/active/rust/claude/wrapper` instead of the correct `/Users/joshrotenberg/Code/active/rust/claude-wrapper`.

## Changes

- Replace `decode_slug(slug: &str) -> PathBuf` with `decode_slug_anchored(slug: &str) -> (PathBuf, bool)` that walks left to right, checking `path.exists()` at each `-` boundary to determine whether the boundary is a real `/` or a literal `-`.
- Add `is_decode_verified: bool` to `ProjectSummary` -- `true` when the decode was confirmed against the real filesystem, `false` when it fell back to the naive algorithm.
- Update `summarize_project` to call the new function and populate both fields.
- Expand the `decode_slug_round_trips_simple_paths` test into a full golden table using `tempfile::TempDir` for controlled filesystem state.

## API change

```rust
// Before
pub struct ProjectSummary {
    pub slug: String,
    pub decoded_path: PathBuf,
    pub session_count: usize,
    pub last_modified: Option<SystemTime>,
}

// After
pub struct ProjectSummary {
    pub slug: String,
    pub decoded_path: PathBuf,
    pub is_decode_verified: bool,   // new
    pub session_count: usize,
    pub last_modified: Option<SystemTime>,
}
```

Closes #607.