### PR TITLE
chore: release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.0...v0.12.1) - 2026-06-15
+
+### Fixed
+
+- *(history)* encode all non-alphanumeric path chars in project slug ([#650](https://github.com/joshrotenberg/claude-wrapper/pull/650))
+
 ## [0.12.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.11.1...v0.12.0) - 2026-06-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.12.0 -> 0.12.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.0...v0.12.1) - 2026-06-15

### Fixed

- *(history)* encode all non-alphanumeric path chars in project slug ([#650](https://github.com/joshrotenberg/claude-wrapper/pull/650))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).