### PR TITLE
ci: install dependency-audit tools as prebuilt binaries

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -26,7 +26,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-machete
-        run: cargo install cargo-machete
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
 
       - name: Check unused dependencies
         run: cargo machete
@@ -45,7 +47,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-outdated
-        run: cargo install cargo-outdated
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-outdated
 
       - name: Check outdated
         run: cargo outdated --root-deps-only


### PR DESCRIPTION
## Problem

The **Outdated dependencies** job (`dependencies.yml`) does `cargo install cargo-outdated`, which compiles from source. cargo-outdated's dep tree (`cargo` -> `cargo-credential 0.4.10`) currently **fails to compile** against the latest `time` crate:

```
error[E0119]: conflicting implementations of trait `From<...HourBase>` ...
  = note: conflicting implementation in crate `time`
error: could not compile `cargo-credential`
error: failed to compile `cargo-outdated v0.19.0`
```

So the job fails on every PR that touches `Cargo.toml`/`Cargo.lock` -- it surfaced on the v0.12.0 release PR (#645). Nothing is wrong in this repo; the tool just can't build right now.

## Fix

Install both `cargo-machete` and `cargo-outdated` as **prebuilt binaries** via `taiki-e/install-action` instead of `cargo install`. No source compilation, so an upstream dependency break can't take down our dependency-audit CI -- and it's much faster.

## Note on the release

This check is informational (it lists newer dep versions) and does not gate the release-plz publish, so #645 can be merged independently. Once this lands, release-plz rebases #645 onto the fixed workflow and the check goes green there too.