### PR TITLE
chore: release v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.3](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.2...v0.12.3) - 2026-06-30
+
+### Added
+
+- detect claude's --max-budget-usd cap as MaxBudgetExceeded ([#666](https://github.com/joshrotenberg/claude-wrapper/pull/666))
+
+### Other
+
+- add roba.toml (safe-default + named worker config) ([#665](https://github.com/joshrotenberg/claude-wrapper/pull/665))
+
 ## [0.12.2](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.1...v0.12.2) - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.12.2 -> 0.12.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.3](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.2...v0.12.3) - 2026-06-30

### Added

- detect claude's --max-budget-usd cap as MaxBudgetExceeded ([#666](https://github.com/joshrotenberg/claude-wrapper/pull/666))

### Other

- add roba.toml (safe-default + named worker config) ([#665](https://github.com/joshrotenberg/claude-wrapper/pull/665))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).