### PR TITLE
feat: add --replay-user-messages and add-json --client-secret

### DIFF
--- a/crates/claude-wrapper/src/command/mcp.rs
+++ b/crates/claude-wrapper/src/command/mcp.rs
@@ -252,6 +252,7 @@ pub struct McpAddJsonCommand {
     name: String,
     json: String,
     scope: Option<Scope>,
+    client_secret: bool,
 }
 
 impl McpAddJsonCommand {
@@ -262,6 +263,7 @@ impl McpAddJsonCommand {
             name: name.into(),
             json: json.into(),
             scope: None,
+            client_secret: false,
         }
     }
 
@@ -269,6 +271,16 @@ impl McpAddJsonCommand {
     #[must_use]
     pub fn scope(mut self, scope: Scope) -> Self {
         self.scope = Some(scope);
+        self
+    }
+
+    /// Prompt for the OAuth client secret (`--client-secret`; or set
+    /// it via the `MCP_CLIENT_SECRET` env var).
+    ///
+    /// Parity with [`McpAddCommand::client_secret`].
+    #[must_use]
+    pub fn client_secret(mut self) -> Self {
+        self.client_secret = true;
         self
     }
 }
@@ -282,6 +294,10 @@ impl ClaudeCommand for McpAddJsonCommand {
         if let Some(ref scope) = self.scope {
             args.push("--scope".to_string());
             args.push(scope.as_arg().to_string());
+        }
+
+        if self.client_secret {
+            args.push("--client-secret".to_string());
         }
 
         args.push(self.name.clone());
@@ -555,6 +571,38 @@ mod tests {
                 "https://example.com/mcp"
             ]
         );
+    }
+
+    #[test]
+    fn test_mcp_add_json_basic() {
+        let cmd = McpAddJsonCommand::new("srv", r#"{"command":"npx"}"#).scope(Scope::User);
+        assert_eq!(
+            cmd.args(),
+            vec![
+                "mcp",
+                "add-json",
+                "--scope",
+                "user",
+                "srv",
+                r#"{"command":"npx"}"#
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mcp_add_json_client_secret() {
+        // #601 parity: add-json accepts --client-secret like add does.
+        let cmd = McpAddJsonCommand::new("srv", "{}").client_secret();
+        assert_eq!(
+            cmd.args(),
+            vec!["mcp", "add-json", "--client-secret", "srv", "{}"]
+        );
+    }
+
+    #[test]
+    fn test_mcp_add_json_no_client_secret_by_default() {
+        let cmd = McpAddJsonCommand::new("srv", "{}");
+        assert!(!cmd.args().contains(&"--client-secret".to_string()));
     }
 
     #[test]

--- a/crates/claude-wrapper/src/command/query.rs
+++ b/crates/claude-wrapper/src/command/query.rs
@@ -77,6 +77,7 @@ pub struct QueryCommand {
     prompt_via_stdin: bool,
     verbose: bool,
     prompt_suggestions: bool,
+    replay_user_messages: bool,
 }
 
 impl QueryCommand {
@@ -132,6 +133,7 @@ impl QueryCommand {
             prompt_via_stdin: false,
             verbose: false,
             prompt_suggestions: false,
+            replay_user_messages: false,
         }
     }
 
@@ -591,6 +593,19 @@ impl QueryCommand {
         self
     }
 
+    /// Re-emit user messages from stdin back on stdout
+    /// (`--replay-user-messages`).
+    ///
+    /// Only meaningful for bidirectional stream-json flows: the CLI
+    /// requires both [`InputFormat::StreamJson`] and
+    /// [`OutputFormat::StreamJson`] for this to take effect. Off by
+    /// default.
+    #[must_use]
+    pub fn replay_user_messages(mut self, value: bool) -> Self {
+        self.replay_user_messages = value;
+        self
+    }
+
     /// Set a per-command retry policy, overriding the client default.
     ///
     /// # Example
@@ -954,6 +969,10 @@ impl QueryCommand {
 
         if self.prompt_suggestions {
             args.push("--prompt-suggestions".to_string());
+        }
+
+        if self.replay_user_messages {
+            args.push("--replay-user-messages".to_string());
         }
 
         if let Some(ref name) = self.name {
@@ -1338,6 +1357,27 @@ mod tests {
                 .prompt_suggestions(false)
                 .args()
                 .contains(&"--prompt-suggestions".to_string())
+        );
+    }
+
+    #[test]
+    fn replay_user_messages_flag_emitted_when_set() {
+        let args = QueryCommand::new("test").replay_user_messages(true).args();
+        assert!(args.contains(&"--replay-user-messages".to_string()));
+    }
+
+    #[test]
+    fn replay_user_messages_absent_by_default_and_when_false() {
+        assert!(
+            !QueryCommand::new("test")
+                .args()
+                .contains(&"--replay-user-messages".to_string())
+        );
+        assert!(
+            !QueryCommand::new("test")
+                .replay_user_messages(false)
+                .args()
+                .contains(&"--replay-user-messages".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

Clears the two genuinely-actionable polish items from the CLI audit follow-up list (#601). Both flag names were verified against the installed `claude` 2.1.173.

- **`QueryCommand::replay_user_messages(bool)` → `--replay-user-messages`.** "Re-emit user messages from stdin back on stdout." Only meaningful for bidirectional stream-json flows (needs `--input-format stream-json` + `--output-format stream-json`); the doc comment says so.
- **`McpAddJsonCommand::client_secret()` → `--client-secret`.** Parity with `McpAddCommand::client_secret()`. Confirmed `claude mcp add-json --help` accepts `--client-secret` ("Prompt for OAuth client secret, or set `MCP_CLIENT_SECRET`").

## Tests

Per-flag emission + default-off tests for both. Also adds the first arg tests for `McpAddJsonCommand` (basic + client-secret + default-off), which had none before.

`cargo fmt`, `clippy --all-targets --all-features -D warnings`, `cargo test --lib --all-features` (420), and `cargo test --doc` (80) all pass.

## Not in scope (#601 stays open as the skip-list)

The rest of #601 is deliberate: interactive-only flags (`--chrome`/`--ide`/`--remote-control`) and `--mcp-debug` (deprecated) are out of scope for `-p` mode, and `UltrareviewCommand` waits on consumer demand. The list's `--worktree <name>` item was already satisfied by `QueryCommand::worktree_named()`. Trimming the issue to reflect that; not closing it.

Refs #601.