### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.11.1...v0.12.0) - 2026-06-12
+
+### Added
+
+- *(error)* add typed Error::MaxTurnsExceeded for error_max_turns ([#643](https://github.com/joshrotenberg/claude-wrapper/pull/643))
+
+### Fixed
+
+- *(history)* derive project slug from canonicalized cwd, encode dots ([#644](https://github.com/joshrotenberg/claude-wrapper/pull/644))
+
+### Other
+
+- *(error)* [**breaking**] mark Error as #[non_exhaustive] ([#648](https://github.com/joshrotenberg/claude-wrapper/pull/648))
+- install dependency-audit tools as prebuilt binaries ([#646](https://github.com/joshrotenberg/claude-wrapper/pull/646))
+
 ## [0.11.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.11.0...v0.11.1) - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.11.1 -> 0.12.0 (⚠ API breaking changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum Error in /tmp/.tmpOuQYz1/claude-wrapper/src/error.rs:14
  enum Error in /tmp/.tmpOuQYz1/claude-wrapper/src/error.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.11.1...v0.12.0) - 2026-06-12

### Added

- *(error)* add typed Error::MaxTurnsExceeded for error_max_turns ([#643](https://github.com/joshrotenberg/claude-wrapper/pull/643))

### Fixed

- *(history)* derive project slug from canonicalized cwd, encode dots ([#644](https://github.com/joshrotenberg/claude-wrapper/pull/644))

### Other

- *(error)* [**breaking**] mark Error as #[non_exhaustive] ([#648](https://github.com/joshrotenberg/claude-wrapper/pull/648))
- install dependency-audit tools as prebuilt binaries ([#646](https://github.com/joshrotenberg/claude-wrapper/pull/646))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).