### PR TITLE
docs: refresh README and crate docs, add introspection example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,10 @@ name = "health_check"
 required-features = ["async"]
 
 [[example]]
+name = "inspect_state"
+required-features = ["json"]
+
+[[example]]
 name = "json_output"
 required-features = ["async", "json"]
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,13 @@ Features:
 - Async (tokio) and blocking (`std::thread` + `wait-timeout`) APIs behind feature flags
 - Long-lived `DuplexSession` for hosts (IDE backends, daemons, agent servers, chat UIs): one `claude` subprocess held open across turns, mid-turn interrupts, mid-turn permission decisions, broadcast event subscribers
 - Transient `Session` for short-lived processes (CLIs, build scripts, batch jobs): subprocess-per-turn with `--resume` continuity, cumulative cost + history, optional `BudgetTracker` hard-stops, streaming
+- `Conversation` for host-side history/cost/budget bookkeeping over a `DuplexSession`
 - NDJSON streaming events (`stream_query` / `stream_query_sync`)
 - Typed tool-permission patterns (`ToolPattern`)
-- MCP server management: list, get, add, add-json, remove, add-from-desktop, serve, reset-project-choices
+- Read-side introspection of Claude Code's on-disk state without spawning the CLI: session history, agents, skills, custom commands, settings, background jobs, worktrees
+- MCP server management: list, get, add, add-json, remove, add-from-desktop, login, logout, serve, reset-project-choices
 - Plugin and marketplace subcommands
+- Other subcommands: `doctor`, `install`, `update`, `project purge`, `auto-mode`, and `ultrareview` (cloud-hosted multi-agent code review)
 - Auth: `status`, `login`, `logout`, `setup-token`
 - `McpConfigBuilder` for programmatic `.mcp.json` generation (with optional tempfile backing)
 - Retry policy with fixed or exponential backoff
@@ -41,7 +44,7 @@ Default features: `["async", "json", "tempfile"]`. To drop `tokio`
 entirely for a sync-only build:
 
 ```toml
-claude-wrapper = { version = "0.6", default-features = false, features = ["json", "sync"] }
+claude-wrapper = { version = "0.12", default-features = false, features = ["json", "sync"] }
 ```
 
 ## Quick start (async)
@@ -117,10 +120,13 @@ let claude = Claude::builder()
 | Category | Builders |
 |---|---|
 | Query | `QueryCommand` |
-| MCP | `McpListCommand`, `McpGetCommand`, `McpAddCommand`, `McpAddJsonCommand`, `McpRemoveCommand`, `McpAddFromDesktopCommand`, `McpServeCommand`, `McpResetProjectChoicesCommand` |
-| Plugins | `PluginListCommand`, `PluginInstallCommand`, `PluginUninstallCommand`, `PluginEnableCommand`, `PluginDisableCommand`, `PluginUpdateCommand`, `PluginValidateCommand` |
+| MCP | `McpListCommand`, `McpGetCommand`, `McpAddCommand`, `McpAddJsonCommand`, `McpRemoveCommand`, `McpAddFromDesktopCommand`, `McpLoginCommand`, `McpLogoutCommand`, `McpServeCommand`, `McpResetProjectChoicesCommand` |
+| Plugins | `PluginListCommand`, `PluginInstallCommand`, `PluginUninstallCommand`, `PluginEnableCommand`, `PluginDisableCommand`, `PluginUpdateCommand`, `PluginValidateCommand`, `PluginDetailsCommand`, `PluginPruneCommand`, `PluginTagCommand` |
 | Marketplace | `MarketplaceListCommand`, `MarketplaceAddCommand`, `MarketplaceRemoveCommand`, `MarketplaceUpdateCommand` |
 | Auth | `AuthStatusCommand`, `AuthLoginCommand`, `AuthLogoutCommand`, `SetupTokenCommand` |
+| Auto-mode | `AutoModeConfigCommand`, `AutoModeDefaultsCommand`, `AutoModeCritiqueCommand` |
+| Lifecycle | `InstallCommand`, `UpdateCommand`, `ProjectPurgeCommand` |
+| Review | `UltrareviewCommand` |
 | Misc | `VersionCommand`, `DoctorCommand`, `AgentsCommand`, `RawCommand` |
 
 Every builder implements `ClaudeCommand` (`args()`, async `execute`).
@@ -344,6 +350,34 @@ stream_query(&claude, &cmd, |event: StreamEvent| {
 Sync: `stream_query_sync`. The handler runs on the caller's thread, so
 it can capture non-`Send` state (`Rc<RefCell<_>>`, etc.).
 
+## On-disk introspection
+
+Read Claude Code's on-disk state under `~/.claude` directly, without
+spawning the CLI. Each module exposes a root/loader with `list` / `get`
+accessors and returns an empty result when the directory is absent.
+
+| Module | Type | Reads |
+|---|---|---|
+| `history` | `HistoryRoot` | sessions and transcripts (`projects/<slug>/<id>.jsonl`) |
+| `artifacts` | `AgentsRoot` | agent definitions (`agents/<name>.md`) |
+| `skills` | `SkillsRoot` | skill definitions (`skills/<name>/SKILL.md`) |
+| `commands` | `CommandsRoot` | custom slash commands |
+| `settings` | `SettingsLoader` | the four settings layers, merged by precedence |
+| `jobs` | `JobsRoot` | background-agent / supervisor state |
+| `worktrees` | `WorktreeRoot` | git worktrees for `--worktree` sessions |
+
+```rust
+use claude_wrapper::history::HistoryRoot;
+
+let history = HistoryRoot::home()?;
+for project in history.list_projects()? {
+    println!("{} ({} sessions)", project.decoded_path.display(), project.session_count);
+}
+```
+
+The `history`, `jobs`, and `settings` modules require the `json`
+feature (on by default). See the `inspect_state` example for a tour.
+
 ## MCP servers
 
 ```rust
@@ -471,7 +505,7 @@ let output = RawCommand::new("custom-subcommand")
 Sync-only build with no tokio:
 
 ```toml
-claude-wrapper = { version = "0.6", default-features = false, features = ["json", "sync"] }
+claude-wrapper = { version = "0.12", default-features = false, features = ["json", "sync"] }
 ```
 
 ## Examples
@@ -484,10 +518,14 @@ cargo run --example mcp_config        # MCP config generation
 cargo run --example health_check      # CLI diagnostics
 cargo run --example agent_worker      # Agent worker setup
 cargo run --example supervised_worker # Restart loop with budget tracking
+cargo run --example duplex_chat       # Interactive multi-turn chat (DuplexSession)
+cargo run --example duplex_interrupt  # Cancel an in-flight turn
+cargo run --example duplex_http_service # One DuplexSession behind HTTP routes
+cargo run --example inspect_state --features json # Read on-disk state (no CLI)
 ```
 
-All examples use the async API and require `--features async` (on by
-default).
+Most examples use the async API (`--features async`, on by default);
+`inspect_state` is read-only and needs just `--features json`.
 
 ## Testing
 

--- a/examples/inspect_state.rs
+++ b/examples/inspect_state.rs
@@ -1,0 +1,75 @@
+//! Inspect Claude Code's on-disk state without spawning the CLI.
+//!
+//! The read-side introspection modules parse `~/.claude` directly:
+//! session history, skills, agents, and merged settings. None of this
+//! launches the `claude` binary, so it is cheap and safe to run in a
+//! read-only context. Every accessor degrades to an empty result when
+//! the underlying directory does not exist, so this runs fine on a
+//! machine that has never used Claude Code.
+//!
+//! ```sh
+//! cargo run --example inspect_state --features json
+//! ```
+
+use claude_wrapper::artifacts::AgentsRoot;
+use claude_wrapper::history::HistoryRoot;
+use claude_wrapper::settings::{SettingsLayer, SettingsLoader};
+use claude_wrapper::skills::SkillsRoot;
+
+fn main() -> claude_wrapper::Result<()> {
+    // --- Session history -------------------------------------------------
+    // Stored as line-delimited JSON under
+    // `~/.claude/projects/<slug>/<session_id>.jsonl`.
+    let history = HistoryRoot::home()?;
+    let projects = history.list_projects()?;
+    println!("projects with history: {}", projects.len());
+
+    if let Some(project) = projects.first() {
+        println!(
+            "  {} ({} session(s))",
+            project.decoded_path.display(),
+            project.session_count
+        );
+
+        let sessions = history.list_sessions(Some(&project.slug))?;
+        if let Some(session) = sessions.first() {
+            println!(
+                "  session {} -- {} message(s)",
+                session.session_id, session.message_count
+            );
+
+            // Read and parse the full session log.
+            let log = history.read_session(&session.session_id)?;
+            println!("  entries in log: {}", log.entries.len());
+        }
+    }
+
+    // --- Skills (`~/.claude/skills/<name>/SKILL.md`) ---------------------
+    println!();
+    for skill in SkillsRoot::home()?.list()? {
+        println!(
+            "skill: {} -- {}",
+            skill.name,
+            skill.description.as_deref().unwrap_or("(no description)")
+        );
+    }
+
+    // --- Agents (`~/.claude/agents/<name>.md`) ---------------------------
+    for agent in AgentsRoot::home()?.list()? {
+        println!(
+            "agent: {} (model: {})",
+            agent.name,
+            agent.model.as_deref().unwrap_or("default")
+        );
+    }
+
+    // --- Settings, merged across the four precedence layers --------------
+    let settings = SettingsLoader::home()?.load()?;
+    let present = SettingsLayer::all()
+        .into_iter()
+        .filter(|&layer| settings.get(layer).is_some())
+        .count();
+    println!("\nsettings layers present: {present}/4");
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,14 @@
 //! | Feature | Default | Purpose |
 //! |---|---|---|
 //! | `async` | yes | tokio-backed async API. Disabling drops tokio from the runtime dep tree. |
-//! | `json` | yes | JSON output parsing ([`QueryCommand::execute_json`], [`streaming::StreamEvent`], [`session::Session`], [`streaming::stream_query`]). |
+//! | `json` | yes | JSON output parsing and the JSON-backed surface ([`QueryCommand::execute_json`], [`streaming`], [`session::Session`], [`duplex`], [`conversation`], and the [`history`] / [`jobs`] / [`settings`] introspection modules). |
 //! | `tempfile` | yes | [`TempMcpConfig`] for one-shot MCP config files. |
 //! | `sync` | no | Blocking API: `*_sync` methods on [`exec`], [`retry`], every command builder, and [`Claude`]. |
 //!
 //! Sync-only (tokio-free) build:
 //!
 //! ```toml
-//! claude-wrapper = { version = "0.6", default-features = false, features = ["json", "sync"] }
+//! claude-wrapper = { version = "0.12", default-features = false, features = ["json", "sync"] }
 //! ```
 //!
 //! # Quick start (async)
@@ -258,6 +258,34 @@
 //!     .mcp_config("/tmp/my-project/.mcp.json")
 //!     .execute(&claude)
 //!     .await?;
+//! # Ok(()) }
+//! # }
+//! ```
+//!
+//! # On-disk introspection
+//!
+//! A family of read-only modules parses Claude Code's on-disk state
+//! under `~/.claude` directly, without spawning the CLI. Each exposes a
+//! root/loader with `list` / `get` accessors and degrades to an empty
+//! result when the directory is absent: [`history`] (sessions and
+//! transcripts), [`artifacts`] (agents), [`skills`], [`commands`]
+//! (custom slash commands), [`settings`] (the four merged layers),
+//! [`jobs`] (background-agent state), and [`worktrees`]. See the
+//! `inspect_state` example for an end-to-end tour.
+//!
+//! ```no_run
+//! # #[cfg(feature = "json")] {
+//! use claude_wrapper::history::HistoryRoot;
+//!
+//! # fn example() -> claude_wrapper::Result<()> {
+//! let history = HistoryRoot::home()?;
+//! for project in history.list_projects()? {
+//!     println!(
+//!         "{} ({} sessions)",
+//!         project.decoded_path.display(),
+//!         project.session_count,
+//!     );
+//! }
 //! # Ok(()) }
 //! # }
 //! ```


### PR DESCRIPTION
## Summary

Documentation-maintenance pass from a review of examples, README, rustdoc, and test coverage. No library code changes.

## Examples

- Add `examples/inspect_state.rs`, covering the read-side introspection layer (session history, skills, agents, merged settings) -- the one capability area that had no example. It is read-only (no `claude` subprocess), degrades gracefully when `~/.claude` is empty, and requires only the `json` feature. Registered in `Cargo.toml`; builds, lints, and runs clean.

All ten existing examples still compile against the current API and remain idiomatic.

## README

- Command-builders table refreshed: added `McpLoginCommand`/`McpLogoutCommand`, `PluginDetailsCommand`/`PluginPruneCommand`/`PluginTagCommand`, and new `Auto-mode` / `Lifecycle` (`Install`/`Update`/`ProjectPurge`) / `Review` (`Ultrareview`) rows.
- Feature list: added the read-side introspection layer and `Conversation`; added `login`/`logout` to MCP and an "other subcommands" line.
- New `On-disk introspection` section with a module table and a `HistoryRoot` snippet.
- Examples section now lists the three duplex examples plus `inspect_state`.
- Bumped the stale `version = "0.6"` install pins to `0.12`.

## Crate docs (`src/lib.rs`)

- New `On-disk introspection` section with a runnable doc example (adds one passing doc test).
- Noted that the `json` feature also gates the `history`/`jobs`/`settings`/`conversation` surface.

## Test coverage

Assessed, no changes. Coverage is solid: 427 unit `#[test]` + 74 async tests + fake-binary integration (`fake_claude`, `fake_claude_sync`) + real-binary `integration` (`--ignored`). The introspection modules are well covered. `exec.rs` has no unit tests but is exercised by every integration command. No line-coverage tooling is wired up (deliberately left out of this pass).

## Verification

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo test --doc --all-features` (82 pass), and `cargo build --examples --all-features` all clean. Ran `inspect_state` against real local state.