### PR TITLE
chore: release v0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.3](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.2...v0.13.3) - 2026-07-17
+
+### Added
+
+- *(duplex)* DuplexOptions::to_command_string preview (parity with QueryCommand) ([#704](https://github.com/joshrotenberg/claude-wrapper/pull/704))
+- *(cr)* streaming output, auto by TTY ([#702](https://github.com/joshrotenberg/claude-wrapper/pull/702))
+- *(cr)* CR_PROFILE env, --session-id, and a config subcommand ([#701](https://github.com/joshrotenberg/claude-wrapper/pull/701))
+
+### Fixed
+
+- *(query)* include global args in to_command_string ([#706](https://github.com/joshrotenberg/claude-wrapper/pull/706))
+- route all spawn paths through a widened ETXTBSY retry ([#697](https://github.com/joshrotenberg/claude-wrapper/pull/697))
+
+### Other
+
+- cr, a minimal config-driven CLI over the wrapper (evaluation, do not merge) ([#699](https://github.com/joshrotenberg/claude-wrapper/pull/699))
+
 ## [0.13.2](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.1...v0.13.2) - 2026-07-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-wrapper"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.13.2 -> 0.13.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.3](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.2...v0.13.3) - 2026-07-17

### Added

- *(duplex)* DuplexOptions::to_command_string preview (parity with QueryCommand) ([#704](https://github.com/joshrotenberg/claude-wrapper/pull/704))
- *(cr)* streaming output, auto by TTY ([#702](https://github.com/joshrotenberg/claude-wrapper/pull/702))
- *(cr)* CR_PROFILE env, --session-id, and a config subcommand ([#701](https://github.com/joshrotenberg/claude-wrapper/pull/701))

### Fixed

- *(query)* include global args in to_command_string ([#706](https://github.com/joshrotenberg/claude-wrapper/pull/706))
- route all spawn paths through a widened ETXTBSY retry ([#697](https://github.com/joshrotenberg/claude-wrapper/pull/697))

### Other

- cr, a minimal config-driven CLI over the wrapper (evaluation, do not merge) ([#699](https://github.com/joshrotenberg/claude-wrapper/pull/699))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).