### PR TITLE
feat: bring DuplexOptions to parity with the QueryCommand knob set

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -9,6 +9,7 @@ pub mod plugin;
 pub mod project;
 pub mod query;
 pub mod raw;
+pub(crate) mod spawn_args;
 pub mod ultrareview;
 pub mod update;
 pub mod version;

--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -1,5 +1,6 @@
 use crate::Claude;
 use crate::command::ClaudeCommand;
+use crate::command::spawn_args::SharedSpawnArgs;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
 use crate::tool_pattern::ToolPattern;
@@ -30,37 +31,17 @@ use crate::types::{Effort, InputFormat, OutputFormat, PermissionMode};
 #[derive(Debug, Clone)]
 pub struct QueryCommand {
     prompt: String,
-    model: Option<String>,
-    system_prompt: Option<String>,
-    append_system_prompt: Option<String>,
+    // Spawn-time knobs shared with DuplexOptions; the flag emission
+    // lives on SharedSpawnArgs so the two builders cannot drift.
+    shared: SharedSpawnArgs,
     output_format: Option<OutputFormat>,
-    max_budget_usd: Option<f64>,
-    permission_mode: Option<PermissionMode>,
-    allowed_tools: Vec<ToolPattern>,
-    disallowed_tools: Vec<ToolPattern>,
-    mcp_config: Vec<String>,
-    add_dir: Vec<String>,
-    effort: Option<Effort>,
-    max_turns: Option<u32>,
-    json_schema: Option<String>,
-    continue_session: bool,
-    resume: Option<String>,
-    session_id: Option<String>,
-    fallback_model: Option<String>,
-    no_session_persistence: bool,
-    dangerously_skip_permissions: bool,
-    agent: Option<String>,
-    agents_json: Option<String>,
     tools: Vec<String>,
     file: Vec<String>,
     include_partial_messages: bool,
     input_format: Option<InputFormat>,
-    strict_mcp_config: bool,
     settings: Option<String>,
     fork_session: bool,
     retry_policy: Option<crate::retry::RetryPolicy>,
-    worktree: bool,
-    worktree_name: Option<String>,
     brief: bool,
     debug_filter: Option<String>,
     debug_file: Option<String>,
@@ -88,37 +69,15 @@ impl QueryCommand {
     pub fn new(prompt: impl Into<String>) -> Self {
         Self {
             prompt: prompt.into(),
-            model: None,
-            system_prompt: None,
-            append_system_prompt: None,
+            shared: SharedSpawnArgs::default(),
             output_format: None,
-            max_budget_usd: None,
-            permission_mode: None,
-            allowed_tools: Vec::new(),
-            disallowed_tools: Vec::new(),
-            mcp_config: Vec::new(),
-            add_dir: Vec::new(),
-            effort: None,
-            max_turns: None,
-            json_schema: None,
-            continue_session: false,
-            resume: None,
-            session_id: None,
-            fallback_model: None,
-            no_session_persistence: false,
-            dangerously_skip_permissions: false,
-            agent: None,
-            agents_json: None,
             tools: Vec::new(),
             file: Vec::new(),
             include_partial_messages: false,
             input_format: None,
-            strict_mcp_config: false,
             settings: None,
             fork_session: false,
             retry_policy: None,
-            worktree: false,
-            worktree_name: None,
             brief: false,
             debug_filter: None,
             debug_file: None,
@@ -144,21 +103,21 @@ impl QueryCommand {
     /// Set the model to use (e.g. "sonnet", "opus", or a full model ID).
     #[must_use]
     pub fn model(mut self, model: impl Into<String>) -> Self {
-        self.model = Some(model.into());
+        self.shared.model = Some(model.into());
         self
     }
 
     /// Set a custom system prompt (replaces the default).
     #[must_use]
     pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
-        self.system_prompt = Some(prompt.into());
+        self.shared.system_prompt = Some(prompt.into());
         self
     }
 
     /// Append to the default system prompt.
     #[must_use]
     pub fn append_system_prompt(mut self, prompt: impl Into<String>) -> Self {
-        self.append_system_prompt = Some(prompt.into());
+        self.shared.append_system_prompt = Some(prompt.into());
         self
     }
 
@@ -172,14 +131,14 @@ impl QueryCommand {
     /// Set the maximum budget in USD.
     #[must_use]
     pub fn max_budget_usd(mut self, budget: f64) -> Self {
-        self.max_budget_usd = Some(budget);
+        self.shared.max_budget_usd = Some(budget);
         self
     }
 
     /// Set the permission mode.
     #[must_use]
     pub fn permission_mode(mut self, mode: PermissionMode) -> Self {
-        self.permission_mode = Some(mode);
+        self.shared.permission_mode = Some(mode);
         self
     }
 
@@ -204,14 +163,16 @@ impl QueryCommand {
         I: IntoIterator<Item = T>,
         T: Into<ToolPattern>,
     {
-        self.allowed_tools.extend(tools.into_iter().map(Into::into));
+        self.shared
+            .allowed_tools
+            .extend(tools.into_iter().map(Into::into));
         self
     }
 
     /// Add a single allowed tool pattern.
     #[must_use]
     pub fn allowed_tool(mut self, tool: impl Into<ToolPattern>) -> Self {
-        self.allowed_tools.push(tool.into());
+        self.shared.allowed_tools.push(tool.into());
         self
     }
 
@@ -222,7 +183,8 @@ impl QueryCommand {
         I: IntoIterator<Item = T>,
         T: Into<ToolPattern>,
     {
-        self.disallowed_tools
+        self.shared
+            .disallowed_tools
             .extend(tools.into_iter().map(Into::into));
         self
     }
@@ -230,63 +192,63 @@ impl QueryCommand {
     /// Add a single disallowed tool pattern.
     #[must_use]
     pub fn disallowed_tool(mut self, tool: impl Into<ToolPattern>) -> Self {
-        self.disallowed_tools.push(tool.into());
+        self.shared.disallowed_tools.push(tool.into());
         self
     }
 
     /// Add an MCP config file path.
     #[must_use]
     pub fn mcp_config(mut self, path: impl Into<String>) -> Self {
-        self.mcp_config.push(path.into());
+        self.shared.mcp_config.push(path.into());
         self
     }
 
     /// Add an additional directory for tool access.
     #[must_use]
     pub fn add_dir(mut self, dir: impl Into<String>) -> Self {
-        self.add_dir.push(dir.into());
+        self.shared.add_dir.push(dir.into());
         self
     }
 
     /// Set the effort level.
     #[must_use]
     pub fn effort(mut self, effort: Effort) -> Self {
-        self.effort = Some(effort);
+        self.shared.effort = Some(effort);
         self
     }
 
     /// Set the maximum number of turns.
     #[must_use]
     pub fn max_turns(mut self, turns: u32) -> Self {
-        self.max_turns = Some(turns);
+        self.shared.max_turns = Some(turns);
         self
     }
 
     /// Set a JSON schema for structured output validation.
     #[must_use]
     pub fn json_schema(mut self, schema: impl Into<String>) -> Self {
-        self.json_schema = Some(schema.into());
+        self.shared.json_schema = Some(schema.into());
         self
     }
 
     /// Continue the most recent conversation.
     #[must_use]
     pub fn continue_session(mut self) -> Self {
-        self.continue_session = true;
+        self.shared.continue_session = true;
         self
     }
 
     /// Resume a specific session by ID.
     #[must_use]
     pub fn resume(mut self, session_id: impl Into<String>) -> Self {
-        self.resume = Some(session_id.into());
+        self.shared.resume = Some(session_id.into());
         self
     }
 
     /// Use a specific session ID.
     #[must_use]
     pub fn session_id(mut self, id: impl Into<String>) -> Self {
-        self.session_id = Some(id.into());
+        self.shared.session_id = Some(id.into());
         self
     }
 
@@ -299,9 +261,9 @@ impl QueryCommand {
     /// the CLI.
     #[cfg(all(feature = "json", feature = "async"))]
     pub(crate) fn replace_session(mut self, id: impl Into<String>) -> Self {
-        self.continue_session = false;
-        self.resume = Some(id.into());
-        self.session_id = None;
+        self.shared.continue_session = false;
+        self.shared.resume = Some(id.into());
+        self.shared.session_id = None;
         self.fork_session = false;
         self
     }
@@ -309,21 +271,21 @@ impl QueryCommand {
     /// Set a fallback model for when the primary model is overloaded.
     #[must_use]
     pub fn fallback_model(mut self, model: impl Into<String>) -> Self {
-        self.fallback_model = Some(model.into());
+        self.shared.fallback_model = Some(model.into());
         self
     }
 
     /// Disable session persistence (sessions won't be saved to disk).
     #[must_use]
     pub fn no_session_persistence(mut self) -> Self {
-        self.no_session_persistence = true;
+        self.shared.no_session_persistence = true;
         self
     }
 
     /// Bypass all permission checks. Only use in sandboxed environments.
     #[must_use]
     pub fn dangerously_skip_permissions(mut self) -> Self {
-        self.dangerously_skip_permissions = true;
+        self.shared.dangerously_skip_permissions = true;
         self
     }
 
@@ -342,7 +304,7 @@ impl QueryCommand {
     /// passing it here.
     #[must_use]
     pub fn agent(mut self, agent: impl Into<String>) -> Self {
-        self.agent = Some(agent.into());
+        self.shared.agent = Some(agent.into());
         self
     }
 
@@ -359,7 +321,7 @@ impl QueryCommand {
     /// "prompt": "You are a code reviewer"}}`.
     #[must_use]
     pub fn agents_json(mut self, json: impl Into<String>) -> Self {
-        self.agents_json = Some(json.into());
+        self.shared.agents_json = Some(json.into());
         self
     }
 
@@ -402,7 +364,7 @@ impl QueryCommand {
     /// Only use MCP servers from `--mcp-config`, ignoring all other MCP configurations.
     #[must_use]
     pub fn strict_mcp_config(mut self) -> Self {
-        self.strict_mcp_config = true;
+        self.shared.strict_mcp_config = true;
         self
     }
 
@@ -423,7 +385,7 @@ impl QueryCommand {
     /// Create a new git worktree for this session, providing an isolated working directory.
     #[must_use]
     pub fn worktree(mut self) -> Self {
-        self.worktree = true;
+        self.shared.worktree = true;
         self
     }
 
@@ -451,8 +413,8 @@ impl QueryCommand {
     /// ```
     #[must_use]
     pub fn worktree_named(mut self, name: impl Into<String>) -> Self {
-        self.worktree = true;
-        self.worktree_name = Some(name.into());
+        self.shared.worktree = true;
+        self.shared.worktree_name = Some(name.into());
         self
     }
 
@@ -797,21 +759,6 @@ impl QueryCommand {
     fn build_args(&self) -> Vec<String> {
         let mut args = vec!["--print".to_string()];
 
-        if let Some(ref model) = self.model {
-            args.push("--model".to_string());
-            args.push(model.clone());
-        }
-
-        if let Some(ref prompt) = self.system_prompt {
-            args.push("--system-prompt".to_string());
-            args.push(prompt.clone());
-        }
-
-        if let Some(ref prompt) = self.append_system_prompt {
-            args.push("--append-system-prompt".to_string());
-            args.push(prompt.clone());
-        }
-
         if let Some(ref format) = self.output_format {
             args.push("--output-format".to_string());
             args.push(format.as_arg().to_string());
@@ -824,87 +771,7 @@ impl QueryCommand {
             args.push("--verbose".to_string());
         }
 
-        if let Some(budget) = self.max_budget_usd {
-            args.push("--max-budget-usd".to_string());
-            args.push(budget.to_string());
-        }
-
-        if let Some(ref mode) = self.permission_mode {
-            args.push("--permission-mode".to_string());
-            args.push(mode.as_arg().to_string());
-        }
-
-        if !self.allowed_tools.is_empty() {
-            args.push("--allowed-tools".to_string());
-            args.push(join_patterns(&self.allowed_tools));
-        }
-
-        if !self.disallowed_tools.is_empty() {
-            args.push("--disallowed-tools".to_string());
-            args.push(join_patterns(&self.disallowed_tools));
-        }
-
-        for config in &self.mcp_config {
-            args.push("--mcp-config".to_string());
-            args.push(config.clone());
-        }
-
-        for dir in &self.add_dir {
-            args.push("--add-dir".to_string());
-            args.push(dir.clone());
-        }
-
-        if let Some(ref effort) = self.effort {
-            args.push("--effort".to_string());
-            args.push(effort.as_arg().to_string());
-        }
-
-        if let Some(turns) = self.max_turns {
-            args.push("--max-turns".to_string());
-            args.push(turns.to_string());
-        }
-
-        if let Some(ref schema) = self.json_schema {
-            args.push("--json-schema".to_string());
-            args.push(schema.clone());
-        }
-
-        if self.continue_session {
-            args.push("--continue".to_string());
-        }
-
-        if let Some(ref session_id) = self.resume {
-            args.push("--resume".to_string());
-            args.push(session_id.clone());
-        }
-
-        if let Some(ref id) = self.session_id {
-            args.push("--session-id".to_string());
-            args.push(id.clone());
-        }
-
-        if let Some(ref model) = self.fallback_model {
-            args.push("--fallback-model".to_string());
-            args.push(model.clone());
-        }
-
-        if self.no_session_persistence {
-            args.push("--no-session-persistence".to_string());
-        }
-
-        if self.dangerously_skip_permissions {
-            args.push("--dangerously-skip-permissions".to_string());
-        }
-
-        if let Some(ref agent) = self.agent {
-            args.push("--agent".to_string());
-            args.push(agent.clone());
-        }
-
-        if let Some(ref agents) = self.agents_json {
-            args.push("--agents".to_string());
-            args.push(agents.clone());
-        }
+        self.shared.append_to(&mut args);
 
         if !self.tools.is_empty() {
             args.push("--tools".to_string());
@@ -925,10 +792,6 @@ impl QueryCommand {
             args.push(format.as_arg().to_string());
         }
 
-        if self.strict_mcp_config {
-            args.push("--strict-mcp-config".to_string());
-        }
-
         if let Some(ref settings) = self.settings {
             args.push("--settings".to_string());
             args.push(settings.clone());
@@ -936,13 +799,6 @@ impl QueryCommand {
 
         if self.fork_session {
             args.push("--fork-session".to_string());
-        }
-
-        if self.worktree {
-            args.push("--worktree".to_string());
-            if let Some(ref name) = self.worktree_name {
-                args.push(name.clone());
-            }
         }
 
         if self.brief {
@@ -1062,17 +918,6 @@ fn shell_quote(arg: &str) -> String {
     } else {
         arg.to_string()
     }
-}
-
-fn join_patterns(patterns: &[ToolPattern]) -> String {
-    let mut out = String::new();
-    for (i, p) in patterns.iter().enumerate() {
-        if i > 0 {
-            out.push(',');
-        }
-        out.push_str(p.as_str());
-    }
-    out
 }
 
 #[cfg(test)]

--- a/src/command/spawn_args.rs
+++ b/src/command/spawn_args.rs
@@ -1,0 +1,260 @@
+//! Shared spawn-time flag construction for
+//! [`QueryCommand`](crate::QueryCommand) and
+//! [`DuplexOptions`](crate::duplex::DuplexOptions).
+//!
+//! Both builders embed [`SharedSpawnArgs`] and delegate their setters
+//! to it, so the flag mapping (names, value normalization, joining)
+//! cannot drift between the oneshot and duplex paths.
+
+use crate::tool_pattern::ToolPattern;
+use crate::types::{Effort, PermissionMode};
+
+/// The spawn-time knobs common to `QueryCommand` and `DuplexOptions`.
+///
+/// Fields mirror the CLI flags one-to-one; [`Self::append_to`] owns
+/// the flag emission. Knobs specific to one builder (output format,
+/// stdin plumbing, subscriber capacity, ...) stay on that builder.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct SharedSpawnArgs {
+    pub(crate) model: Option<String>,
+    pub(crate) system_prompt: Option<String>,
+    pub(crate) append_system_prompt: Option<String>,
+    pub(crate) max_budget_usd: Option<f64>,
+    pub(crate) permission_mode: Option<PermissionMode>,
+    pub(crate) allowed_tools: Vec<ToolPattern>,
+    pub(crate) disallowed_tools: Vec<ToolPattern>,
+    pub(crate) mcp_config: Vec<String>,
+    pub(crate) add_dir: Vec<String>,
+    pub(crate) effort: Option<Effort>,
+    pub(crate) max_turns: Option<u32>,
+    pub(crate) json_schema: Option<String>,
+    pub(crate) continue_session: bool,
+    pub(crate) resume: Option<String>,
+    pub(crate) session_id: Option<String>,
+    pub(crate) fallback_model: Option<String>,
+    pub(crate) no_session_persistence: bool,
+    pub(crate) dangerously_skip_permissions: bool,
+    pub(crate) agent: Option<String>,
+    pub(crate) agents_json: Option<String>,
+    pub(crate) strict_mcp_config: bool,
+    pub(crate) worktree: bool,
+    pub(crate) worktree_name: Option<String>,
+}
+
+impl SharedSpawnArgs {
+    /// Append the configured flags to `args`, in a stable order.
+    pub(crate) fn append_to(&self, args: &mut Vec<String>) {
+        if let Some(ref model) = self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+
+        if let Some(ref prompt) = self.system_prompt {
+            args.push("--system-prompt".to_string());
+            args.push(prompt.clone());
+        }
+
+        if let Some(ref prompt) = self.append_system_prompt {
+            args.push("--append-system-prompt".to_string());
+            args.push(prompt.clone());
+        }
+
+        if let Some(budget) = self.max_budget_usd {
+            args.push("--max-budget-usd".to_string());
+            args.push(budget.to_string());
+        }
+
+        if let Some(ref mode) = self.permission_mode {
+            args.push("--permission-mode".to_string());
+            args.push(mode.as_arg().to_string());
+        }
+
+        if !self.allowed_tools.is_empty() {
+            args.push("--allowed-tools".to_string());
+            args.push(join_patterns(&self.allowed_tools));
+        }
+
+        if !self.disallowed_tools.is_empty() {
+            args.push("--disallowed-tools".to_string());
+            args.push(join_patterns(&self.disallowed_tools));
+        }
+
+        for config in &self.mcp_config {
+            args.push("--mcp-config".to_string());
+            args.push(config.clone());
+        }
+
+        for dir in &self.add_dir {
+            args.push("--add-dir".to_string());
+            args.push(dir.clone());
+        }
+
+        if let Some(ref effort) = self.effort {
+            args.push("--effort".to_string());
+            args.push(effort.as_arg().to_string());
+        }
+
+        if let Some(turns) = self.max_turns {
+            args.push("--max-turns".to_string());
+            args.push(turns.to_string());
+        }
+
+        if let Some(ref schema) = self.json_schema {
+            args.push("--json-schema".to_string());
+            args.push(schema.clone());
+        }
+
+        if self.continue_session {
+            args.push("--continue".to_string());
+        }
+
+        if let Some(ref session_id) = self.resume {
+            args.push("--resume".to_string());
+            args.push(session_id.clone());
+        }
+
+        if let Some(ref id) = self.session_id {
+            args.push("--session-id".to_string());
+            args.push(id.clone());
+        }
+
+        if let Some(ref model) = self.fallback_model {
+            args.push("--fallback-model".to_string());
+            args.push(model.clone());
+        }
+
+        if self.no_session_persistence {
+            args.push("--no-session-persistence".to_string());
+        }
+
+        if self.dangerously_skip_permissions {
+            args.push("--dangerously-skip-permissions".to_string());
+        }
+
+        if let Some(ref agent) = self.agent {
+            args.push("--agent".to_string());
+            args.push(agent.clone());
+        }
+
+        if let Some(ref agents) = self.agents_json {
+            args.push("--agents".to_string());
+            args.push(agents.clone());
+        }
+
+        if self.strict_mcp_config {
+            args.push("--strict-mcp-config".to_string());
+        }
+
+        if self.worktree {
+            args.push("--worktree".to_string());
+            if let Some(ref name) = self.worktree_name {
+                args.push(name.clone());
+            }
+        }
+    }
+}
+
+/// Join tool patterns into the comma-separated form the CLI's
+/// `--allowed-tools` / `--disallowed-tools` flags expect.
+pub(crate) fn join_patterns(patterns: &[ToolPattern]) -> String {
+    let mut out = String::new();
+    for (i, p) in patterns.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(p.as_str());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_of(shared: SharedSpawnArgs) -> Vec<String> {
+        let mut args = Vec::new();
+        shared.append_to(&mut args);
+        args
+    }
+
+    #[test]
+    fn default_emits_nothing() {
+        assert!(args_of(SharedSpawnArgs::default()).is_empty());
+    }
+
+    #[test]
+    fn scalar_flags_carry_their_values() {
+        let args = args_of(SharedSpawnArgs {
+            max_turns: Some(3),
+            max_budget_usd: Some(0.5),
+            json_schema: Some(r#"{"type":"object"}"#.to_string()),
+            fallback_model: Some("haiku".to_string()),
+            session_id: Some("sid-1".to_string()),
+            ..Default::default()
+        });
+        for pair in [
+            ["--max-turns", "3"],
+            ["--max-budget-usd", "0.5"],
+            ["--json-schema", r#"{"type":"object"}"#],
+            ["--fallback-model", "haiku"],
+            ["--session-id", "sid-1"],
+        ] {
+            assert!(
+                args.windows(2).any(|w| w[0] == pair[0] && w[1] == pair[1]),
+                "expected {pair:?} in {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn repeatable_flags_emit_once_per_value() {
+        let args = args_of(SharedSpawnArgs {
+            mcp_config: vec!["a.json".to_string(), "b.json".to_string()],
+            add_dir: vec!["/x".to_string()],
+            ..Default::default()
+        });
+        assert_eq!(args.iter().filter(|a| *a == "--mcp-config").count(), 2);
+        assert_eq!(args.iter().filter(|a| *a == "--add-dir").count(), 1);
+    }
+
+    #[test]
+    fn tool_patterns_join_comma_separated() {
+        let args = args_of(SharedSpawnArgs {
+            allowed_tools: vec!["Read".into(), "Bash(git:*)".into()],
+            ..Default::default()
+        });
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--allowed-tools" && w[1] == "Read,Bash(git:*)"),
+            "got {args:?}"
+        );
+    }
+
+    #[test]
+    fn bare_flags_emit_without_values() {
+        let args = args_of(SharedSpawnArgs {
+            continue_session: true,
+            no_session_persistence: true,
+            strict_mcp_config: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            args,
+            vec![
+                "--continue".to_string(),
+                "--no-session-persistence".to_string(),
+                "--strict-mcp-config".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn worktree_name_follows_flag() {
+        let args = args_of(SharedSpawnArgs {
+            worktree: true,
+            worktree_name: Some("wt1".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(args, vec!["--worktree".to_string(), "wt1".to_string()]);
+    }
+}

--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -190,8 +190,10 @@ use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
 use crate::Claude;
+use crate::command::spawn_args::SharedSpawnArgs;
 use crate::error::{Error, Result};
-use crate::types::PermissionMode;
+use crate::tool_pattern::ToolPattern;
+use crate::types::{Effort, PermissionMode};
 
 /// Default capacity of the per-session [`broadcast::Sender`] backing
 /// [`DuplexSession::subscribe`].
@@ -312,17 +314,9 @@ impl std::fmt::Debug for PermissionHandler {
 /// regardless of these options.
 #[derive(Debug, Default, Clone)]
 pub struct DuplexOptions {
-    model: Option<String>,
-    system_prompt: Option<String>,
-    append_system_prompt: Option<String>,
-    resume: Option<String>,
-    continue_session: bool,
-    worktree: bool,
-    worktree_name: Option<String>,
-    agent: Option<String>,
-    agents_json: Option<String>,
-    permission_mode: Option<PermissionMode>,
-    dangerously_skip_permissions: bool,
+    // Spawn-time knobs shared with QueryCommand; the flag emission
+    // lives on SharedSpawnArgs so the two builders cannot drift.
+    shared: SharedSpawnArgs,
     additional_args: Vec<String>,
     subscriber_capacity: Option<usize>,
     on_permission: Option<PermissionHandler>,
@@ -332,21 +326,21 @@ impl DuplexOptions {
     /// Set the model for this session (`--model`).
     #[must_use]
     pub fn model(mut self, model: impl Into<String>) -> Self {
-        self.model = Some(model.into());
+        self.shared.model = Some(model.into());
         self
     }
 
     /// Set the system prompt for this session (`--system-prompt`).
     #[must_use]
     pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
-        self.system_prompt = Some(prompt.into());
+        self.shared.system_prompt = Some(prompt.into());
         self
     }
 
     /// Append to the default system prompt (`--append-system-prompt`).
     #[must_use]
     pub fn append_system_prompt(mut self, prompt: impl Into<String>) -> Self {
-        self.append_system_prompt = Some(prompt.into());
+        self.shared.append_system_prompt = Some(prompt.into());
         self
     }
 
@@ -368,7 +362,7 @@ impl DuplexOptions {
     /// at the CLI; passing both lets the CLI decide (it errors today).
     #[must_use]
     pub fn resume(mut self, session_id: impl Into<String>) -> Self {
-        self.resume = Some(session_id.into());
+        self.shared.resume = Some(session_id.into());
         self
     }
 
@@ -380,7 +374,7 @@ impl DuplexOptions {
     /// session id; use this when "the last one" is what you want.
     #[must_use]
     pub fn continue_session(mut self) -> Self {
-        self.continue_session = true;
+        self.shared.continue_session = true;
         self
     }
 
@@ -396,9 +390,9 @@ impl DuplexOptions {
     /// merge later.
     #[must_use]
     pub fn worktree(mut self, name: Option<impl Into<String>>) -> Self {
-        self.worktree = true;
+        self.shared.worktree = true;
         if let Some(n) = name {
-            self.worktree_name = Some(n.into());
+            self.shared.worktree_name = Some(n.into());
         }
         self
     }
@@ -418,7 +412,7 @@ impl DuplexOptions {
     /// passing it here.
     #[must_use]
     pub fn agent(mut self, name: impl Into<String>) -> Self {
-        self.agent = Some(name.into());
+        self.shared.agent = Some(name.into());
         self
     }
 
@@ -435,7 +429,7 @@ impl DuplexOptions {
     /// "prompt": "You are a code reviewer"}}`.
     #[must_use]
     pub fn agents_json(mut self, json: impl Into<String>) -> Self {
-        self.agents_json = Some(json.into());
+        self.shared.agents_json = Some(json.into());
         self
     }
 
@@ -456,7 +450,7 @@ impl DuplexOptions {
     /// when you really need it.
     #[must_use]
     pub fn permission_mode(mut self, mode: PermissionMode) -> Self {
-        self.permission_mode = Some(mode);
+        self.shared.permission_mode = Some(mode);
         self
     }
 
@@ -469,7 +463,155 @@ impl DuplexOptions {
     /// [`PermissionMode::AcceptEdits`] instead.
     #[must_use]
     pub fn dangerously_skip_permissions(mut self) -> Self {
-        self.dangerously_skip_permissions = true;
+        self.shared.dangerously_skip_permissions = true;
+        self
+    }
+
+    /// Start a new session under a caller-chosen id
+    /// (`--session-id <uuid>`).
+    ///
+    /// Mirrors [`QueryCommand::session_id`](crate::QueryCommand::session_id)
+    /// for the duplex path. Unlike [`Self::resume`] (pick up an
+    /// existing session) or [`Self::continue_session`] (pick up the
+    /// most recent one), this mints a fresh session whose id the host
+    /// knows up front -- useful when the host indexes sessions
+    /// externally before the first turn completes.
+    #[must_use]
+    pub fn session_id(mut self, id: impl Into<String>) -> Self {
+        self.shared.session_id = Some(id.into());
+        self
+    }
+
+    /// Set a JSON schema for structured output validation
+    /// (`--json-schema <schema>`).
+    ///
+    /// Mirrors [`QueryCommand::json_schema`](crate::QueryCommand::json_schema)
+    /// for the duplex path. `schema` is the inline JSON of the schema;
+    /// the turn's closing result message carries the validated
+    /// `structured_output`.
+    #[must_use]
+    pub fn json_schema(mut self, schema: impl Into<String>) -> Self {
+        self.shared.json_schema = Some(schema.into());
+        self
+    }
+
+    /// Add allowed tool patterns (`--allowed-tools`).
+    ///
+    /// Mirrors [`QueryCommand::allowed_tools`](crate::QueryCommand::allowed_tools)
+    /// for the duplex path: accepts anything convertible into
+    /// [`ToolPattern`], including bare strings (e.g. `"Bash"`,
+    /// `"Bash(git log:*)"`, `"mcp__my-server__*"`), and joins them
+    /// into the comma-separated form the CLI expects.
+    #[must_use]
+    pub fn allowed_tools<I, T>(mut self, tools: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<ToolPattern>,
+    {
+        self.shared
+            .allowed_tools
+            .extend(tools.into_iter().map(Into::into));
+        self
+    }
+
+    /// Add a single allowed tool pattern.
+    #[must_use]
+    pub fn allowed_tool(mut self, tool: impl Into<ToolPattern>) -> Self {
+        self.shared.allowed_tools.push(tool.into());
+        self
+    }
+
+    /// Add disallowed tool patterns (`--disallowed-tools`).
+    #[must_use]
+    pub fn disallowed_tools<I, T>(mut self, tools: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<ToolPattern>,
+    {
+        self.shared
+            .disallowed_tools
+            .extend(tools.into_iter().map(Into::into));
+        self
+    }
+
+    /// Add a single disallowed tool pattern.
+    #[must_use]
+    pub fn disallowed_tool(mut self, tool: impl Into<ToolPattern>) -> Self {
+        self.shared.disallowed_tools.push(tool.into());
+        self
+    }
+
+    /// Cap the number of agentic turns (`--max-turns <n>`).
+    ///
+    /// The cap applies per turn sent through [`DuplexSession::send`];
+    /// a turn that exhausts it closes with an `error_max_turns`
+    /// result rather than an assistant reply.
+    #[must_use]
+    pub fn max_turns(mut self, turns: u32) -> Self {
+        self.shared.max_turns = Some(turns);
+        self
+    }
+
+    /// Cap claude's own spend for the session
+    /// (`--max-budget-usd <usd>`).
+    ///
+    /// This is the CLI's cap, checked post-hoc after each API call,
+    /// so a session can overspend before tripping. It is distinct
+    /// from the wrapper's [`BudgetTracker`](crate::budget::BudgetTracker)
+    /// ceiling, which gates oneshot dispatch host-side.
+    #[must_use]
+    pub fn max_budget_usd(mut self, budget: f64) -> Self {
+        self.shared.max_budget_usd = Some(budget);
+        self
+    }
+
+    /// Set a fallback model for when the primary is overloaded
+    /// (`--fallback-model <model>`).
+    #[must_use]
+    pub fn fallback_model(mut self, model: impl Into<String>) -> Self {
+        self.shared.fallback_model = Some(model.into());
+        self
+    }
+
+    /// Set the reasoning effort level (`--effort <level>`).
+    #[must_use]
+    pub fn effort(mut self, effort: Effort) -> Self {
+        self.shared.effort = Some(effort);
+        self
+    }
+
+    /// Add an additional directory for tool access
+    /// (`--add-dir <dir>`, repeatable).
+    #[must_use]
+    pub fn add_dir(mut self, dir: impl Into<String>) -> Self {
+        self.shared.add_dir.push(dir.into());
+        self
+    }
+
+    /// Add an MCP config file path (`--mcp-config <path>`,
+    /// repeatable).
+    ///
+    /// Pair with [`crate::McpConfigBuilder`] to generate the file.
+    #[must_use]
+    pub fn mcp_config(mut self, path: impl Into<String>) -> Self {
+        self.shared.mcp_config.push(path.into());
+        self
+    }
+
+    /// Only use MCP servers from `--mcp-config` files, ignoring the
+    /// user- and project-level MCP configuration
+    /// (`--strict-mcp-config`).
+    #[must_use]
+    pub fn strict_mcp_config(mut self) -> Self {
+        self.shared.strict_mcp_config = true;
+        self
+    }
+
+    /// Do not persist the session to on-disk history
+    /// (`--no-session-persistence`).
+    #[must_use]
+    pub fn no_session_persistence(mut self) -> Self {
+        self.shared.no_session_persistence = true;
         self
     }
 
@@ -529,46 +671,8 @@ impl DuplexOptions {
             "stream-json".to_string(),
         ];
 
-        if let Some(m) = self.model {
-            args.push("--model".to_string());
-            args.push(m);
-        }
-        if let Some(p) = self.system_prompt {
-            args.push("--system-prompt".to_string());
-            args.push(p);
-        }
-        if let Some(p) = self.append_system_prompt {
-            args.push("--append-system-prompt".to_string());
-            args.push(p);
-        }
-        if let Some(id) = self.resume {
-            args.push("--resume".to_string());
-            args.push(id);
-        }
-        if self.continue_session {
-            args.push("--continue".to_string());
-        }
-        if self.worktree {
-            args.push("--worktree".to_string());
-            if let Some(n) = self.worktree_name {
-                args.push(n);
-            }
-        }
-        if let Some(json) = self.agents_json {
-            args.push("--agents".to_string());
-            args.push(json);
-        }
-        if let Some(name) = self.agent {
-            args.push("--agent".to_string());
-            args.push(name);
-        }
-        if let Some(mode) = self.permission_mode {
-            args.push("--permission-mode".to_string());
-            args.push(mode.as_arg().to_string());
-        }
-        if self.dangerously_skip_permissions {
-            args.push("--dangerously-skip-permissions".to_string());
-        }
+        self.shared.append_to(&mut args);
+
         if self.on_permission.is_some() {
             args.push("--permission-prompt-tool".to_string());
             args.push("stdio".to_string());
@@ -1605,6 +1709,132 @@ mod tests {
             agents_pos < dash_dash_pos,
             "--agents must precede `--` separator; got {args:?}"
         );
+    }
+
+    // -- QueryCommand knob-set parity (#672) -------------------------
+
+    #[test]
+    fn into_args_includes_session_id() {
+        let args = DuplexOptions::default().session_id("sid-9").into_args();
+        assert!(args.windows(2).any(|w| w == ["--session-id", "sid-9"]));
+    }
+
+    #[test]
+    fn into_args_includes_json_schema() {
+        let schema = r#"{"type":"object"}"#;
+        let args = DuplexOptions::default().json_schema(schema).into_args();
+        assert!(args.windows(2).any(|w| w == ["--json-schema", schema]));
+    }
+
+    #[test]
+    fn into_args_joins_allowed_tools_comma_separated() {
+        let args = DuplexOptions::default()
+            .allowed_tools(["Read", "Bash(git log:*)"])
+            .allowed_tool("Write")
+            .into_args();
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--allowed-tools", "Read,Bash(git log:*),Write"]),
+            "missing joined --allowed-tools in {args:?}"
+        );
+    }
+
+    #[test]
+    fn into_args_joins_disallowed_tools_comma_separated() {
+        let args = DuplexOptions::default()
+            .disallowed_tools(["WebSearch"])
+            .disallowed_tool("WebFetch")
+            .into_args();
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--disallowed-tools", "WebSearch,WebFetch"]),
+            "missing joined --disallowed-tools in {args:?}"
+        );
+    }
+
+    #[test]
+    fn into_args_includes_caps() {
+        let args = DuplexOptions::default()
+            .max_turns(4)
+            .max_budget_usd(0.25)
+            .into_args();
+        assert!(args.windows(2).any(|w| w == ["--max-turns", "4"]));
+        assert!(args.windows(2).any(|w| w == ["--max-budget-usd", "0.25"]));
+    }
+
+    #[test]
+    fn into_args_includes_fallback_model_and_effort() {
+        let args = DuplexOptions::default()
+            .fallback_model("haiku")
+            .effort(Effort::Low)
+            .into_args();
+        assert!(args.windows(2).any(|w| w == ["--fallback-model", "haiku"]));
+        assert!(args.windows(2).any(|w| w == ["--effort", "low"]));
+    }
+
+    #[test]
+    fn into_args_repeats_add_dir_and_mcp_config() {
+        let args = DuplexOptions::default()
+            .add_dir("/a")
+            .add_dir("/b")
+            .mcp_config("x.json")
+            .strict_mcp_config()
+            .into_args();
+        assert!(args.windows(2).any(|w| w == ["--add-dir", "/a"]));
+        assert!(args.windows(2).any(|w| w == ["--add-dir", "/b"]));
+        assert!(args.windows(2).any(|w| w == ["--mcp-config", "x.json"]));
+        assert!(args.iter().any(|a| a == "--strict-mcp-config"));
+    }
+
+    #[test]
+    fn into_args_includes_no_session_persistence() {
+        let args = DuplexOptions::default()
+            .no_session_persistence()
+            .into_args();
+        assert!(args.iter().any(|a| a == "--no-session-persistence"));
+    }
+
+    #[test]
+    fn parity_flags_land_before_additional_args() {
+        // Same `--` ordering bug class as resume/agent.
+        let args = DuplexOptions::default()
+            .max_turns(2)
+            .json_schema("{}")
+            .arg("--")
+            .arg("trailing")
+            .into_args();
+        let dash_dash_pos = args.iter().position(|a| a == "--").unwrap();
+        for flag in ["--max-turns", "--json-schema"] {
+            let pos = args.iter().position(|a| a == flag).unwrap();
+            assert!(
+                pos < dash_dash_pos,
+                "{flag} must precede `--` separator; got {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn into_args_omits_parity_flags_by_default() {
+        let args = DuplexOptions::default().into_args();
+        for flag in [
+            "--session-id",
+            "--json-schema",
+            "--allowed-tools",
+            "--disallowed-tools",
+            "--max-turns",
+            "--max-budget-usd",
+            "--fallback-model",
+            "--effort",
+            "--add-dir",
+            "--mcp-config",
+            "--strict-mcp-config",
+            "--no-session-persistence",
+        ] {
+            assert!(
+                !args.iter().any(|a| a == flag),
+                "{flag} should not appear by default; got {args:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #672.

## Context

`DuplexOptions` covers only a subset of the `QueryCommand` knob set; the rest (`--json-schema`, `--allowed-tools`/`--disallowed-tools`, `--max-turns`, `--max-budget-usd`, `--fallback-model`, `--effort`, `--add-dir`, `--mcp-config`/`--strict-mcp-config`, `--no-session-persistence`, `--session-id`) must go through the raw `.arg()` escape hatch, losing type safety and value normalization. The issue prefers sharing the flag construction between the two builders over duplicating it, so they cannot drift.

## Plan

1. New `pub(crate)` module `src/command/spawn_args.rs` with `SharedSpawnArgs`: the 23 spawn-time knobs common to both builders (model, prompts, session selection, worktree, agent, permissions, tool patterns, caps, schema, MCP config, dirs, effort, fallback model, persistence) plus an `append_to(&self, args: &mut Vec<String>)` that emits the flags in `QueryCommand`'s current order. `join_patterns` moves here from `query.rs`.
2. `QueryCommand` replaces its copies of those fields with an embedded `SharedSpawnArgs`; its builder methods delegate, `build_args` emits `--print`, output format, and verbose first, then the shared block, then the query-only flags and the `--`/prompt tail. Public API unchanged.
3. `DuplexOptions` embeds the same struct: existing builders delegate, and the missing knobs get first-class builders mirroring `QueryCommand`'s signatures (`json_schema`, `allowed_tools`/`allowed_tool`, `disallowed_tools`/`disallowed_tool`, `max_turns`, `max_budget_usd`, `fallback_model`, `effort`, `add_dir`, `mcp_config`, `strict_mcp_config`, `no_session_persistence`, `session_id`). `into_args` becomes base flags + shared block + `--permission-prompt-tool` + raw args (raw args stay last).
4. Tests: existing `query` and `duplex` arg tests keep passing; new `into_args` tests cover each added builder, including `ToolPattern` joining and numeric formatting.
5. Gates: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib --all-features`, `cargo test --lib --no-default-features`, `cargo test --doc --all-features`, integration tests.

## Out of scope

The issue's related note about a session-level budget accumulator on `DuplexSession` (`TurnResult` is per-turn only) is a separate feature; it gets its own issue.

## Semver

Additive only (new methods, private fields); a regular `feat:` minor.