### PR TITLE
fix: bump install snippets from 0.12 to 0.13 (closes #677)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Default features: `["async", "json", "tempfile"]`. To drop `tokio`
 entirely for a sync-only build:
 
 ```toml
-claude-wrapper = { version = "0.12", default-features = false, features = ["json", "sync"] }
+claude-wrapper = { version = "0.13", default-features = false, features = ["json", "sync"] }
 ```
 
 ## Quick start (async)
@@ -505,7 +505,7 @@ let output = RawCommand::new("custom-subcommand")
 Sync-only build with no tokio:
 
 ```toml
-claude-wrapper = { version = "0.12", default-features = false, features = ["json", "sync"] }
+claude-wrapper = { version = "0.13", default-features = false, features = ["json", "sync"] }
 ```
 
 ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! Sync-only (tokio-free) build:
 //!
 //! ```toml
-//! claude-wrapper = { version = "0.12", default-features = false, features = ["json", "sync"] }
+//! claude-wrapper = { version = "0.13", default-features = false, features = ["json", "sync"] }
 //! ```
 //!
 //! # Quick start (async)


### PR DESCRIPTION
Closes #677.

## Change

The three sync-only install snippets pinned `version = "0.12"`, which as a caret requirement resolves `>=0.12.0, <0.13.0` and will not pull the released 0.13.0. Bumped to `"0.13"`:

- README.md (x2)
- src/lib.rs (`//!` sync-only example)

The primary install (`cargo add claude-wrapper`) is version-agnostic and was already correct. Docs-only.