### PR TITLE
test: cover mcp_config write_to / build_temp filesystem paths

### DIFF
--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -341,4 +341,96 @@ mod tests {
         assert!(json.contains("hub"));
         assert!(json.contains("tool"));
     }
+
+    // -- filesystem / constructor coverage (#681) -------------------
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn write_to_creates_parent_dirs_and_roundtrips() {
+        // Nested path whose parent does not exist exercises create_dir_all.
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a/b/c/servers.mcp.json");
+
+        let written = McpConfigBuilder::new()
+            .http_server("hub", "http://localhost:9090")
+            .stdio_server("tool", "node", ["server.js"])
+            .write_to(&nested)
+            .unwrap();
+
+        assert_eq!(written, nested);
+        assert!(nested.exists());
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&nested).unwrap()).unwrap();
+        let servers = &parsed["mcpServers"];
+        assert_eq!(servers["hub"]["type"], "http");
+        assert_eq!(servers["hub"]["url"], "http://localhost:9090");
+        assert_eq!(servers["tool"]["type"], "stdio");
+        assert_eq!(servers["tool"]["command"], "node");
+        assert_eq!(servers["tool"]["args"][0], "server.js");
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn http_server_with_headers_serializes_headers() {
+        let config = McpConfigBuilder::new().http_server_with_headers(
+            "hub",
+            "http://localhost:9090",
+            [("Authorization", "Bearer token")],
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&config.to_json().unwrap()).unwrap();
+        let hub = &parsed["mcpServers"]["hub"];
+        assert_eq!(hub["type"], "http");
+        assert_eq!(hub["url"], "http://localhost:9090");
+        assert_eq!(hub["headers"]["Authorization"], "Bearer token");
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn stdio_server_with_env_serializes_env() {
+        let config = McpConfigBuilder::new().stdio_server_with_env(
+            "tool",
+            "node",
+            ["server.js"],
+            [("API_KEY", "secret")],
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&config.to_json().unwrap()).unwrap();
+        let tool = &parsed["mcpServers"]["tool"];
+        assert_eq!(tool["type"], "stdio");
+        assert_eq!(tool["command"], "node");
+        assert_eq!(tool["args"][0], "server.js");
+        assert_eq!(tool["env"]["API_KEY"], "secret");
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn raw_server_config_serializes() {
+        let config = McpConfigBuilder::new().server(
+            "raw",
+            McpServerConfig::Http {
+                url: "http://example.test".into(),
+                headers: HashMap::new(),
+            },
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&config.to_json().unwrap()).unwrap();
+        assert_eq!(parsed["mcpServers"]["raw"]["type"], "http");
+        assert_eq!(parsed["mcpServers"]["raw"]["url"], "http://example.test");
+    }
+
+    #[test]
+    #[cfg(all(feature = "tempfile", feature = "json"))]
+    fn build_temp_roundtrips_to_parsed_servers() {
+        let config = McpConfigBuilder::new().http_server_with_headers(
+            "hub",
+            "http://localhost:9090",
+            [("X-Test", "1")],
+        );
+
+        let temp = config.build_temp().unwrap();
+        assert!(temp.path().ends_with(".mcp.json"));
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(temp.path()).unwrap()).unwrap();
+        assert_eq!(parsed["mcpServers"]["hub"]["headers"]["X-Test"], "1");
+    }
 }


### PR DESCRIPTION
Closes #681.

## Context

`src/mcp_config.rs` sits at 60.9% line / 52.4% function. The `to_json` serialization tests exist, but the filesystem and header/env-carrying paths are untested: `write_to` (including the `create_dir_all` branch), `build_temp` round-trips, and the `http_server_with_headers` / `stdio_server_with_env` / raw `server` constructors.

## Plan

Add unit tests, gated per the #670 feature pattern:

- `write_to` into a nested path under a tempdir: exercises `create_dir_all`, asserts the returned path and that the emitted `.mcp.json` parses back (via `serde_json::Value`) to the configured servers.
- `build_temp` round-trip: read the temp file back and assert the parsed servers, including a header.
- `http_server_with_headers` / `stdio_server_with_env` / raw `server`: assert the headers/env/type land in the serialized JSON.

`tempfile` is a dev-dependency, so the tempdir-based `write_to` tests need only the `json` gate; `build_temp` tests are gated on `json` + `tempfile`.

## Gates

`cargo fmt`, `clippy -D warnings`, `cargo test --lib` (all-features and no-default), before/after `llvm-cov` on mcp_config.rs in a PR comment.