### PR TITLE
fix: sync-only test build + keep local scratch out of the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ CLAUDE.md
 .worktrees/
 NAME_IDEAS.md
 /tmp/
+mcp-spec.md
+.claude-server-*.toml

--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -1079,6 +1079,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "async")] // uses tokio + the async-only execute()
     #[ignore = "requires a real claude binary"]
     fn prompt_via_stdin_integration() {
         // Verify round-trip: prompt sent via stdin produces a valid response.


### PR DESCRIPTION
Two pre-release hygiene fixes surfaced by a doc/test audit.

## 1. Sync-only lib test build was broken

`cargo test --lib --no-default-features --features "json,sync"` failed to compile:

```
error[E0599]: no method named `execute` found for struct `QueryCommand`
   --> src/command/query.rs:1092
```

`prompt_via_stdin_integration` uses `tokio::runtime` + the async-only `QueryCommand::execute()` but wasn't `#[cfg(feature = "async")]`. The **library** already builds sync-only (verified); only this `#[ignore]`d test broke the sync-only *test* build. Gated it on `async`.

After: `cargo test --lib --no-default-features --features "json,sync"` compiles and passes (336 tests). All-features unchanged (420).

## 2. Local scratch files could be published

`cargo package --list` was sweeping in `mcp-spec.md`, `.claude-server-dev.toml`, and `.claude-server-sandbox.toml` -- untracked local notes/config that weren't gitignored. They'd leak into a local `cargo publish` (and trip its dirty-tree guard). `mcp-spec.md` was even documented as gitignored. Added the patterns; `cargo package --list` no longer includes them.

## Not included

The audit also flagged ~74 `missing_docs` warnings (un-doc'd public struct fields on `error`/`exec`/`history`, `pub mod` declarations, and a few command `new()` fns). Not a release blocker -- there's no `deny(missing_docs)` and docs.rs builds clean -- so I left it out of this PR. Happy to do a focused docs pass separately if you want to close that gap.

## Verification

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo test --lib --all-features` (420), sync-only `--lib` (336) and `fake_claude_sync` (14), and `cargo test --doc` (80) all pass.