### PR TITLE
feat: add setting_sources to DuplexOptions

### DIFF
--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -58,7 +58,6 @@ pub struct QueryCommand {
     betas: Option<String>,
     plugin_dirs: Vec<String>,
     plugin_urls: Vec<String>,
-    setting_sources: Option<String>,
     tmux: bool,
     bare: bool,
     safe_mode: bool,
@@ -94,7 +93,6 @@ impl QueryCommand {
             betas: None,
             plugin_dirs: Vec::new(),
             plugin_urls: Vec::new(),
-            setting_sources: None,
             tmux: false,
             bare: false,
             safe_mode: false,
@@ -475,7 +473,7 @@ impl QueryCommand {
     /// Comma-separated list of setting sources to load (e.g., "user,project,local").
     #[must_use]
     pub fn setting_sources(mut self, sources: impl Into<String>) -> Self {
-        self.setting_sources = Some(sources.into());
+        self.shared.setting_sources = Some(sources.into());
         self
     }
 
@@ -838,11 +836,6 @@ impl QueryCommand {
         for url in &self.plugin_urls {
             args.push("--plugin-url".to_string());
             args.push(url.clone());
-        }
-
-        if let Some(ref sources) = self.setting_sources {
-            args.push("--setting-sources".to_string());
-            args.push(sources.clone());
         }
 
         if self.tmux {

--- a/src/command/spawn_args.rs
+++ b/src/command/spawn_args.rs
@@ -37,6 +37,7 @@ pub(crate) struct SharedSpawnArgs {
     pub(crate) agent: Option<String>,
     pub(crate) agents_json: Option<String>,
     pub(crate) strict_mcp_config: bool,
+    pub(crate) setting_sources: Option<String>,
     pub(crate) worktree: bool,
     pub(crate) worktree_name: Option<String>,
 }
@@ -145,6 +146,11 @@ impl SharedSpawnArgs {
             args.push("--strict-mcp-config".to_string());
         }
 
+        if let Some(ref sources) = self.setting_sources {
+            args.push("--setting-sources".to_string());
+            args.push(sources.clone());
+        }
+
         if self.worktree {
             args.push("--worktree".to_string());
             if let Some(ref name) = self.worktree_name {
@@ -215,6 +221,29 @@ mod tests {
         });
         assert_eq!(args.iter().filter(|a| *a == "--mcp-config").count(), 2);
         assert_eq!(args.iter().filter(|a| *a == "--add-dir").count(), 1);
+    }
+
+    #[test]
+    fn setting_sources_carries_its_value() {
+        let args = args_of(SharedSpawnArgs {
+            setting_sources: Some("user,project".to_string()),
+            ..Default::default()
+        });
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--setting-sources" && w[1] == "user,project"),
+            "got {args:?}"
+        );
+    }
+
+    #[test]
+    fn empty_setting_sources_still_emits_flag() {
+        // An empty value is meaningful: it loads no setting sources (a full seal).
+        let args = args_of(SharedSpawnArgs {
+            setting_sources: Some(String::new()),
+            ..Default::default()
+        });
+        assert_eq!(args, vec!["--setting-sources".to_string(), String::new()]);
     }
 
     #[test]

--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -622,6 +622,17 @@ impl DuplexOptions {
         self
     }
 
+    /// Comma-separated list of setting sources the CLI loads, for example
+    /// `"user,project,local"` (`--setting-sources`). Pass an empty string to
+    /// load none, sealing the session's promptspace against ambient project
+    /// config (agents, skills, `CLAUDE.md`). Mirrors
+    /// [`QueryCommand::setting_sources`](crate::QueryCommand::setting_sources).
+    #[must_use]
+    pub fn setting_sources(mut self, sources: impl Into<String>) -> Self {
+        self.shared.setting_sources = Some(sources.into());
+        self
+    }
+
     /// Do not persist the session to on-disk history
     /// (`--no-session-persistence`).
     #[must_use]
@@ -1741,6 +1752,24 @@ mod tests {
     fn into_args_includes_session_id() {
         let args = DuplexOptions::default().session_id("sid-9").into_args();
         assert!(args.windows(2).any(|w| w == ["--session-id", "sid-9"]));
+    }
+
+    #[test]
+    fn into_args_includes_setting_sources() {
+        let args = DuplexOptions::default()
+            .setting_sources("user,project")
+            .into_args();
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--setting-sources", "user,project"]),
+            "got {args:?}"
+        );
+    }
+
+    #[test]
+    fn into_args_omits_setting_sources_by_default() {
+        let args = DuplexOptions::default().into_args();
+        assert!(!args.iter().any(|a| a == "--setting-sources"));
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -669,7 +669,8 @@ fn extract_user_text_preview(entry: &Value, max_chars: usize) -> Option<String> 
     let content = entry.get("message")?.get("content")?;
     let raw = if let Some(s) = content.as_str() {
         s.to_string()
-    } else if let Some(arr) = content.as_array() {
+    } else {
+        let arr = content.as_array()?;
         let mut buf = String::new();
         for block in arr {
             let ty = block.get("type").and_then(Value::as_str).unwrap_or("");
@@ -683,8 +684,6 @@ fn extract_user_text_preview(entry: &Value, max_chars: usize) -> Option<String> 
             }
         }
         buf
-    } else {
-        return None;
     };
     let one_line = raw
         .split('\n')


### PR DESCRIPTION
`--setting-sources` was emitted only by `QueryCommand`, so `DuplexOptions` (and DuplexSession-backed hosts) could not seal a session's promptspace against ambient project config (agents, skills, `CLAUDE.md`).

## Change
- Move `setting_sources` from `QueryCommand` onto the shared `SharedSpawnArgs`, so both the one-shot and duplex spawn paths carry it and the builders cannot drift (matching the existing shared model for `strict_mcp_config`, `mcp_config`, etc.).
- Add a `DuplexOptions::setting_sources` builder mirroring `QueryCommand::setting_sources`.
- `QueryCommand`'s public setter is unchanged; its value now lives in the shared struct. An empty value is meaningful (loads no setting sources, a full seal) and still emits the flag.

## Tests
`SharedSpawnArgs` emits the flag (and with an empty value); `DuplexOptions::into_args` includes it when set and omits it by default; the existing `QueryCommand` test still passes. Full suite: 497 lib + 82 doc.

## Also
A second commit fixes a `clippy::question_mark` lint in `history.rs` that a newer stable clippy (1.97) raises on `main` (toolchain drift, unrelated to this change), so CI is green.

## Downstream
Enables hermetic sealing for duplex `session_start` / `run` in claude-server-mcp (joshrotenberg/claude-server-mcp#14). That server can consume this after a claude-wrapper release.