### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.11.0...v0.11.1) - 2026-06-11
+
+### Added
+
+- add --replay-user-messages and add-json --client-secret ([#636](https://github.com/joshrotenberg/claude-wrapper/pull/636))
+- *(query)* add .verbose() and .prompt_suggestions() builders ([#635](https://github.com/joshrotenberg/claude-wrapper/pull/635))
+
+### Fixed
+
+- sync-only test build + keep local scratch out of the package ([#638](https://github.com/joshrotenberg/claude-wrapper/pull/638))
+- *(auth)* don't classify model-404 as auth; surface --bare missing key ([#633](https://github.com/joshrotenberg/claude-wrapper/pull/633))
+
+### Other
+
+- expand live integration coverage (streaming, Session, command surface) ([#639](https://github.com/joshrotenberg/claude-wrapper/pull/639))
+- flatten workspace to a single top-level crate ([#637](https://github.com/joshrotenberg/claude-wrapper/pull/637))
+- update changelog ([#627](https://github.com/joshrotenberg/claude-wrapper/pull/627))
+- bump which from 8.0.2 to 8.0.3 ([#631](https://github.com/joshrotenberg/claude-wrapper/pull/631))
+
 ## [0.11.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.10.1...v0.11.0) - 2026-06-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.11.0 -> 0.11.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.11.0...v0.11.1) - 2026-06-11

### Added

- add --replay-user-messages and add-json --client-secret ([#636](https://github.com/joshrotenberg/claude-wrapper/pull/636))
- *(query)* add .verbose() and .prompt_suggestions() builders ([#635](https://github.com/joshrotenberg/claude-wrapper/pull/635))

### Fixed

- sync-only test build + keep local scratch out of the package ([#638](https://github.com/joshrotenberg/claude-wrapper/pull/638))
- *(auth)* don't classify model-404 as auth; surface --bare missing key ([#633](https://github.com/joshrotenberg/claude-wrapper/pull/633))

### Other

- expand live integration coverage (streaming, Session, command surface) ([#639](https://github.com/joshrotenberg/claude-wrapper/pull/639))
- flatten workspace to a single top-level crate ([#637](https://github.com/joshrotenberg/claude-wrapper/pull/637))
- update changelog ([#627](https://github.com/joshrotenberg/claude-wrapper/pull/627))
- bump which from 8.0.2 to 8.0.3 ([#631](https://github.com/joshrotenberg/claude-wrapper/pull/631))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).