### PR TITLE
fix: gate mcp_config serialization tests on the json feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Unit tests
         run: cargo test --lib --all-features
 
+      - name: Unit tests without default features
+        run: cargo test --lib --no-default-features
+
       - name: Doc tests
         run: cargo test --doc --all-features
 

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -275,6 +275,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "json")]
     fn test_http_server_config() {
         let config = McpConfigBuilder::new().http_server("my-hub", "http://127.0.0.1:9090");
 
@@ -285,6 +286,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "json")]
     fn test_stdio_server_config() {
         let config = McpConfigBuilder::new().stdio_server(
             "my-tool",
@@ -300,7 +302,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tempfile")]
+    #[cfg(all(feature = "tempfile", feature = "json"))]
     fn test_build_temp() {
         let config = McpConfigBuilder::new()
             .http_server("hub", "http://localhost:9090")
@@ -316,6 +318,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "json")]
     fn test_multiple_servers() {
         let config = McpConfigBuilder::new()
             .http_server("hub", "http://localhost:9090")


### PR DESCRIPTION
Closes #670.

## Context

`cargo test --lib --no-default-features` fails: three `mcp_config` tests unwrap `McpConfigBuilder::to_json()`, which by design returns `Err` when the `json` feature is off. CI never caught it because it builds `--no-default-features` but only tests `--all-features`.

## Plan

1. Gate `test_http_server_config`, `test_stdio_server_config`, and `test_multiple_servers` with `#[cfg(feature = "json")]`.
2. Gate `test_build_temp` with `#[cfg(all(feature = "tempfile", feature = "json"))]`: the `tempfile` feature does not imply `json`, and `build_temp()` goes through `to_json()`.
3. Add `cargo test --lib --no-default-features` to `.github/workflows/ci.yml` next to the existing no-default-features build step, so the gap stays closed.
4. Gates before push: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib --all-features`, `cargo test --lib --no-default-features`.