### PR TITLE
chore: release v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/claude-wrapper/CHANGELOG.md
+++ b/crates/claude-wrapper/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.10.1...v0.11.0) - 2026-06-03
+
+### Fixed
+
+- *(history)* anchor decoded_path on filesystem for hyphenated slugs (closes #607) ([#625](https://github.com/joshrotenberg/claude-wrapper/pull/625))
+- *(history)* anchor decoded_path on filesystem for hyphenated slugs (closes #607) ([#622](https://github.com/joshrotenberg/claude-wrapper/pull/622))
+
+### Other
+
+- *(duplex)* document upstream permission handler limitation ([#626](https://github.com/joshrotenberg/claude-wrapper/pull/626))
+
 ## [0.10.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.10.0...v0.10.1) - 2026-05-30
 
 ### Added

--- a/crates/claude-wrapper/Cargo.toml
+++ b/crates/claude-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.10.1 -> 0.11.0 (⚠ API breaking changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ProjectSummary.is_decode_verified in /tmp/.tmprxAIk5/claude-wrapper/crates/claude-wrapper/src/history.rs:365
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.10.1...v0.11.0) - 2026-06-03

### Fixed

- *(history)* anchor decoded_path on filesystem for hyphenated slugs (closes #607) ([#625](https://github.com/joshrotenberg/claude-wrapper/pull/625))
- *(history)* anchor decoded_path on filesystem for hyphenated slugs (closes #607) ([#622](https://github.com/joshrotenberg/claude-wrapper/pull/622))

### Other

- *(duplex)* document upstream permission handler limitation ([#626](https://github.com/joshrotenberg/claude-wrapper/pull/626))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).