### PR TITLE
ci: run fake-binary integration tests on ubuntu and macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
       - name: Unit tests without default features
         run: cargo test --lib --no-default-features
 
+      - name: Integration tests (fake-binary)
+        # tests/fake-claude.sh is a bash script and cannot run on
+        # Windows; gate this step to the Unix runners. integration.rs
+        # is entirely #[ignore] (real binary + auth), so `--test '*'`
+        # without `--ignored` runs only the fake-binary suites.
+        if: matrix.os != 'windows-latest'
+        run: cargo test --test '*' --all-features
+
       - name: Doc tests
         run: cargo test --doc --all-features
 

--- a/tests/fake-claude.sh
+++ b/tests/fake-claude.sh
@@ -10,6 +10,10 @@
 #   FAKE_CLAUDE_COST_USD    - cost in JSON output (default: 0.0)
 #   FAKE_CLAUDE_NUM_TURNS   - num_turns in JSON output (default: 1)
 #   FAKE_CLAUDE_FORKED_SESSION_ID - session_id when --fork-session is present
+#   FAKE_CLAUDE_OUTPUT_BYTES - if >0, OUTPUT becomes this many 'x' bytes,
+#       generated in-process. Use for large-output tests: passing a big
+#       string via FAKE_CLAUDE_OUTPUT hits Linux's 128KB per-env-string
+#       limit (MAX_ARG_STRLEN) and fails execve with E2BIG.
 #
 # Output format is selected by --output-format argument:
 #   stream-json  ->  three NDJSON lines (system/assistant/result)
@@ -18,6 +22,12 @@
 
 OUTPUT="${FAKE_CLAUDE_OUTPUT:-fake response}"
 EXIT_CODE="${FAKE_CLAUDE_EXIT_CODE:-0}"
+
+# Generate large output in-process rather than passing it through the
+# environment (which would exceed Linux's per-env-string limit).
+if [[ -n "${FAKE_CLAUDE_OUTPUT_BYTES:-}" && "${FAKE_CLAUDE_OUTPUT_BYTES}" -gt 0 ]]; then
+    OUTPUT=$(head -c "$FAKE_CLAUDE_OUTPUT_BYTES" /dev/zero | tr '\0' 'x')
+fi
 SESSION_ID="${FAKE_CLAUDE_SESSION_ID:-fake-session-id}"
 ERROR_MSG="${FAKE_CLAUDE_ERROR_MSG:-command failed}"
 DELAY="${FAKE_CLAUDE_DELAY:-0}"

--- a/tests/fake_claude_sync.rs
+++ b/tests/fake_claude_sync.rs
@@ -87,15 +87,18 @@ fn sync_timeout_fires_and_returns_promptly() {
 fn sync_large_output_does_not_deadlock() {
     // Emit ~256KB of output — larger than any reasonable pipe buffer —
     // so the test catches a naive "wait then read" implementation
-    // that would block the child once the pipe fills.
-    let big = "x".repeat(256 * 1024);
-    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", &big)]);
+    // that would block the child once the pipe fills. The payload is
+    // generated inside the child (FAKE_CLAUDE_OUTPUT_BYTES): passing it
+    // via the environment would exceed Linux's 128KB per-env-string
+    // limit and fail execve with E2BIG.
+    let bytes = 256 * 1024;
+    let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT_BYTES", &bytes.to_string())]);
 
     let output = run_claude_sync(&claude, vec!["--version".to_string()])
         .expect("sync execution with large output should succeed");
 
     assert!(output.success);
-    assert!(output.stdout.len() >= big.len());
+    assert!(output.stdout.len() >= bytes);
 }
 
 #[test]
@@ -104,10 +107,10 @@ fn sync_large_output_does_not_deadlock_with_timeout() {
     // (i.e. a Claude with a timeout set, even though we finish well
     // under it). This is the one that proves the concurrent-drain
     // threads in the sync timeout code path actually work.
-    let big = "x".repeat(256 * 1024);
+    let bytes = 256 * 1024;
     let claude = Claude::builder()
         .binary(fake_binary())
-        .env("FAKE_CLAUDE_OUTPUT", &big)
+        .env("FAKE_CLAUDE_OUTPUT_BYTES", bytes.to_string())
         .timeout(Duration::from_secs(10))
         .build()
         .unwrap();
@@ -116,7 +119,7 @@ fn sync_large_output_does_not_deadlock_with_timeout() {
         .expect("sync timeout-path execution with large output should succeed");
 
     assert!(output.success);
-    assert!(output.stdout.len() >= big.len());
+    assert!(output.stdout.len() >= bytes);
 }
 
 // ── command-surface tests ─────────────────────────────────────────


### PR DESCRIPTION
Closes #688.

## Change

Add an integration-tests step to the `test` job that runs the non-ignored, fake-binary suites (`tests/fake_claude.rs`, `tests/fake_claude_sync.rs` -- 45 tests) which CI currently never executes.

```yaml
- name: Integration tests (fake-binary)
  if: matrix.os != 'windows-latest'
  run: cargo test --test '*' --all-features
```

## Why non-Windows only (Option 2 from the issue)

`tests/fake-claude.sh` is a bash script and cannot execute on Windows. Rather than port the fixture or `#[cfg(unix)]`-gate the existing suites, the step is gated to ubuntu + macOS (Option 2 from #688, the lower-risk start). Windows stays on `--lib` / `--doc` as today.

`integration.rs` is entirely `#[ignore]` (real binary + auth) and stays excluded: `--test '*'` without `--ignored` runs 0 of its tests.

## Verification

`cargo test --test '*' --all-features` locally: 31 + 14 + 0 = 45 pass, 27 ignored.