### PR TITLE
fix: route all spawn paths through a widened ETXTBSY retry

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -379,11 +379,13 @@ async fn run_internal(
         cmd.env(key, value);
     }
 
-    let output = cmd.output().await.map_err(|e| Error::Io {
-        message: format!("failed to spawn claude: {e}"),
-        source: e,
-        working_dir: working_dir.map(|p| p.to_path_buf()),
-    })?;
+    let output = output_retrying_txtbsy(&mut cmd)
+        .await
+        .map_err(|e| Error::Io {
+            message: format!("failed to spawn claude: {e}"),
+            source: e,
+            working_dir: working_dir.map(|p| p.to_path_buf()),
+        })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -560,6 +562,31 @@ async fn spawn_retrying_txtbsy(cmd: &mut Command) -> std::io::Result<tokio::proc
     let mut backoff = Duration::from_millis(1);
     loop {
         match cmd.spawn() {
+            Err(e)
+                if e.kind() == std::io::ErrorKind::ExecutableFileBusy
+                    && start.elapsed() < TXTBSY_RETRY_BUDGET =>
+            {
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(TXTBSY_MAX_BACKOFF);
+            }
+            other => return other,
+        }
+    }
+}
+
+/// Run `cmd` to completion, retrying on `ETXTBSY` like
+/// [`spawn_retrying_txtbsy`].
+///
+/// The one-shot capture paths call `Command::output` (spawn, wait, and
+/// collect in one step) rather than holding a `Child`, so they need the
+/// same retry wrapped around `output` itself. The `ETXTBSY` still occurs
+/// at the `execve` inside `output`.
+#[cfg(feature = "async")]
+async fn output_retrying_txtbsy(cmd: &mut Command) -> std::io::Result<std::process::Output> {
+    let start = std::time::Instant::now();
+    let mut backoff = Duration::from_millis(1);
+    loop {
+        match cmd.output().await {
             Err(e)
                 if e.kind() == std::io::ErrorKind::ExecutableFileBusy
                     && start.elapsed() < TXTBSY_RETRY_BUDGET =>
@@ -888,7 +915,7 @@ fn run_internal_sync(
         cmd.env(key, value);
     }
 
-    let output = cmd.output().map_err(|e| Error::Io {
+    let output = output_retrying_txtbsy_sync(&mut cmd).map_err(|e| Error::Io {
         message: format!("failed to spawn claude: {e}"),
         source: e,
         working_dir: working_dir.map(|p| p.to_path_buf()),
@@ -1036,6 +1063,28 @@ fn spawn_retrying_txtbsy_sync(
     let mut backoff = Duration::from_millis(1);
     loop {
         match cmd.spawn() {
+            Err(e)
+                if e.kind() == std::io::ErrorKind::ExecutableFileBusy
+                    && start.elapsed() < TXTBSY_RETRY_BUDGET =>
+            {
+                std::thread::sleep(backoff);
+                backoff = (backoff * 2).min(TXTBSY_MAX_BACKOFF);
+            }
+            other => return other,
+        }
+    }
+}
+
+/// Blocking mirror of [`output_retrying_txtbsy`]. See that function for
+/// why the one-shot capture paths need the retry around `output`.
+#[cfg(feature = "sync")]
+fn output_retrying_txtbsy_sync(
+    cmd: &mut std::process::Command,
+) -> std::io::Result<std::process::Output> {
+    let start = std::time::Instant::now();
+    let mut backoff = Duration::from_millis(1);
+    loop {
+        match cmd.output() {
             Err(e)
                 if e.kind() == std::io::ErrorKind::ExecutableFileBusy
                     && start.elapsed() < TXTBSY_RETRY_BUDGET =>
@@ -1274,6 +1323,19 @@ mod tests {
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound, "got: {err:?}");
     }
 
+    // Same guarantee for the one-shot capture path: a missing binary must
+    // surface `NotFound` immediately, not spin until the ETXTBSY budget
+    // elapses.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_output_retry_passes_through_non_txtbsy_error() {
+        let mut cmd = Command::new("/nonexistent/definitely-not-a-real-binary");
+        let err = output_retrying_txtbsy(&mut cmd)
+            .await
+            .expect_err("output of missing binary should fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound, "got: {err:?}");
+    }
+
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn async_allow_exit_codes_permits_listed_code() {
@@ -1438,6 +1500,15 @@ mod tests {
         let mut cmd = std::process::Command::new("/nonexistent/definitely-not-a-real-binary");
         let err =
             spawn_retrying_txtbsy_sync(&mut cmd).expect_err("spawn of missing binary should fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound, "got: {err:?}");
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn sync_output_retry_passes_through_non_txtbsy_error() {
+        let mut cmd = std::process::Command::new("/nonexistent/definitely-not-a-real-binary");
+        let err = output_retrying_txtbsy_sync(&mut cmd)
+            .expect_err("output of missing binary should fail");
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound, "got: {err:?}");
     }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -524,9 +524,25 @@ async fn drain<R: AsyncReadExt + Unpin>(reader: &mut R) -> String {
     String::from_utf8_lossy(&buf).into_owned()
 }
 
-/// Total time to keep retrying a spawn that reports `ETXTBSY`.
+/// Total wall-clock time to keep retrying a spawn that reports `ETXTBSY`.
+///
+/// Measured as elapsed time rather than a sum of backoffs so a saturated
+/// host (a CI job running build + clippy + tests at once) still gets the
+/// full window: the busy descriptor can stay open longer than the old
+/// 500ms budget under that load, which surfaced as a spurious spawn
+/// failure. This is only ever spent when a real `ETXTBSY` occurs, which
+/// does not happen against an already-installed binary in production.
 #[cfg(any(feature = "async", feature = "sync"))]
-const TXTBSY_RETRY_BUDGET: Duration = Duration::from_millis(500);
+const TXTBSY_RETRY_BUDGET: Duration = Duration::from_secs(3);
+
+/// Per-attempt backoff ceiling while retrying `ETXTBSY`.
+///
+/// Backoff grows exponentially but is capped so retries stay frequent for
+/// the whole budget: the busy window can clear at any instant, and a large
+/// tail sleep (the old loop reached 1-2s) would keep spawning stalled long
+/// after the descriptor closed.
+#[cfg(any(feature = "async", feature = "sync"))]
+const TXTBSY_MAX_BACKOFF: Duration = Duration::from_millis(25);
 
 /// Spawn `cmd`, retrying briefly on `ETXTBSY` (`ExecutableFileBusy`).
 ///
@@ -536,19 +552,20 @@ const TXTBSY_RETRY_BUDGET: Duration = Duration::from_millis(500);
 /// while a writable descriptor to the binary is still open, the child inherits
 /// that descriptor and holds it until its own `exec` completes. Any `execve`
 /// of the file in that window sees a writer and fails. The condition always
-/// clears on its own, so retry with a short bounded backoff rather than
+/// clears on its own, so retry within a bounded wall-clock budget rather than
 /// surfacing a spurious spawn failure.
 #[cfg(feature = "async")]
 async fn spawn_retrying_txtbsy(cmd: &mut Command) -> std::io::Result<tokio::process::Child> {
+    let start = std::time::Instant::now();
     let mut backoff = Duration::from_millis(1);
     loop {
         match cmd.spawn() {
             Err(e)
                 if e.kind() == std::io::ErrorKind::ExecutableFileBusy
-                    && backoff <= TXTBSY_RETRY_BUDGET =>
+                    && start.elapsed() < TXTBSY_RETRY_BUDGET =>
             {
                 tokio::time::sleep(backoff).await;
-                backoff *= 2;
+                backoff = (backoff * 2).min(TXTBSY_MAX_BACKOFF);
             }
             other => return other,
         }
@@ -1015,15 +1032,16 @@ fn drain_sync<R: std::io::Read>(mut reader: R) -> String {
 fn spawn_retrying_txtbsy_sync(
     cmd: &mut std::process::Command,
 ) -> std::io::Result<std::process::Child> {
+    let start = std::time::Instant::now();
     let mut backoff = Duration::from_millis(1);
     loop {
         match cmd.spawn() {
             Err(e)
                 if e.kind() == std::io::ErrorKind::ExecutableFileBusy
-                    && backoff <= TXTBSY_RETRY_BUDGET =>
+                    && start.elapsed() < TXTBSY_RETRY_BUDGET =>
             {
                 std::thread::sleep(backoff);
-                backoff *= 2;
+                backoff = (backoff * 2).min(TXTBSY_MAX_BACKOFF);
             }
             other => return other,
         }


### PR DESCRIPTION
## Problem

`exec::tests::sync_nonzero_exit_maps_command_failed` flakes on the loaded "Quick checks" CI job with a spurious ETXTBSY spawn failure, even after #696 added an ETXTBSY spawn retry:

```
panicked at src/exec.rs: expected CommandFailed, got Io { message:
  "failed to spawn claude: Text file busy (os error 26)",
  source: Os { code: 26, kind: ExecutableFileBusy, ... } }
```

## Root cause (two independent gaps)

1. **The retry never ran on this path.** The test goes `run_claude_sync` → `run_claude_once_sync`, which calls `Command::output()` directly. #696 wired the retry into the stdin and timeout variants but missed the two primary one-shot capture paths (`run_claude_once` / `run_claude_once_sync`), so ETXTBSY surfaced on the first attempt. The tell: the whole suite "finished in 0.75s", far under any retry budget, proving the retry loop wasn't on this code path.
2. **The budget was too tight even where it did run.** #696's `backoff <= 500ms` guard capped *cumulative sleep*, not wall-clock, and doubled backoff unbounded (1-2s tail sleeps). On a host running build + clippy + tests at once, the busy descriptor stays open longer than that.

## Fix

- **Route the capture paths through the retry.** Add `output_retrying_txtbsy` / `output_retrying_txtbsy_sync` (mirroring the spawn helpers but wrapping `Command::output()`), and use them in `run_claude_once` and `run_claude_once_sync`.
- **Widen and even out the retry.** Elapsed-time budget via `Instant` (3s) instead of a sum-of-backoffs, and a 25ms per-attempt backoff cap so retries stay frequent across the whole window. Applied to all four helpers (async/sync × spawn/output).

The loops only ever sleep on a genuine ETXTBSY and return every other error on the first attempt (pass-through tests added for the two new helpers, matching the existing spawn ones). A real installed binary never hits this path in production, so the budget has no runtime cost there.

## Verification

- `cargo fmt`, `clippy -D warnings`, full `--lib` green.
- Ran the `exec::` suite repeatedly (3-5x) locally with no failures; 27 exec tests pass.