### PR TITLE
docs: add module-level //! headers to 16 modules (closes #679)

### DIFF
--- a/src/command/agents.rs
+++ b/src/command/agents.rs
@@ -1,3 +1,10 @@
+//! The deprecated `agents` subcommand builder.
+//!
+//! [`AgentsCommand`] wraps `claude agents`. It is retained for
+//! back-compat; prefer the read-side [`crate::artifacts`] introspection
+//! for agent definitions and `--agent` / `--agents` on
+//! [`QueryCommand`](crate::QueryCommand) for selecting one.
+
 #[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;

--- a/src/command/auth.rs
+++ b/src/command/auth.rs
@@ -1,3 +1,10 @@
+//! Authentication subcommand builders.
+//!
+//! Builders for the `claude` auth surface: [`AuthStatusCommand`],
+//! [`AuthLoginCommand`], [`AuthLogoutCommand`], and
+//! [`SetupTokenCommand`]. For detecting which auth strategy the CLI
+//! will use without invoking it, see [`crate::auth`].
+
 use crate::Claude;
 use crate::command::ClaudeCommand;
 use crate::error::Result;

--- a/src/command/doctor.rs
+++ b/src/command/doctor.rs
@@ -1,3 +1,9 @@
+//! The `claude doctor` builder.
+//!
+//! [`DoctorCommand`] runs `claude doctor`, the CLI's installation and
+//! environment health check, and returns its output as
+//! [`CommandOutput`].
+
 #[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;

--- a/src/command/marketplace.rs
+++ b/src/command/marketplace.rs
@@ -1,3 +1,9 @@
+//! Marketplace subcommand builders.
+//!
+//! Builders for the `claude plugin marketplace` surface: list, add,
+//! remove, and update the marketplaces that [`crate::command::plugin`]
+//! installs plugins from.
+
 #[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;

--- a/src/command/mcp.rs
+++ b/src/command/mcp.rs
@@ -1,3 +1,10 @@
+//! MCP server management subcommand builders.
+//!
+//! Builders for the `claude mcp` surface: list, get, add, add-json,
+//! remove, add-from-desktop, login, logout, serve, and
+//! reset-project-choices. To generate a `.mcp.json` config file
+//! programmatically, see [`crate::mcp_config`].
+
 #[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;

--- a/src/command/plugin.rs
+++ b/src/command/plugin.rs
@@ -1,3 +1,10 @@
+//! Plugin subcommand builders.
+//!
+//! Builders for the `claude plugin` surface: list, install, uninstall,
+//! enable, disable, update, validate, details, prune, and tag. See
+//! [`crate::command::marketplace`] for managing the marketplaces
+//! plugins are installed from.
+
 #[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;

--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -1,3 +1,13 @@
+//! The `claude -p` query builder.
+//!
+//! [`QueryCommand`] is the crate's workhorse: a builder for oneshot
+//! print-mode queries covering the full `claude -p` flag surface, with
+//! typed output ([`execute`](QueryCommand::execute) /
+//! [`execute_json`](QueryCommand::execute_json)) and, under the `sync`
+//! feature, blocking peers. Spawn-time flags shared with
+//! [`DuplexOptions`](crate::duplex::DuplexOptions) live in a common
+//! internal `SharedSpawnArgs`, so the two builders cannot drift.
+
 use crate::Claude;
 use crate::command::ClaudeCommand;
 use crate::command::spawn_args::SharedSpawnArgs;

--- a/src/command/raw.rs
+++ b/src/command/raw.rs
@@ -1,3 +1,10 @@
+//! The raw-subcommand escape hatch.
+//!
+//! [`RawCommand`] runs an arbitrary `claude` subcommand with
+//! caller-supplied args, for surfaces this crate does not yet wrap as a
+//! typed builder. Output comes back as [`CommandOutput`]; there is no
+//! typed parsing.
+
 #[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;

--- a/src/command/version.rs
+++ b/src/command/version.rs
@@ -1,3 +1,10 @@
+//! The `claude --version` builder.
+//!
+//! [`VersionCommand`] runs `claude --version` and returns the raw
+//! output. For a parsed, comparable version and tested-range checks,
+//! use [`Claude::cli_version`](crate::Claude::cli_version) and
+//! [`crate::version`].
+
 #[cfg(feature = "async")]
 use crate::Claude;
 use crate::command::ClaudeCommand;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,11 @@
+//! The crate's [`Error`] type and [`Result`] alias.
+//!
+//! Every fallible operation returns [`Result<T>`]. [`Error`] is
+//! `#[non_exhaustive]` and classifies CLI failures into typed variants
+//! (auth, rail-stop caps, timeouts) via
+//! [`Error::from_command_failure`]; see its variant docs for what each
+//! carries.
+
 use std::path::PathBuf;
 
 use crate::auth::AuthErrorKind;

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,3 +1,13 @@
+//! Process spawning and execution for the `claude` CLI.
+//!
+//! Builds and runs the child process behind every command: applies the
+//! [`Claude`] client's binary path, working directory, environment, and
+//! timeout, scrubs the `CLAUDECODE` env var so nested runs are not
+//! detected as recursive, drains stdout/stderr without deadlocking, and
+//! maps failures onto [`Error`] via
+//! [`from_command_failure`](crate::error::Error::from_command_failure).
+//! Both the async (tokio) and blocking (`sync` feature) paths live here.
+
 use std::time::Duration;
 
 #[cfg(feature = "async")]

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -1,3 +1,11 @@
+//! Programmatic `.mcp.json` generation.
+//!
+//! [`McpConfigBuilder`] assembles HTTP and stdio MCP server entries and
+//! serializes them to the `.mcp.json` shape the `claude` CLI expects,
+//! either to a string, a caller-chosen path, or (with the `tempfile`
+//! feature) a self-cleaning [`TempMcpConfig`] for one-shot use with
+//! [`QueryCommand::mcp_config`](crate::QueryCommand::mcp_config).
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,3 +1,10 @@
+//! Retry and backoff for transient CLI failures.
+//!
+//! [`RetryPolicy`] configures how many attempts to make, the
+//! [`BackoffStrategy`] between them, and which errors count as
+//! retryable. A default policy can be attached to the
+//! [`Claude`](crate::Claude) client and overridden per command.
+
 use std::time::Duration;
 
 use tracing::warn;

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,3 +1,10 @@
+//! NDJSON streaming of `claude` events.
+//!
+//! [`stream_query`] (and its blocking peer `stream_query_sync`) run a
+//! query in `stream-json` mode and hand each decoded event to a
+//! caller-supplied callback as it arrives, rather than buffering the
+//! whole run. Requires the `json` feature.
+
 #[cfg(feature = "json")]
 use std::time::Duration;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,10 @@
+//! Shared enums and serde types used across the command builders.
+//!
+//! Small value types like [`Transport`], [`Scope`], [`Effort`],
+//! [`PermissionMode`], [`OutputFormat`], and [`InputFormat`] that map
+//! onto `claude` CLI flag values, with `Display`/`FromStr` and serde
+//! wiring so they round-trip cleanly through args and JSON.
+
 use std::fmt;
 use std::str::FromStr;
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,3 +1,10 @@
+//! Claude CLI version parsing and tested-range checks.
+//!
+//! [`CliVersion`] parses the `claude --version` string; the helpers
+//! here compare it against the range this crate is tested against and
+//! surface drift (via [`CliVersionStatus`] and a `tracing::warn!`) so a
+//! host can react to an unexpectedly old or new CLI.
+
 use std::fmt;
 use std::str::FromStr;
 


### PR DESCRIPTION
Closes #679.

## Change

Added `//!` module-level headers to the 16 modules that lacked them, each a short orientation (role + pointer to the primary type), matching the tone of the already-headed modules:

- Core: `types`, `exec`, `error`, `version`, `mcp_config`, `streaming`, `retry`
- Command builders: `query`, `auth`, `mcp`, `plugin`, `marketplace`, `agents`, `doctor`, `version`, `raw`

Docs-only. `cargo doc --no-deps --all-features` is warning-free; fmt/clippy/tests green.