### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.4](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.3...v0.13.4) - 2026-07-24
+
+### Added
+
+- *(cr)* env precedence, alias profiles, editor compose; ship as installable crate claude-cr ([#715](https://github.com/joshrotenberg/claude-wrapper/pull/715))
+
+### Other
+
+- bump the serde-ecosystem group across 1 directory with 2 updates ([#708](https://github.com/joshrotenberg/claude-wrapper/pull/708))
+- bump toml from 0.8.23 to 1.1.3+spec-1.1.0 ([#712](https://github.com/joshrotenberg/claude-wrapper/pull/712))
+
 ## [0.13.3](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.2...v0.13.3) - 2026-07-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "claude-wrapper"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 
 [package]
 name = "claude-wrapper"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]

--- a/examples/cr/CHANGELOG.md
+++ b/examples/cr/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.0](https://github.com/joshrotenberg/claude-wrapper/releases/tag/cr-v0.1.0) - 2026-07-24
+
+### Added
+
+- *(cr)* env precedence, alias profiles, editor compose; ship as installable crate claude-cr ([#715](https://github.com/joshrotenberg/claude-wrapper/pull/715))
+
 ### Features
 
 - Config-driven CLI over claude-wrapper: TOML profiles with


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.13.3 -> 0.13.4 (✓ API compatible changes)
* `claude-cr`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-wrapper`

<blockquote>

## [0.13.4](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.3...v0.13.4) - 2026-07-27

### Added

- *(cr)* env precedence, alias profiles, editor compose; ship as installable crate claude-cr ([#715](https://github.com/joshrotenberg/claude-wrapper/pull/715))

### Other

- bump tokio from 1.53.0 to 1.53.1 in the tokio-ecosystem group ([#716](https://github.com/joshrotenberg/claude-wrapper/pull/716))
- bump clap from 4.6.2 to 4.6.4 ([#717](https://github.com/joshrotenberg/claude-wrapper/pull/717))
- bump the serde-ecosystem group across 1 directory with 2 updates ([#708](https://github.com/joshrotenberg/claude-wrapper/pull/708))
- bump toml from 0.8.23 to 1.1.3+spec-1.1.0 ([#712](https://github.com/joshrotenberg/claude-wrapper/pull/712))
</blockquote>

## `claude-cr`

<blockquote>

## [0.1.0](https://github.com/joshrotenberg/claude-wrapper/releases/tag/cr-v0.1.0) - 2026-07-27

### Added

- *(cr)* env precedence, alias profiles, editor compose; ship as installable crate claude-cr ([#715](https://github.com/joshrotenberg/claude-wrapper/pull/715))

### Features

- Config-driven CLI over claude-wrapper: TOML profiles with
  `defaults < profile < CR_<KEY> env < CLI flag` layering, alias profiles with
  `{{args}}`/`{{N}}`/`{{stdin}}` prompt templates, `-e` editor compose,
  `--explain` dry-run, `--save` creation-by-use, and a cost/turns footer.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).