### PR TITLE
feat: add hermetic() preset to seal ambient claude config

### DIFF
--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -14,7 +14,7 @@ use crate::command::spawn_args::SharedSpawnArgs;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
 use crate::tool_pattern::ToolPattern;
-use crate::types::{Effort, InputFormat, OutputFormat, PermissionMode};
+use crate::types::{Effort, HermeticScope, InputFormat, OutputFormat, PermissionMode};
 
 /// Builder for `claude -p <prompt>` (oneshot print-mode queries).
 ///
@@ -442,6 +442,38 @@ impl QueryCommand {
     #[must_use]
     pub fn setting_sources(mut self, sources: impl Into<String>) -> Self {
         self.shared.setting_sources = Some(sources.into());
+        self
+    }
+
+    /// Seal the ambient `~/.claude` config for a reproducible run
+    /// ([`HermeticScope::Full`]).
+    ///
+    /// Equivalent to `hermetic_scoped(HermeticScope::Full)`: drops all
+    /// ambient setting sources (`--setting-sources ""`), restricts MCP
+    /// to `--mcp-config` servers (`--strict-mcp-config`), and moves
+    /// per-machine sections out of the system prompt
+    /// (`--exclude-dynamic-system-prompt-sections`). Provide everything
+    /// the run needs explicitly via [`Self::append_system_prompt`],
+    /// [`Self::mcp_config`], [`Self::add_dir`], and friends.
+    ///
+    /// This is not [`Self::bare`]: a hermetic seal leaves OAuth and
+    /// keychain auth working, whereas `--bare` forces API-key billing.
+    /// A later [`Self::setting_sources`] call overrides the seal scope.
+    #[must_use]
+    pub fn hermetic(mut self) -> Self {
+        self.shared.apply_hermetic(HermeticScope::Full);
+        self
+    }
+
+    /// Seal the ambient `~/.claude` config at an explicit
+    /// [`HermeticScope`].
+    ///
+    /// See [`Self::hermetic`] for the flag set. Use
+    /// [`HermeticScope::Project`] to keep the user's global `~/.claude`
+    /// while sealing project and local ambient config.
+    #[must_use]
+    pub fn hermetic_scoped(mut self, scope: HermeticScope) -> Self {
+        self.shared.apply_hermetic(scope);
         self
     }
 
@@ -1322,6 +1354,48 @@ mod tests {
         let cmd = QueryCommand::new("test");
         let args = cmd.args();
         assert!(!args.contains(&"--safe-mode".to_string()));
+    }
+
+    #[test]
+    fn hermetic_emits_full_seal_flags() {
+        let args = QueryCommand::new("test").hermetic().args();
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--setting-sources" && w[1].is_empty()),
+            "got {args:?}"
+        );
+        assert!(args.contains(&"--strict-mcp-config".to_string()));
+        assert!(args.contains(&"--exclude-dynamic-system-prompt-sections".to_string()));
+        assert!(!args.contains(&"--bare".to_string()));
+    }
+
+    #[test]
+    fn hermetic_scoped_project_keeps_user() {
+        let args = QueryCommand::new("test")
+            .hermetic_scoped(HermeticScope::Project)
+            .args();
+        assert!(args.windows(2).any(|w| w == ["--setting-sources", "user"]));
+        assert!(args.contains(&"--strict-mcp-config".to_string()));
+    }
+
+    #[test]
+    fn setting_sources_overrides_hermetic_scope() {
+        // The escape hatch: a later setting_sources call wins over the
+        // scope the hermetic preset chose.
+        let args = QueryCommand::new("test")
+            .hermetic()
+            .setting_sources("user,project")
+            .args();
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--setting-sources", "user,project"]),
+            "got {args:?}"
+        );
+        assert_eq!(
+            args.iter().filter(|a| *a == "--setting-sources").count(),
+            1,
+            "--setting-sources must not be duplicated"
+        );
     }
 
     #[test]

--- a/src/command/spawn_args.rs
+++ b/src/command/spawn_args.rs
@@ -7,7 +7,7 @@
 //! cannot drift between the oneshot and duplex paths.
 
 use crate::tool_pattern::ToolPattern;
-use crate::types::{Effort, PermissionMode};
+use crate::types::{Effort, HermeticScope, PermissionMode};
 
 /// The spawn-time knobs common to `QueryCommand` and `DuplexOptions`.
 ///
@@ -59,6 +59,25 @@ pub(crate) struct SharedSpawnArgs {
 }
 
 impl SharedSpawnArgs {
+    /// Seal the ambient `~/.claude` promptspace for a reproducible run.
+    ///
+    /// Sets the three flags a hermetic run needs, in one place so the
+    /// oneshot and duplex presets cannot drift:
+    /// - `--setting-sources <scope>` (the ambient-config seal)
+    /// - `--strict-mcp-config` (only servers from `--mcp-config`)
+    /// - `--exclude-dynamic-system-prompt-sections` (drop cwd/env/git
+    ///   status from the default system prompt)
+    ///
+    /// Deliberately does not touch `bare`: a hermetic seal must leave
+    /// authentication alone, whereas `--bare` forces API-key billing.
+    /// A later [`Self::setting_sources`](crate::QueryCommand::setting_sources)
+    /// call (or its duplex peer) overrides the scope chosen here.
+    pub(crate) fn apply_hermetic(&mut self, scope: HermeticScope) {
+        self.setting_sources = Some(scope.setting_sources_value().to_string());
+        self.strict_mcp_config = true;
+        self.exclude_dynamic_system_prompt_sections = true;
+    }
+
     /// Append the configured flags to `args`, in a stable order.
     pub(crate) fn append_to(&self, args: &mut Vec<String>) {
         if let Some(ref model) = self.model {
@@ -364,6 +383,47 @@ mod tests {
                 "--strict-mcp-config".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn hermetic_full_seals_all_setting_sources() {
+        let mut shared = SharedSpawnArgs::default();
+        shared.apply_hermetic(HermeticScope::Full);
+        let args = args_of(shared);
+        // Empty --setting-sources value (full seal) plus the two guards.
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--setting-sources" && w[1].is_empty()),
+            "got {args:?}"
+        );
+        assert!(args.iter().any(|a| a == "--strict-mcp-config"));
+        assert!(
+            args.iter()
+                .any(|a| a == "--exclude-dynamic-system-prompt-sections")
+        );
+        // A seal must never imply --bare (that would force API-key billing).
+        assert!(!args.iter().any(|a| a == "--bare"));
+    }
+
+    #[test]
+    fn hermetic_project_keeps_user_source() {
+        let mut shared = SharedSpawnArgs::default();
+        shared.apply_hermetic(HermeticScope::Project);
+        let args = args_of(shared);
+        assert!(
+            args.windows(2).any(|w| w == ["--setting-sources", "user"]),
+            "got {args:?}"
+        );
+        assert!(args.iter().any(|a| a == "--strict-mcp-config"));
+        assert!(
+            args.iter()
+                .any(|a| a == "--exclude-dynamic-system-prompt-sections")
+        );
+    }
+
+    #[test]
+    fn hermetic_default_scope_is_full() {
+        assert_eq!(HermeticScope::default(), HermeticScope::Full);
     }
 
     #[test]

--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -206,7 +206,7 @@ use crate::Claude;
 use crate::command::spawn_args::SharedSpawnArgs;
 use crate::error::{Error, Result};
 use crate::tool_pattern::ToolPattern;
-use crate::types::{Effort, PermissionMode};
+use crate::types::{Effort, HermeticScope, PermissionMode};
 
 /// Default capacity of the per-session [`broadcast::Sender`] backing
 /// [`DuplexSession::subscribe`].
@@ -651,6 +651,35 @@ impl DuplexOptions {
     #[must_use]
     pub fn setting_sources(mut self, sources: impl Into<String>) -> Self {
         self.shared.setting_sources = Some(sources.into());
+        self
+    }
+
+    /// Seal the ambient `~/.claude` config for a reproducible session
+    /// ([`HermeticScope::Full`]).
+    ///
+    /// Sets `--setting-sources ""`, `--strict-mcp-config`, and
+    /// `--exclude-dynamic-system-prompt-sections`. This gives a warm
+    /// duplex session a clean seal without the [`Self::arg`] escape
+    /// hatch. Mirrors
+    /// [`QueryCommand::hermetic`](crate::QueryCommand::hermetic).
+    ///
+    /// This is not [`Self::bare`]: a hermetic seal leaves OAuth and
+    /// keychain auth working, whereas `--bare` forces API-key billing.
+    /// A later [`Self::setting_sources`] call overrides the seal scope.
+    #[must_use]
+    pub fn hermetic(mut self) -> Self {
+        self.shared.apply_hermetic(HermeticScope::Full);
+        self
+    }
+
+    /// Seal the ambient `~/.claude` config at an explicit
+    /// [`HermeticScope`].
+    ///
+    /// See [`Self::hermetic`] for the flag set. Mirrors
+    /// [`QueryCommand::hermetic_scoped`](crate::QueryCommand::hermetic_scoped).
+    #[must_use]
+    pub fn hermetic_scoped(mut self, scope: HermeticScope) -> Self {
+        self.shared.apply_hermetic(scope);
         self
     }
 
@@ -1959,6 +1988,32 @@ mod tests {
     fn into_args_omits_setting_sources_by_default() {
         let args = DuplexOptions::default().into_args();
         assert!(!args.iter().any(|a| a == "--setting-sources"));
+    }
+
+    #[test]
+    fn into_args_hermetic_emits_full_seal() {
+        let args = DuplexOptions::default().hermetic().into_args();
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--setting-sources" && w[1].is_empty()),
+            "got {args:?}"
+        );
+        assert!(args.iter().any(|a| a == "--strict-mcp-config"));
+        assert!(
+            args.iter()
+                .any(|a| a == "--exclude-dynamic-system-prompt-sections")
+        );
+        // A hermetic seal must never imply --bare.
+        assert!(!args.iter().any(|a| a == "--bare"));
+    }
+
+    #[test]
+    fn into_args_hermetic_scoped_project_keeps_user() {
+        let args = DuplexOptions::default()
+            .hermetic_scoped(HermeticScope::Project)
+            .into_args();
+        assert!(args.windows(2).any(|w| w == ["--setting-sources", "user"]));
+        assert!(args.iter().any(|a| a == "--strict-mcp-config"));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -213,6 +213,43 @@ impl Effort {
     }
 }
 
+/// How far a hermetic seal reaches when sealing the ambient `~/.claude`
+/// promptspace (`CLAUDE.md`, agents, skills, MCP servers).
+///
+/// Chooses the value passed to `--setting-sources`; the seal itself is
+/// applied by `hermetic` / `hermetic_scoped` on
+/// [`QueryCommand`](crate::QueryCommand) and
+/// [`DuplexOptions`](crate::duplex::DuplexOptions), which also set
+/// `--strict-mcp-config` and
+/// `--exclude-dynamic-system-prompt-sections`.
+///
+/// A hermetic seal never touches authentication. It is distinct from
+/// `--bare`, which forces API-key billing by reading auth strictly from
+/// `ANTHROPIC_API_KEY` / `apiKeyHelper`; a seal leaves OAuth and
+/// keychain auth working as normal.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum HermeticScope {
+    /// Drop every ambient setting source: user, project, and local
+    /// (`--setting-sources ""`). Only the CLI's built-in agents and
+    /// defaults remain; a user-level `~/.claude` no longer leaks in.
+    #[default]
+    Full,
+    /// Seal only the project and local ambient config while keeping the
+    /// user's global `~/.claude` (`--setting-sources user`). A project
+    /// `CLAUDE.md` and project-level agents stop being adopted.
+    Project,
+}
+
+impl HermeticScope {
+    /// The value emitted for `--setting-sources` under this scope.
+    pub(crate) fn setting_sources_value(self) -> &'static str {
+        match self {
+            Self::Full => "",
+            Self::Project => "user",
+        }
+    }
+}
+
 /// Scope for MCP and plugin commands.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Scope {


### PR DESCRIPTION
Closes #691.

## What

Adds a hermetic seal as a first-class preset on the shared spawn options, reachable from both `QueryCommand` and `DuplexOptions`. Sealing the ambient `~/.claude` config (`CLAUDE.md`, agents, skills, MCP) pins a run's surface to exactly what was passed explicitly, which matters most for headless/programmatic use where interactive visibility is gone.

## API

- `HermeticScope::{Full, Project}` chooses the seal reach:
  - `Full` (default) drops every ambient setting source (`--setting-sources ""`); only the CLI's built-ins remain.
  - `Project` keeps the user's global `~/.claude` while sealing project + local (`--setting-sources user`).
- `hermetic()` applies the `Full` seal; `hermetic_scoped(scope)` takes an explicit scope.
- Both set `--setting-sources <scope>` + `--strict-mcp-config` + `--exclude-dynamic-system-prompt-sections` through a single `SharedSpawnArgs::apply_hermetic`, so the oneshot and duplex presets cannot drift.
- A later `setting_sources(...)` call overrides the seal scope (tested).

## Load-bearing caveat: hermetic is not `--bare`

The seal uses `--setting-sources`, never `--bare`. `--bare` reads auth strictly from `ANTHROPIC_API_KEY` / `apiKeyHelper` (OAuth + keychain never read), forcing API-key billing. Hermetic seals the promptspace *without* touching auth. `apply_hermetic` deliberately does not set `bare`, and a test asserts `--bare` is absent.

## Relationship to #690 / #692

`setting_sources` (#692) and `exclude_dynamic_system_prompt_sections` (#694) already landed in `SharedSpawnArgs`, so step 1 of the issue (promote the two seal flags) was already done and both command types could reach them. This PR adds the preset over them, plus the `--setting-sources` gap for duplex is already closed. Built on top of the #694 merge.

## Tests

- `apply_hermetic` unit tests (Full seals all sources, Project keeps user, never emits `--bare`, default scope is `Full`).
- `QueryCommand` and `DuplexOptions` `hermetic()` / `hermetic_scoped()` flag assertions, plus a `setting_sources` override test (no duplicate `--setting-sources`).
- `cargo fmt`, `clippy -D warnings`, `--lib`, `--test '*'`, and `--doc` all pass locally.