### PR TITLE
refactor(error)!: mark Error as #[non_exhaustive]

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,14 @@ use std::path::PathBuf;
 use crate::auth::AuthErrorKind;
 
 /// Errors returned by claude-wrapper operations.
+///
+/// This enum is `#[non_exhaustive]`: new variants may be added in
+/// future releases without a major version bump, so downstream `match`
+/// expressions must include a wildcard (`_ =>`) arm. Matching on the
+/// specific variants you care about (e.g. [`Error::Auth`],
+/// [`Error::MaxTurnsExceeded`]) keeps working across upgrades.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// The `claude` binary was not found in PATH.
     #[error("claude binary not found in PATH")]


### PR DESCRIPTION
## Why

`Error` was a plain `pub enum`, so **every new variant is a semver-breaking change** -- downstream `match err { ... }` without a `_` arm stops compiling. Most recently #641's `Error::MaxTurnsExceeded` is what bumped the pending release to a minor (`0.12.0`) on its own.

Marking the enum `#[non_exhaustive]` makes future variant additions non-breaking: consumers must include a `_ =>` arm, after which we can add error variants in patch/minor releases without churn.

```rust
#[derive(Debug, thiserror::Error)]
#[non_exhaustive]
pub enum Error { ... }
```

In-crate matching is unaffected (same-crate matches on a `#[non_exhaustive]` enum may still be exhaustive). Verified: `fmt`, `clippy --all-features -D warnings`, 429 lib + 80 doc tests all pass.

## Timing (important)

This is itself a **one-time breaking change** (consumers matching exhaustively must add `_`). The pending release PR (#645) is already `0.12.0` -- a minor bump from #641's variant -- so this should **land on `main` before #645 is merged** to ride that same release rather than forcing a separate `0.13.0`. release-plz will rebase #645 to include it; the version stays `0.12.0`.

## Scope

Enum-level only -- covers variant additions, the actual pain point. Variant-level `#[non_exhaustive]` (for future field additions) is intentionally out of scope.

Closes #647.