### PR TITLE
spike: cr, a minimal config-driven CLI over the wrapper (evaluation, do not merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,20 +135,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "claude-wrapper"
 version = "0.13.1"
 dependencies = [
  "anyhow",
  "axum",
+ "clap",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "tracing",
  "wait-timeout",
  "which",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "equivalent"
@@ -303,6 +401,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +479,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -540,6 +650,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +701,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -662,6 +787,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +898,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"
@@ -822,6 +994,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,16 +40,25 @@ which = "8"
 [dev-dependencies]
 anyhow = "1"
 axum = "0.8"
+clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
+toml = "0.8"
 
 # All examples use the async API; require the feature so they're
 # skipped automatically on sync-only builds.
 [[example]]
 name = "agent_worker"
 required-features = ["async", "json"]
+
+# Spike: `cr`, a minimal config-driven CLI over the wrapper's sync API.
+# Not a shipped binary -- an evaluation prototype. `cargo run --example cr
+# --no-default-features --features sync,json,tempfile -- ...`
+[[example]]
+name = "cr"
+required-features = ["sync", "json"]
 
 [[example]]
 name = "duplex_chat"

--- a/examples/cr.rs
+++ b/examples/cr.rs
@@ -1,0 +1,453 @@
+//! `cr` -- a spike of a minimal, config-driven CLI over `claude-wrapper`.
+//!
+//! This is an EVALUATION PROTOTYPE, not a shipped binary. It exists to answer
+//! one question: is a curated "profiles + a handful of flags" front door over
+//! the wrapper genuinely simpler than the full roba surface, or does it just
+//! move the complexity around?
+//!
+//! What it demonstrates:
+//! - the mocked `cr` flag surface, rendered by clap (`cr --help`)
+//! - TOML profiles with `defaults < profile < CLI` layering
+//! - `--explain` (dry-run: print the exact `claude` command), no spawn
+//! - `--save NAME` (creation-by-use: capture resolved flags into a profile)
+//! - the cost/turns footer, from the parsed `QueryResult`
+//!
+//! Deliberately NOT in the spike: streaming, `-e` editor compose, worktree
+//! lifecycle, the composition family (`--attach`/`--git-*`). Wiring those is a
+//! one-liner each against the wrapper; they're omitted to keep the surface
+//! honest.
+//!
+//! Run:
+//!   cargo run --example cr --no-default-features \
+//!     --features sync,json,tempfile -- --help
+//!   cargo run --example cr ... -- --profile cheap --explain "summarize this"
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use clap::{Parser, Subcommand};
+use claude_wrapper::{Claude, Effort, QueryCommand};
+use serde::{Deserialize, Serialize};
+
+/// A saved `claude -p` you can re-run: isolated, typed, repeatable.
+#[derive(Parser, Debug)]
+#[command(name = "cr", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    #[command(flatten)]
+    run: RunArgs,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// List profiles and show what one resolves to.
+    Profiles,
+}
+
+#[derive(clap::Args, Debug, Default)]
+struct RunArgs {
+    /// Prompt text. Omit to read stdin; or use -f / -e.
+    prompt: Option<String>,
+
+    /// Read the prompt from a file.
+    #[arg(short = 'f', long, value_name = "PATH", help_heading = "Prompt")]
+    file: Option<PathBuf>,
+
+    /// Compose the prompt in $EDITOR.
+    #[arg(short = 'e', long, help_heading = "Prompt")]
+    editor: bool,
+
+    /// sonnet | opus | haiku | full model id.
+    #[arg(short = 'm', long, value_name = "MODEL", help_heading = "Model")]
+    model: Option<String>,
+
+    /// low | medium | high | xhigh | max.
+    #[arg(long, value_name = "LEVEL", help_heading = "Model")]
+    effort: Option<String>,
+
+    /// Full structured result (JSON) instead of prose.
+    #[arg(long, help_heading = "Output")]
+    json: bool,
+
+    /// Constrain the answer to a JSON Schema file (implies --json).
+    #[arg(long, value_name = "FILE", help_heading = "Output")]
+    schema: Option<PathBuf>,
+
+    /// Answer only: no footer.
+    #[arg(short = 'q', long, help_heading = "Output")]
+    quiet: bool,
+
+    /// Continue the most recent session in this dir.
+    #[arg(long, help_heading = "Session")]
+    r#continue: bool,
+
+    /// Resume a specific session id.
+    #[arg(long, value_name = "ID", help_heading = "Session")]
+    resume: Option<String>,
+
+    /// Run as if from PATH (git -C style); resolved first.
+    #[arg(
+        short = 'C',
+        long,
+        value_name = "PATH",
+        help_heading = "Location & isolation"
+    )]
+    cwd: Option<PathBuf>,
+
+    /// Run in a fresh isolated git worktree (anonymous).
+    #[arg(long, help_heading = "Location & isolation")]
+    worktree: bool,
+
+    /// ...with an explicit worktree/branch name.
+    #[arg(long, value_name = "NAME", help_heading = "Location & isolation")]
+    worktree_name: Option<String>,
+
+    /// Seal ambient ~/.claude config (reproducible promptspace).
+    #[arg(long, help_heading = "Location & isolation")]
+    hermetic: bool,
+
+    /// Apply a named profile (project or user config).
+    #[arg(long, value_name = "NAME", help_heading = "Profile")]
+    profile: Option<String>,
+
+    /// Ignore the auto-applied default profile.
+    #[arg(long, help_heading = "Profile")]
+    no_profile: bool,
+
+    /// Print the exact `claude` command it would run, then exit.
+    #[arg(long, help_heading = "Meta")]
+    explain: bool,
+
+    /// Capture the resolved flags into a project profile, then exit.
+    #[arg(long, value_name = "NAME", help_heading = "Meta")]
+    save: Option<String>,
+}
+
+/// The profile-able subset of settings: the keys a `[profile.NAME]` (or
+/// `[defaults]`) table may set, and what `--save` writes back. Per-invocation
+/// flags (prompt, session, cwd, output mode) are not profile state.
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+struct Settings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hermetic: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    worktree: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    append_system_prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_budget_usd: Option<f64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    allowed_tools: Vec<String>,
+}
+
+impl Settings {
+    /// Overlay `over` onto `self`: any field set in `over` wins. This is the
+    /// whole layering mechanism -- `defaults.overlay(profile).overlay(cli)`.
+    fn overlay(mut self, over: &Settings) -> Settings {
+        if over.model.is_some() {
+            self.model = over.model.clone();
+        }
+        if over.effort.is_some() {
+            self.effort = over.effort.clone();
+        }
+        if over.hermetic.is_some() {
+            self.hermetic = over.hermetic;
+        }
+        if over.worktree.is_some() {
+            self.worktree = over.worktree;
+        }
+        if over.agent.is_some() {
+            self.agent = over.agent.clone();
+        }
+        if over.append_system_prompt.is_some() {
+            self.append_system_prompt = over.append_system_prompt.clone();
+        }
+        if over.max_budget_usd.is_some() {
+            self.max_budget_usd = over.max_budget_usd;
+        }
+        if !over.allowed_tools.is_empty() {
+            self.allowed_tools = over.allowed_tools.clone();
+        }
+        self
+    }
+}
+
+#[derive(Deserialize, Debug, Default)]
+struct ConfigFile {
+    default_profile: Option<String>,
+    defaults: Option<Settings>,
+    #[serde(default)]
+    profiles: BTreeMap<String, Settings>,
+}
+
+fn load_config(path: &Path) -> ConfigFile {
+    match std::fs::read_to_string(path) {
+        Ok(text) => toml::from_str(&text).unwrap_or_else(|e| {
+            eprintln!("cr: ignoring malformed {}: {e}", path.display());
+            ConfigFile::default()
+        }),
+        Err(_) => ConfigFile::default(),
+    }
+}
+
+/// User config (`~/.config/cr/config.toml`) is the base; project (`./cr.toml`)
+/// layers on top. Two files, no walk-up in the spike.
+fn config_paths() -> (Option<PathBuf>, PathBuf) {
+    let user = std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join(".config/cr/config.toml"))
+        .filter(|p| p.exists());
+    (user, PathBuf::from("cr.toml"))
+}
+
+fn main() -> std::process::ExitCode {
+    let cli = Cli::parse();
+    let (user_path, project_path) = config_paths();
+    let user = user_path.as_deref().map(load_config).unwrap_or_default();
+    let project = load_config(&project_path);
+
+    if let Some(Command::Profiles) = cli.command {
+        return cmd_profiles(&user, &project);
+    }
+
+    match run(cli.run, &user, &project, &project_path) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("cr: {e}");
+            std::process::ExitCode::from(1)
+        }
+    }
+}
+
+fn cmd_profiles(user: &ConfigFile, project: &ConfigFile) -> std::process::ExitCode {
+    let mut names: BTreeMap<&str, &str> = BTreeMap::new();
+    for n in user.profiles.keys() {
+        names.insert(n, "user");
+    }
+    for n in project.profiles.keys() {
+        names.insert(n, "project");
+    }
+    if names.is_empty() {
+        eprintln!("no profiles defined (add [profiles.NAME] to cr.toml)");
+        return std::process::ExitCode::SUCCESS;
+    }
+    let default = project
+        .default_profile
+        .as_deref()
+        .or(user.default_profile.as_deref());
+    for (name, source) in names {
+        let star = if Some(name) == default {
+            " (default)"
+        } else {
+            ""
+        };
+        println!("{name}  [{source}]{star}");
+    }
+    std::process::ExitCode::SUCCESS
+}
+
+fn run(
+    args: RunArgs,
+    user: &ConfigFile,
+    project: &ConfigFile,
+    project_path: &Path,
+) -> anyhow::Result<std::process::ExitCode> {
+    // 1. Resolve settings: defaults < profile < CLI.
+    let mut settings = Settings::default();
+    if let Some(d) = &user.defaults {
+        settings = settings.overlay(d);
+    }
+    if let Some(d) = &project.defaults {
+        settings = settings.overlay(d);
+    }
+
+    let active = if args.no_profile {
+        None
+    } else {
+        args.profile.clone().or_else(|| {
+            project
+                .default_profile
+                .clone()
+                .or_else(|| user.default_profile.clone())
+        })
+    };
+    if let Some(name) = &active {
+        let p = project
+            .profiles
+            .get(name)
+            .or_else(|| user.profiles.get(name));
+        match p {
+            Some(p) => settings = settings.overlay(p),
+            None => anyhow::bail!("unknown profile: {name}"),
+        }
+    }
+
+    // CLI flags override the profile.
+    if args.model.is_some() {
+        settings.model = args.model.clone();
+    }
+    if args.effort.is_some() {
+        settings.effort = args.effort.clone();
+    }
+    if args.hermetic {
+        settings.hermetic = Some(true);
+    }
+    if args.worktree || args.worktree_name.is_some() {
+        settings.worktree = Some(true);
+    }
+
+    // 2. --save: capture and exit before doing any work.
+    if let Some(name) = &args.save {
+        save_profile(project_path, name, &settings)?;
+        println!("saved [profiles.{name}] to {}", project_path.display());
+        return Ok(std::process::ExitCode::SUCCESS);
+    }
+
+    // 3. Resolve the prompt (file > positional > stdin).
+    let prompt = resolve_prompt(&args)?;
+
+    // 4. Build the Claude client (cwd) and the query.
+    let mut builder = Claude::builder();
+    if let Some(cwd) = &args.cwd {
+        builder = builder.working_dir(cwd);
+    }
+    let claude = builder.build()?;
+
+    let mut cmd = QueryCommand::new(prompt).prompt_via_stdin(true);
+    if let Some(m) = &settings.model {
+        cmd = cmd.model(m);
+    }
+    if let Some(e) = &settings.effort {
+        cmd = cmd.effort(parse_effort(e)?);
+    }
+    if settings.hermetic == Some(true) {
+        cmd = cmd.hermetic();
+    }
+    if let Some(name) = &args.worktree_name {
+        cmd = cmd.worktree_named(name);
+    } else if settings.worktree == Some(true) {
+        cmd = cmd.worktree();
+    }
+    if let Some(a) = &settings.agent {
+        cmd = cmd.agent(a);
+    }
+    if let Some(sp) = &settings.append_system_prompt {
+        cmd = cmd.append_system_prompt(sp);
+    }
+    if let Some(b) = settings.max_budget_usd {
+        cmd = cmd.max_budget_usd(b);
+    }
+    if !settings.allowed_tools.is_empty() {
+        cmd = cmd.allowed_tools(settings.allowed_tools.iter().map(String::as_str));
+    }
+    if args.r#continue {
+        cmd = cmd.continue_session();
+    }
+    if let Some(id) = &args.resume {
+        cmd = cmd.resume(id);
+    }
+    if let Some(schema_path) = &args.schema {
+        let schema = std::fs::read_to_string(schema_path)?;
+        cmd = cmd.json_schema(schema);
+    }
+
+    // 5. --explain: print the command it would run, no spawn.
+    if args.explain {
+        println!("{}", cmd.to_command_string(&claude));
+        return Ok(std::process::ExitCode::SUCCESS);
+    }
+
+    // 6. Run (buffered; streaming is a deliberate spike gap) and render.
+    let result = cmd.execute_json_sync(&claude)?;
+
+    if args.json || args.schema.is_some() {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        print!("{}", result.result);
+        if !result.result.ends_with('\n') {
+            println!();
+        }
+    }
+
+    if !args.quiet && !args.json {
+        eprintln!("{}", footer(&settings, &result));
+    }
+
+    Ok(if result.is_error {
+        std::process::ExitCode::from(1)
+    } else {
+        std::process::ExitCode::SUCCESS
+    })
+}
+
+fn resolve_prompt(args: &RunArgs) -> anyhow::Result<String> {
+    if args.editor {
+        anyhow::bail!("-e/--editor is not wired in this spike; pass a prompt or pipe stdin");
+    }
+    if let Some(f) = &args.file {
+        return Ok(std::fs::read_to_string(f)?);
+    }
+    if let Some(p) = &args.prompt {
+        return Ok(p.clone());
+    }
+    use std::io::Read;
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf)?;
+    if buf.trim().is_empty() {
+        anyhow::bail!("no prompt: pass a positional prompt, -f FILE, or pipe stdin");
+    }
+    Ok(buf)
+}
+
+fn parse_effort(s: &str) -> anyhow::Result<Effort> {
+    Ok(match s {
+        "low" => Effort::Low,
+        "medium" => Effort::Medium,
+        "high" => Effort::High,
+        "xhigh" => Effort::Xhigh,
+        "max" => Effort::Max,
+        other => anyhow::bail!("unknown effort '{other}' (low|medium|high|xhigh|max)"),
+    })
+}
+
+fn footer(settings: &Settings, r: &claude_wrapper::QueryResult) -> String {
+    let model = settings.model.as_deref().unwrap_or("default");
+    let turns = r
+        .num_turns
+        .map(|n| format!("{n} turns"))
+        .unwrap_or_default();
+    let cost = r.cost_usd.map(|c| format!("${c:.4}")).unwrap_or_default();
+    let dur = r
+        .duration_ms
+        .map(|d| format!("{:.1}s", d as f64 / 1000.0))
+        .unwrap_or_default();
+    [model.to_string(), turns, cost, dur]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(" · ")
+}
+
+/// Write `settings` as `[profiles.NAME]` into the project cr.toml, preserving
+/// whatever else is already there.
+fn save_profile(path: &Path, name: &str, settings: &Settings) -> anyhow::Result<()> {
+    let mut doc: toml::Table = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|t| t.parse().ok())
+        .unwrap_or_default();
+    let profiles = doc
+        .entry("profiles".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+    if let toml::Value::Table(t) = profiles {
+        t.insert(name.to_string(), toml::Value::try_from(settings)?);
+    }
+    std::fs::write(path, toml::to_string_pretty(&doc)?)?;
+    Ok(())
+}

--- a/examples/cr.rs
+++ b/examples/cr.rs
@@ -418,7 +418,7 @@ fn parse_effort(s: &str) -> anyhow::Result<Effort> {
 }
 
 fn footer(settings: &Settings, r: &claude_wrapper::QueryResult) -> String {
-    let model = settings.model.as_deref().unwrap_or("default");
+    let model = actual_model(settings, r);
     let turns = r
         .num_turns
         .map(|n| format!("{n} turns"))
@@ -428,11 +428,26 @@ fn footer(settings: &Settings, r: &claude_wrapper::QueryResult) -> String {
         .duration_ms
         .map(|d| format!("{:.1}s", d as f64 / 1000.0))
         .unwrap_or_default();
-    [model.to_string(), turns, cost, dur]
+    [model, turns, cost, dur]
         .into_iter()
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join(" · ")
+}
+
+/// The model(s) the CLI actually billed, from the result's `modelUsage` map
+/// (keyed by model id). Falls back to the configured model, then "default" --
+/// so even a bare run reports what ran, not what you happened to set.
+fn actual_model(settings: &Settings, r: &claude_wrapper::QueryResult) -> String {
+    if let Some(serde_json::Value::Object(usage)) = r.extra.get("modelUsage")
+        && !usage.is_empty()
+    {
+        return usage.keys().cloned().collect::<Vec<_>>().join("+");
+    }
+    settings
+        .model
+        .clone()
+        .unwrap_or_else(|| "default".to_string())
 }
 
 /// Write `settings` as `[profiles.NAME]` into the project cr.toml, preserving


### PR DESCRIPTION
**Evaluation spike — not for merge.** A runnable prototype to answer one question: is a curated "profiles + a handful of flags" front door over `claude-wrapper` genuinely simpler than roba's full surface, or does it just move the complexity around?

It's a single `examples/cr.rs` built on the wrapper's **sync** API (no async runtime for a CLI). `clap` + `toml` are dev-dependencies and the example requires `sync,json`, so nothing leaks into the library's public dependency graph.

## Run it
```
cargo run --example cr --no-default-features --features sync,json,tempfile -- --help
```

## What it demonstrates
- The mocked `cr` surface, rendered by clap (18 flags, one subcommand).
- TOML profiles with `defaults < profile < CLI` layering + an auto-applied `default_profile`.
- `--explain` — dry-run that prints the exact `claude` command, no spawn (via `to_command_string`).
- `--save NAME` — creation-by-use: capture the resolved flags into a project profile, never hand-author TOML.
- A cost/turns footer from the parsed `QueryResult`.
- `prompt_via_stdin` on by default (the prompt never appears in the explained command / argv).

## `--explain` output (real)
```
# default_profile = "quick"
$ cr --explain "summarize this diff"
claude --print --model haiku --effort low

$ cr --profile review --explain "audit"
claude --print --model opus --allowed-tools 'Read,Bash(git diff:*)' --effort high \
  --agent code-reviewer --strict-mcp-config --setting-sources  --exclude-dynamic-system-prompt-sections

$ cr --profile review -m sonnet --explain   # CLI overrides profile
claude --print --model sonnet ...
```
`--hermetic` expands to its three flags; CLI beats profile beats defaults.

## Deliberately omitted (to keep the surface honest)
Streaming, `-e` editor compose, worktree lifecycle, and the composition family (`--attach`/`--git-*`). Each is a one-liner against the wrapper; left out so the spike doesn't quietly re-inflate toward roba.

## Open question this is meant to inform
Does this feel like "a genuinely simpler thing" worth having as its own tool, or does it confirm that the better move is a presentation/landmine pass on roba? The `--explain` + `--save` + profile-layering ergonomics are the parts worth judging.