### PR TITLE
fix(query): include global args in to_command_string

### DIFF
--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -633,9 +633,11 @@ impl QueryCommand {
 
     /// Return the full command as a string that could be run in a shell.
     ///
-    /// Constructs a command string using the binary path from the Claude instance
-    /// and the arguments from this query. Arguments containing spaces or special
-    /// shell characters are shell-quoted to be safe for shell execution.
+    /// Constructs a command string using the binary path from the Claude instance,
+    /// the client's global args, and the arguments from this query -- the same
+    /// assembly the exec path performs, so the preview matches what actually
+    /// runs. Arguments containing spaces or special shell characters are
+    /// shell-quoted to be safe for shell execution.
     ///
     /// # Example
     ///
@@ -654,7 +656,7 @@ impl QueryCommand {
     /// # }
     /// ```
     pub fn to_command_string(&self, claude: &Claude) -> String {
-        let args = self.build_args();
+        let args = exec::full_command_args(claude, self.build_args());
         let quoted_args = args.iter().map(|arg| shell_quote(arg)).collect::<Vec<_>>();
         format!("{} {}", claude.binary().display(), quoted_args.join(" "))
     }
@@ -1252,6 +1254,24 @@ mod tests {
 
         // Single quotes should be escaped in shell
         assert!(command_str.contains("'it'\\''s'"));
+    }
+
+    #[test]
+    fn to_command_string_includes_global_args() {
+        // The exec path prepends the client's global args; the preview
+        // must show them too (#705).
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .arg("--debug")
+            .build()
+            .unwrap();
+
+        let command_str = QueryCommand::new("hello").to_command_string(&claude);
+
+        assert!(
+            command_str.starts_with("/usr/local/bin/claude --debug --print"),
+            "global args must precede command args; got {command_str}"
+        );
     }
 
     #[test]

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -19,6 +19,18 @@ use tracing::{debug, warn};
 use crate::Claude;
 use crate::error::{Error, Result};
 
+/// Assemble the full argv passed to the CLI binary: the client's
+/// global args followed by the command's own args.
+///
+/// Single assembly path shared by every exec entry point and
+/// [`QueryCommand::to_command_string`](crate::QueryCommand::to_command_string),
+/// so a rendered preview cannot drift from what actually spawns.
+pub(crate) fn full_command_args(claude: &Claude, args: Vec<String>) -> Vec<String> {
+    let mut command_args = claude.global_args.clone();
+    command_args.extend(args);
+    command_args
+}
+
 /// Raw output from a claude CLI invocation.
 #[derive(Debug, Clone)]
 pub struct CommandOutput {
@@ -79,9 +91,7 @@ async fn run_claude_with_stdin_prompt_internal(
     args: Vec<String>,
     stdin_content: String,
 ) -> Result<CommandOutput> {
-    let mut command_args = Vec::new();
-    command_args.extend(claude.global_args.clone());
-    command_args.extend(args);
+    let command_args = full_command_args(claude, args);
 
     debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command (stdin prompt)");
 
@@ -297,13 +307,7 @@ async fn run_with_timeout_stdin(
 
 #[cfg(feature = "async")]
 async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
-    let mut command_args = Vec::new();
-
-    // Global args first (before subcommand)
-    command_args.extend(claude.global_args.clone());
-
-    // Then command-specific args
-    command_args.extend(args);
+    let command_args = full_command_args(claude, args);
 
     debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command");
 
@@ -634,9 +638,7 @@ pub fn run_claude_with_stdin_prompt_sync(
     args: Vec<String>,
     stdin_content: String,
 ) -> Result<CommandOutput> {
-    let mut command_args = Vec::new();
-    command_args.extend(claude.global_args.clone());
-    command_args.extend(args);
+    let command_args = full_command_args(claude, args);
 
     debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command (stdin prompt, sync)");
 
@@ -845,9 +847,7 @@ fn run_with_timeout_stdin_sync(
 
 #[cfg(feature = "sync")]
 fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
-    let mut command_args = Vec::new();
-    command_args.extend(claude.global_args.clone());
-    command_args.extend(args);
+    let command_args = full_command_args(claude, args);
 
     debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command (sync)");
 
@@ -1184,6 +1184,28 @@ mod tests {
             .binary(path)
             .build()
             .expect("build client")
+    }
+
+    #[test]
+    fn full_command_args_puts_global_args_first() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .arg("--debug")
+            .arg("--verbose")
+            .build()
+            .expect("build client");
+        let args = full_command_args(&claude, vec!["--print".to_string(), "hi".to_string()]);
+        assert_eq!(args, ["--debug", "--verbose", "--print", "hi"]);
+    }
+
+    #[test]
+    fn full_command_args_without_global_args_is_passthrough() {
+        let claude = Claude::builder()
+            .binary("/usr/local/bin/claude")
+            .build()
+            .expect("build client");
+        let args = full_command_args(&claude, vec!["--print".to_string()]);
+        assert_eq!(args, ["--print"]);
     }
 
     // Serializes the env-scrub tests, which mutate process-global env.


### PR DESCRIPTION
Closes #705.

## Problem

`QueryCommand::to_command_string` renders the binary plus the command's own args only. Every exec path prepends `claude.global_args` first (four assembly sites in `src/exec.rs`), so a client built with `.arg("--debug")` or `.verbose()` runs a command line the preview under-reports. Same drift class as #703, on the oneshot path.

## Plan

1. Add a shared `exec::full_command_args(claude, args)` helper that assembles global args followed by command args.
2. Replace the four hand-rolled assemblies in `src/exec.rs` with it.
3. `QueryCommand::to_command_string` calls the same helper, so preview and spawn share one assembly path.
4. Tests: preview includes global args; helper orders global args before command args.

## Behavior change

`to_command_string` output gains the global args it previously omitted. That is the fix: the preview now matches what actually runs.

## Note on #704

Textually independent of #704 (that PR touches the duplex path and moves `shell_quote`; this one touches `to_command_string`'s body and `exec.rs`). Whichever merges second may need a trivial rebase.