### PR TITLE
chore: release v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.2](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.1...v0.13.2) - 2026-07-13
+
+### Added
+
+- add hermetic() preset to seal ambient claude config ([#695](https://github.com/joshrotenberg/claude-wrapper/pull/695))
+- promote spawn-safe QueryCommand knobs to DuplexOptions builders ([#694](https://github.com/joshrotenberg/claude-wrapper/pull/694))
+- add setting_sources to DuplexOptions ([#692](https://github.com/joshrotenberg/claude-wrapper/pull/692))
+
+### Fixed
+
+- retry spawn on ETXTBSY to debounce fork/exec race in tests ([#696](https://github.com/joshrotenberg/claude-wrapper/pull/696))
+
 ## [0.13.1](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.0...v0.13.1) - 2026-07-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.13.1 -> 0.13.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.2](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.1...v0.13.2) - 2026-07-13

### Added

- add hermetic() preset to seal ambient claude config ([#695](https://github.com/joshrotenberg/claude-wrapper/pull/695))
- promote spawn-safe QueryCommand knobs to DuplexOptions builders ([#694](https://github.com/joshrotenberg/claude-wrapper/pull/694))
- add setting_sources to DuplexOptions ([#692](https://github.com/joshrotenberg/claude-wrapper/pull/692))

### Fixed

- retry spawn on ETXTBSY to debounce fork/exec race in tests ([#696](https://github.com/joshrotenberg/claude-wrapper/pull/696))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).