### PR TITLE
docs: enforce missing_docs and document undocumented public items

### DIFF
--- a/src/command/agents.rs
+++ b/src/command/agents.rs
@@ -40,6 +40,7 @@ pub struct AgentsCommand {
 
 #[allow(deprecated)]
 impl AgentsCommand {
+    /// Create a new [`AgentsCommand`].
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/src/command/auto_mode.rs
+++ b/src/command/auto_mode.rs
@@ -40,6 +40,7 @@ use crate::exec::CommandOutput;
 pub struct AutoModeConfigCommand;
 
 impl AutoModeConfigCommand {
+    /// Create a new [`AutoModeConfigCommand`].
     #[must_use]
     pub fn new() -> Self {
         Self
@@ -67,6 +68,7 @@ impl ClaudeCommand for AutoModeConfigCommand {
 pub struct AutoModeDefaultsCommand;
 
 impl AutoModeDefaultsCommand {
+    /// Create a new [`AutoModeDefaultsCommand`].
     #[must_use]
     pub fn new() -> Self {
         Self
@@ -113,6 +115,7 @@ pub struct AutoModeCritiqueCommand {
 }
 
 impl AutoModeCritiqueCommand {
+    /// Create a new [`AutoModeCritiqueCommand`].
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/src/command/doctor.rs
+++ b/src/command/doctor.rs
@@ -31,6 +31,7 @@ use crate::exec::CommandOutput;
 pub struct DoctorCommand {}
 
 impl DoctorCommand {
+    /// Create a new [`DoctorCommand`].
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -38,6 +38,7 @@ pub struct InstallCommand {
 }
 
 impl InstallCommand {
+    /// Create a new [`InstallCommand`].
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/src/command/mcp.rs
+++ b/src/command/mcp.rs
@@ -474,6 +474,7 @@ impl ClaudeCommand for McpServeCommand {
 pub struct McpResetProjectChoicesCommand;
 
 impl McpResetProjectChoicesCommand {
+    /// Create a new [`McpResetProjectChoicesCommand`].
     #[must_use]
     pub fn new() -> Self {
         Self

--- a/src/command/update.rs
+++ b/src/command/update.rs
@@ -30,6 +30,7 @@ use crate::exec::CommandOutput;
 pub struct UpdateCommand;
 
 impl UpdateCommand {
+    /// Create a new [`UpdateCommand`].
     #[must_use]
     pub fn new() -> Self {
         Self

--- a/src/command/version.rs
+++ b/src/command/version.rs
@@ -32,6 +32,7 @@ use crate::exec::CommandOutput;
 pub struct VersionCommand;
 
 impl VersionCommand {
+    /// Create a new [`VersionCommand`].
     #[must_use]
     pub fn new() -> Self {
         Self

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,31 +27,44 @@ pub enum Error {
     /// A claude command failed with a non-zero exit code.
     #[error("claude command failed: {command} (exit code {exit_code}){}{}{}", working_dir.as_ref().map(|d| format!(" (in {})", d.display())).unwrap_or_default(), if stdout.is_empty() { String::new() } else { format!("\nstdout: {stdout}") }, if stderr.is_empty() { String::new() } else { format!("\nstderr: {stderr}") })]
     CommandFailed {
+        /// The full command line that failed.
         command: String,
+        /// Process exit code.
         exit_code: i32,
+        /// Captured standard output.
         stdout: String,
+        /// Captured standard error.
         stderr: String,
+        /// Working directory the command ran in, when set.
         working_dir: Option<PathBuf>,
     },
 
     /// An I/O error occurred while spawning or communicating with the process.
     #[error("io error: {message}{}", working_dir.as_ref().map(|d| format!(" (in {})", d.display())).unwrap_or_default())]
     Io {
+        /// Human-readable description of the I/O failure.
         message: String,
+        /// The underlying I/O error.
         #[source]
         source: std::io::Error,
+        /// Working directory the operation ran in, when set.
         working_dir: Option<PathBuf>,
     },
 
     /// The command timed out.
     #[error("claude command timed out after {timeout_seconds}s")]
-    Timeout { timeout_seconds: u64 },
+    Timeout {
+        /// The timeout, in seconds, that was exceeded.
+        timeout_seconds: u64,
+    },
 
     /// JSON parsing failed.
     #[cfg(feature = "json")]
     #[error("json parse error: {message}")]
     Json {
+        /// Human-readable description of what failed to parse.
         message: String,
+        /// The underlying serde error.
         #[source]
         source: serde_json::Error,
     },
@@ -59,7 +72,9 @@ pub enum Error {
     /// The installed CLI version does not meet the minimum requirement.
     #[error("CLI version {found} does not meet minimum requirement {minimum}")]
     VersionMismatch {
+        /// The version detected on the system.
         found: crate::version::CliVersion,
+        /// The minimum version required.
         minimum: crate::version::CliVersion,
     },
 
@@ -69,13 +84,21 @@ pub enum Error {
     #[error(
         "dangerous operations are not allowed; set the env var `{env_var}=1` at process start if you really mean it"
     )]
-    DangerousNotAllowed { env_var: &'static str },
+    DangerousNotAllowed {
+        /// Name of the opt-in env var that must be set.
+        env_var: &'static str,
+    },
 
     /// A configured [`BudgetTracker`](crate::budget::BudgetTracker) has
     /// hit its `max_usd` ceiling. Raised before the next call is
     /// dispatched, so the CLI is not invoked.
     #[error("budget exceeded: ${total_usd:.4} spent, ${max_usd:.4} max")]
-    BudgetExceeded { total_usd: f64, max_usd: f64 },
+    BudgetExceeded {
+        /// Total spend accumulated so far, in USD.
+        total_usd: f64,
+        /// The configured ceiling, in USD.
+        max_usd: f64,
+    },
 
     /// A [`DuplexSession`](crate::duplex::DuplexSession) operation was
     /// attempted after the session task exited (child died, EOF on

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -22,9 +22,13 @@ use crate::error::{Error, Result};
 /// Raw output from a claude CLI invocation.
 #[derive(Debug, Clone)]
 pub struct CommandOutput {
+    /// Captured standard output.
     pub stdout: String,
+    /// Captured standard error.
     pub stderr: String,
+    /// Process exit code.
     pub exit_code: i32,
+    /// Whether the process exited successfully (exit code 0).
     pub success: bool,
 }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -454,8 +454,11 @@ pub struct SessionSummary {
 /// Full parsed session.
 #[derive(Debug, Clone, Serialize)]
 pub struct SessionLog {
+    /// The session id (the `.jsonl` file stem).
     pub session_id: String,
+    /// Slug of the project the session belongs to.
     pub project_slug: String,
+    /// Every parsed entry, in file order.
     pub entries: Vec<HistoryEntry>,
 }
 
@@ -468,22 +471,35 @@ pub struct SessionLog {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum HistoryEntry {
+    /// A `user` entry: a prompt turn written by the user.
     User {
+        /// Entry uuid, when present.
         uuid: Option<String>,
+        /// ISO-8601 timestamp, when present.
         timestamp: Option<String>,
+        /// Working directory recorded for the turn, when present.
         cwd: Option<String>,
+        /// Git branch recorded for the turn, when present.
         git_branch: Option<String>,
+        /// The raw `message` payload as Claude Code wrote it.
         message: Value,
+        /// Any additional fields not modeled above.
         #[serde(flatten)]
         rest: serde_json::Map<String, Value>,
     },
+    /// An `assistant` entry: a model response turn.
     Assistant {
+        /// Entry uuid, when present.
         uuid: Option<String>,
+        /// ISO-8601 timestamp, when present.
         timestamp: Option<String>,
+        /// The raw `message` payload as Claude Code wrote it.
         message: Value,
+        /// Any additional fields not modeled above.
         #[serde(flatten)]
         rest: serde_json::Map<String, Value>,
     },
+    /// Any other entry type, carried as raw JSON for caller inspection.
     Other {
         /// The `type` field as Claude Code wrote it.
         type_tag: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,10 +315,12 @@
 //! # Ok(()) }
 //! # }
 //! ```
+#![warn(missing_docs)]
 
 pub mod artifacts;
 pub mod auth;
 pub mod budget;
+/// Per-subcommand builders and the [`command::ClaudeCommand`] trait.
 pub mod command;
 pub mod commands;
 #[cfg(all(feature = "json", feature = "async"))]

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -43,7 +43,9 @@ pub enum McpServerConfig {
     /// HTTP transport (streamable HTTP or SSE).
     #[serde(rename = "http")]
     Http {
+        /// The server endpoint URL.
         url: String,
+        /// Extra HTTP headers to send (e.g. auth).
         #[serde(skip_serializing_if = "HashMap::is_empty")]
         headers: HashMap<String, String>,
     },
@@ -51,9 +53,12 @@ pub enum McpServerConfig {
     /// Stdio transport (subprocess).
     #[serde(rename = "stdio")]
     Stdio {
+        /// The executable to launch.
         command: String,
+        /// Arguments passed to the command.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         args: Vec<String>,
+        /// Environment variables set for the subprocess.
         #[serde(skip_serializing_if = "HashMap::is_empty")]
         env: HashMap<String, String>,
     },

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -232,9 +232,13 @@ impl Settings {
 /// isn't there.
 #[derive(Debug, Clone, Serialize)]
 pub struct SettingsPaths {
+    /// Path to the user settings file (`~/.claude/settings.json`).
     pub user: PathBuf,
+    /// Path to the user-local settings file (`settings.local.json`).
     pub user_local: PathBuf,
+    /// Path to the project settings file, when a project root is known.
     pub project: Option<PathBuf>,
+    /// Path to the project-local settings file, when a project root is known.
     pub project_local: Option<PathBuf>,
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -25,8 +25,11 @@ use std::str::FromStr;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub struct CliVersion {
+    /// Major version component.
     pub major: u32,
+    /// Minor version component.
     pub minor: u32,
+    /// Patch version component.
     pub patch: u32,
 }
 


### PR DESCRIPTION
Closes #678.

## Plan

1. Add `#![warn(missing_docs)]` at the crate root in `src/lib.rs`.
2. Document every item the lint reports, working from the authoritative list:
   `RUSTFLAGS="-W missing_docs" cargo build --all-features 2>&1 | grep "missing documentation"`.
   Most are one-line field docs (struct fields, enum-variant fields, `pub mod` re-exports).
3. Bring the older `Error` variants (`CommandFailed`, `Io`, `Timeout`, etc.) into line with the already-documented `MaxTurnsExceeded` / `MaxBudgetExceeded` fields, so the enum is internally consistent.
4. Verify clean: the same `RUSTFLAGS` build reports zero `missing documentation` warnings under `--all-features` and `--no-default-features`.
5. Gates: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full test matrix.

Promoting to `#![deny(missing_docs)]` in CI is deferred as a follow-up once the tree is proven clean across the release cycle; `warn` gets us the signal without breaking builds on a future stray item.

## Notes

Module-level `//!` headers were handled separately in #679 / PR #684. This pass is item-level docs only.