### PR TITLE
chore: release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.2](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.1...v0.12.2) - 2026-06-24
+
+### Added
+
+- *(ultrareview)* wrap the ultrareview command ([#661](https://github.com/joshrotenberg/claude-wrapper/pull/661))
+- *(mcp)* wrap mcp login and mcp logout ([#660](https://github.com/joshrotenberg/claude-wrapper/pull/660))
+- *(query)* add --plugin-url and --safe-mode flags ([#659](https://github.com/joshrotenberg/claude-wrapper/pull/659))
+
+### Other
+
+- refresh README and crate docs, add introspection example ([#662](https://github.com/joshrotenberg/claude-wrapper/pull/662))
+- *(agents)* CLI coverage scope plus module-inventory refresh ([#658](https://github.com/joshrotenberg/claude-wrapper/pull/658))
+- bump actions/checkout from 6 to 7 ([#652](https://github.com/joshrotenberg/claude-wrapper/pull/652))
+
 ## [0.12.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.0...v0.12.1) - 2026-06-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.12.1 -> 0.12.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.2](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.1...v0.12.2) - 2026-06-24

### Added

- *(ultrareview)* wrap the ultrareview command ([#661](https://github.com/joshrotenberg/claude-wrapper/pull/661))
- *(mcp)* wrap mcp login and mcp logout ([#660](https://github.com/joshrotenberg/claude-wrapper/pull/660))
- *(query)* add --plugin-url and --safe-mode flags ([#659](https://github.com/joshrotenberg/claude-wrapper/pull/659))

### Other

- refresh README and crate docs, add introspection example ([#662](https://github.com/joshrotenberg/claude-wrapper/pull/662))
- *(agents)* CLI coverage scope plus module-inventory refresh ([#658](https://github.com/joshrotenberg/claude-wrapper/pull/658))
- bump actions/checkout from 6 to 7 ([#652](https://github.com/joshrotenberg/claude-wrapper/pull/652))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).