### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.0...v0.13.1) - 2026-07-06
+
+### Fixed
+
+- bump install snippets from 0.12 to 0.13 (closes #677) ([#682](https://github.com/joshrotenberg/claude-wrapper/pull/682))
+
+### Other
+
+- run fake-binary integration tests on ubuntu and macos ([#689](https://github.com/joshrotenberg/claude-wrapper/pull/689))
+- cover mcp_config write_to / build_temp filesystem paths ([#687](https://github.com/joshrotenberg/claude-wrapper/pull/687))
+- add exec.rs unit coverage ([#686](https://github.com/joshrotenberg/claude-wrapper/pull/686))
+- enforce missing_docs and document undocumented public items ([#685](https://github.com/joshrotenberg/claude-wrapper/pull/685))
+- add module-level //! headers to 16 modules (closes #679) ([#684](https://github.com/joshrotenberg/claude-wrapper/pull/684))
+
 ## [0.13.0](https://github.com/joshrotenberg/claude-wrapper/compare/v0.12.3...v0.13.0) - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.13.0 -> 0.13.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.0...v0.13.1) - 2026-07-06

### Fixed

- bump install snippets from 0.12 to 0.13 (closes #677) ([#682](https://github.com/joshrotenberg/claude-wrapper/pull/682))

### Other

- run fake-binary integration tests on ubuntu and macos ([#689](https://github.com/joshrotenberg/claude-wrapper/pull/689))
- cover mcp_config write_to / build_temp filesystem paths ([#687](https://github.com/joshrotenberg/claude-wrapper/pull/687))
- add exec.rs unit coverage ([#686](https://github.com/joshrotenberg/claude-wrapper/pull/686))
- enforce missing_docs and document undocumented public items ([#685](https://github.com/joshrotenberg/claude-wrapper/pull/685))
- add module-level //! headers to 16 modules (closes #679) ([#684](https://github.com/joshrotenberg/claude-wrapper/pull/684))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).