### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.3...v0.13.0) - 2026-07-06
+
+### Added
+
+- bring DuplexOptions to parity with the QueryCommand knob set ([#674](https://github.com/joshrotenberg/claude-wrapper/pull/674))
+- [**breaking**] carry cost and turn figures on rail-stop error variants ([#669](https://github.com/joshrotenberg/claude-wrapper/pull/669))
+
+### Fixed
+
+- gate mcp_config serialization tests on the json feature ([#673](https://github.com/joshrotenberg/claude-wrapper/pull/673))
+
+### Other
+
+- point duplex users at Conversation for cost and budget bookkeeping ([#676](https://github.com/joshrotenberg/claude-wrapper/pull/676))
+
 ## [0.12.3](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.2...v0.12.3) - 2026-06-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.12.3"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.12.3 -> 0.13.0 (⚠ API breaking changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure enum_variant_marked_non_exhaustive: enum variant marked #[non_exhaustive] ---

Description:
A public enum's variant has been marked #[non_exhaustive], which will prevent it from being constructed using a literal outside of its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_marked_non_exhaustive.ron

Failed in:
  variant Error:MaxTurnsExceeded in /tmp/.tmpszDGhb/claude-wrapper/src/error.rs:171
  variant Error:MaxBudgetExceeded in /tmp/.tmpszDGhb/claude-wrapper/src/error.rs:219
  variant Error:MaxTurnsExceeded in /tmp/.tmpszDGhb/claude-wrapper/src/error.rs:171
  variant Error:MaxBudgetExceeded in /tmp/.tmpszDGhb/claude-wrapper/src/error.rs:219
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.3...v0.13.0) - 2026-07-06

### Added

- bring DuplexOptions to parity with the QueryCommand knob set ([#674](https://github.com/joshrotenberg/claude-wrapper/pull/674))
- [**breaking**] carry cost and turn figures on rail-stop error variants ([#669](https://github.com/joshrotenberg/claude-wrapper/pull/669))

### Fixed

- gate mcp_config serialization tests on the json feature ([#673](https://github.com/joshrotenberg/claude-wrapper/pull/673))

### Other

- point duplex users at Conversation for cost and budget bookkeeping ([#676](https://github.com/joshrotenberg/claude-wrapper/pull/676))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).