### PR TITLE
feat(cr): env precedence, alias profiles, editor compose; ship as installable crate claude-cr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,15 @@ jobs:
         if: matrix.rust == 'stable'
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Clippy (cr CLI)
+        if: matrix.rust == 'stable'
+        run: cargo clippy -p claude-cr --all-targets -- -D warnings
+
       - name: Build
         run: cargo build --all-features
+
+      - name: Build (cr CLI)
+        run: cargo build -p claude-cr
 
       - name: Build without default features
         run: cargo build --no-default-features
@@ -102,6 +109,9 @@ jobs:
 
       - name: Check MSRV
         run: cargo check --all-features
+
+      - name: Check MSRV (cr CLI)
+        run: cargo check -p claude-cr
 
   docs:
     name: Documentation

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Clippy (cr CLI)
+        run: cargo clippy -p claude-cr --all-targets -- -D warnings
+
       - name: Check
         run: cargo check --all-features
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,18 +6,24 @@ Guidance for AI assistants working on this repo.
 
 `claude-wrapper` is a type-safe Rust wrapper around the Claude Code CLI. Each subcommand is a builder that produces a typed result. Execution is via tokio (default) or `std::thread` (with the `sync` feature). Built in: long-lived `DuplexSession` for hosts (one child held open across turns; mid-turn interrupts, permission handlers, broadcast subscribers), transient `Session` for short-lived processes (subprocess-per-turn with `--resume`, cumulative cost + history, optional `BudgetTracker` hard-stops, streaming), typed tool-permission patterns (`ToolPattern`), retry policy, and an `McpConfigBuilder` for programmatic `.mcp.json` generation. It also exposes a read-side introspection layer that parses Claude Code's on-disk state (sessions, agents, skills, custom commands, settings, background jobs, worktrees) directly, without spawning the CLI.
 
-This is the only crate in the repo.
+The repo is a Cargo workspace: the root `claude-wrapper` library plus one member,
+`examples/cr` (the `cr` CLI), which is built on the library and published separately.
 
 ## Layout
 
-Flat single-crate layout:
+Cargo workspace; the root library crate keeps a flat layout:
 
 ```
-Cargo.toml        # package + deps + feature flags
+Cargo.toml        # workspace root + claude-wrapper package + deps + feature flags
 src/              # library
 tests/            # integration tests + fake-claude.sh
-examples/         # runnable examples (async-only)
+examples/         # runnable examples (async-only, single-file)
+examples/cr/      # member crate `claude-cr`: the `cr` CLI (sync API); own Cargo.toml + README
 ```
+
+The workspace has a root package, so bare `cargo <cmd>` operates on `claude-wrapper`
+only. Target the CLI explicitly with `-p claude-cr` (CI runs a dedicated clippy/build
+step for it).
 
 ## Build and test
 
@@ -199,9 +205,11 @@ There is no sync twin of `Session` yet. Sync callers compose `Session`-like stat
 
 Releases are driven by [`release-plz`](https://github.com/release-plz/release-plz):
 
-- `release-plz.toml` at the repo root configures the release for `claude-wrapper`
-- On every push to `main`, the `release-plz` workflow updates a long-running "chore: release" PR with the pending version bump + changelog
-- Merging that PR tags `v{version}`, creates a GitHub release, and publishes to crates.io
+- `release-plz.toml` at the repo root configures the release for both workspace
+  crates: `claude-wrapper` (tag `v{version}`, changelog `CHANGELOG.md`) and
+  `claude-cr` (tag `cr-v{version}`, changelog `examples/cr/CHANGELOG.md`)
+- On every push to `main`, the `release-plz` workflow updates a long-running "chore: release" PR with the pending version bump + changelog, per crate
+- Merging that PR tags the released crate(s), creates GitHub release(s), and publishes to crates.io. The two crates version independently; `claude-cr` depends on `claude-wrapper` by version, so a library release it needs must land first
 
 ## CLI coverage
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,18 +175,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "claude-cr"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "claude-wrapper",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "claude-wrapper"
 version = "0.13.3"
 dependencies = [
  "anyhow",
  "axum",
- "clap",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
  "tracing",
  "wait-timeout",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace]
+# claude-wrapper is the root library crate; `examples/cr` is a companion CLI
+# member crate (published separately as `claude-cr`, installs the `cr` binary).
+members = ["examples/cr"]
+resolver = "3"
+
 [package]
 name = "claude-wrapper"
 version = "0.13.3"
@@ -40,25 +46,16 @@ which = "8"
 [dev-dependencies]
 anyhow = "1"
 axum = "0.8"
-clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
-toml = "1.1"
 
 # All examples use the async API; require the feature so they're
 # skipped automatically on sync-only builds.
 [[example]]
 name = "agent_worker"
 required-features = ["async", "json"]
-
-# Spike: `cr`, a minimal config-driven CLI over the wrapper's sync API.
-# Not a shipped binary -- an evaluation prototype. `cargo run --example cr
-# --no-default-features --features sync,json,tempfile -- ...`
-[[example]]
-name = "cr"
-required-features = ["sync", "json"]
 
 [[example]]
 name = "duplex_chat"

--- a/examples/cr.rs
+++ b/examples/cr.rs
@@ -7,14 +7,19 @@
 //!
 //! What it demonstrates:
 //! - the mocked `cr` flag surface, rendered by clap (`cr --help`)
-//! - TOML profiles with `defaults < profile < CLI` layering
+//! - per-option layering `defaults < profile < CR_<KEY> env < CLI flag`
+//! - alias profiles: a `[profiles.NAME]` that carries a `prompt` template is
+//!   invocable positionally (`cr review foo.rs`), with `{{args}}`/`{{1}}`/
+//!   `{{stdin}}` substitution
+//! - `-e` editor compose ($VISUAL/$EDITOR on a `.md` scratch file)
 //! - `--explain` (dry-run: print the exact `claude` command), no spawn
-//! - `--save NAME` (creation-by-use: capture resolved flags into a profile)
+//! - `--save NAME` (creation-by-use: capture resolved flags, and a supplied
+//!   prompt, into a profile)
 //! - the cost/turns footer, from the parsed `QueryResult`
 //!
-//! Deliberately NOT in the spike: `-e` editor compose, worktree lifecycle, the
-//! composition family (`--attach`/`--git-*`). Wiring those is a one-liner each
-//! against the wrapper; they're omitted to keep the surface honest.
+//! Deliberately NOT in the spike: worktree lifecycle, and the composition
+//! family (`--attach`/`--git-*`, file prepend/append) -- cr stays passthrough-
+//! thin and does no host-side prompt assembly beyond template substitution.
 //!
 //! Run:
 //!   cargo run --example cr --no-default-features \
@@ -55,8 +60,14 @@ enum Command {
 
 #[derive(clap::Args, Debug, Default)]
 struct RunArgs {
-    /// Prompt text. Omit to read stdin; or use -f / -e.
+    /// Prompt text, or an alias-profile name (see `cr profiles`). Omit to read
+    /// stdin; or use -f / -e.
+    #[arg(value_name = "PROMPT_OR_ALIAS")]
     prompt: Option<String>,
+
+    /// Template arguments for an alias profile (`{{args}}`, `{{1}}`, ...).
+    #[arg(value_name = "ARG", help_heading = "Prompt")]
+    extra: Vec<String>,
 
     /// Read the prompt from a file.
     #[arg(short = 'f', long, value_name = "PATH", help_heading = "Prompt")]
@@ -154,6 +165,11 @@ struct RunArgs {
 /// flags (prompt, session, cwd, output mode) are not profile state.
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
 struct Settings {
+    /// A saved prompt template. A profile with a `prompt` is an *alias*:
+    /// invocable positionally (`cr NAME [args]`) with `{{args}}`/`{{N}}`/
+    /// `{{stdin}}` substitution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -176,6 +192,9 @@ impl Settings {
     /// Overlay `over` onto `self`: any field set in `over` wins. This is the
     /// whole layering mechanism -- `defaults.overlay(profile).overlay(cli)`.
     fn overlay(mut self, over: &Settings) -> Settings {
+        if over.prompt.is_some() {
+            self.prompt = over.prompt.clone();
+        }
         if over.model.is_some() {
             self.model = over.model.clone();
         }
@@ -231,6 +250,146 @@ fn config_paths() -> (Option<PathBuf>, PathBuf) {
     (user, PathBuf::from("cr.toml"))
 }
 
+/// The `CR_<KEY>` env layer: a partial `Settings` read from the environment,
+/// overlaid between the config file and the CLI flags (so `file < env < flag`).
+/// Every profile-able option has a mirror; `CR_PROFILE` is separate (it selects
+/// a profile, it is not an option value).
+fn env_settings() -> Settings {
+    let max_budget_usd = match env_str("CR_MAX_BUDGET_USD") {
+        Some(v) => match v.parse() {
+            Ok(n) => Some(n),
+            Err(_) => {
+                eprintln!("cr: ignoring non-numeric CR_MAX_BUDGET_USD={v:?}");
+                None
+            }
+        },
+        None => None,
+    };
+    let allowed_tools = env_str("CR_ALLOWED_TOOLS")
+        .map(|v| {
+            v.split([',', ' '])
+                .filter(|t| !t.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    Settings {
+        prompt: None,
+        model: env_str("CR_MODEL"),
+        effort: env_str("CR_EFFORT"),
+        hermetic: env_bool("CR_HERMETIC"),
+        worktree: env_bool("CR_WORKTREE"),
+        agent: env_str("CR_AGENT"),
+        append_system_prompt: env_str("CR_APPEND_SYSTEM_PROMPT"),
+        max_budget_usd,
+        allowed_tools,
+    }
+}
+
+fn env_str(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+/// Parse a boolean env var. `1|true|yes|on` -> true, `0|false|no|off` -> false;
+/// anything else (or unset) is treated as unset, with a warning for garbage.
+fn env_bool(key: &str) -> Option<bool> {
+    let v = env_str(key)?;
+    match v.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => {
+            eprintln!("cr: ignoring non-boolean {key}={v:?}");
+            None
+        }
+    }
+}
+
+/// The CLI-flag layer as a partial `Settings` (the top of `file < env < flag`).
+/// Only the flags that map to a profile-able option appear here; `hermetic` and
+/// `worktree` are one-way (a flag can turn them on, env/file can set either).
+fn cli_settings(args: &RunArgs) -> Settings {
+    Settings {
+        prompt: None,
+        model: args.model.clone(),
+        effort: args.effort.clone(),
+        hermetic: if args.hermetic { Some(true) } else { None },
+        worktree: if args.worktree || args.worktree_name.is_some() {
+            Some(true)
+        } else {
+            None
+        },
+        agent: None,
+        append_system_prompt: None,
+        max_budget_usd: None,
+        allowed_tools: Vec::new(),
+    }
+}
+
+/// Look up a profile by name: project profiles shadow user profiles.
+fn lookup_profile<'a>(
+    project: &'a ConfigFile,
+    user: &'a ConfigFile,
+    name: &str,
+) -> Option<&'a Settings> {
+    project
+        .profiles
+        .get(name)
+        .or_else(|| user.profiles.get(name))
+}
+
+/// Substitute a profile's prompt template. `{{args}}` -> all args joined,
+/// `{{1}}`..`{{9}}` -> the Nth arg, `{{stdin}}` -> piped stdin (read only when
+/// referenced). A template with no `{{...}}` placeholder appends the args.
+fn render_template(template: &str, args: &[String]) -> anyhow::Result<String> {
+    if !template.contains("{{") {
+        return Ok(if args.is_empty() {
+            template.to_string()
+        } else {
+            format!("{template}\n\n{}", args.join(" "))
+        });
+    }
+    let mut out = template.replace("{{args}}", &args.join(" "));
+    for (i, a) in args.iter().enumerate() {
+        out = out.replace(&format!("{{{{{}}}}}", i + 1), a);
+    }
+    if out.contains("{{stdin}}") {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf)?;
+        out = out.replace("{{stdin}}", buf.trim_end_matches('\n'));
+    }
+    Ok(out)
+}
+
+/// Compose a prompt in `$VISUAL`/`$EDITOR` (fallback `vi`) on a `.md` scratch
+/// file. Errors on a non-zero editor exit or an empty buffer.
+fn compose_in_editor() -> anyhow::Result<String> {
+    let tmp = tempfile::Builder::new()
+        .prefix("cr-prompt-")
+        .suffix(".md")
+        .tempfile()?;
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string());
+    let mut parts = editor.split_whitespace();
+    let program = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("empty $EDITOR"))?;
+    let status = std::process::Command::new(program)
+        .args(parts)
+        .arg(tmp.path())
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("editor exited with {status}");
+    }
+    let body = std::fs::read_to_string(tmp.path())?;
+    let trimmed = body.trim().to_string();
+    if trimmed.is_empty() {
+        anyhow::bail!("editor returned an empty prompt");
+    }
+    Ok(trimmed)
+}
+
 fn main() -> std::process::ExitCode {
     let cli = Cli::parse();
     let (user_path, project_path) = config_paths();
@@ -276,7 +435,11 @@ fn cmd_profiles(user: &ConfigFile, project: &ConfigFile) -> std::process::ExitCo
         } else {
             ""
         };
-        println!("{name}  [{source}]{star}");
+        let alias = lookup_profile(project, user, name)
+            .filter(|p| p.prompt.is_some())
+            .map(|_| " (alias)")
+            .unwrap_or("");
+        println!("{name}  [{source}]{star}{alias}");
     }
     std::process::ExitCode::SUCCESS
 }
@@ -314,7 +477,31 @@ fn run(
     project: &ConfigFile,
     project_path: &Path,
 ) -> anyhow::Result<std::process::ExitCode> {
-    // 1. Resolve settings: defaults < profile < CLI.
+    // 1. Alias dispatch: a bare first positional that names a profile carrying
+    //    a `prompt` template runs that profile, with the rest as template args.
+    //    Only when nothing else already fixes the prompt or the profile.
+    let alias = if args.no_profile || args.profile.is_some() || args.file.is_some() || args.editor {
+        None
+    } else if let Some(word) = &args.prompt {
+        lookup_profile(project, user, word)
+            .filter(|p| p.prompt.is_some())
+            .map(|_| word.clone())
+    } else {
+        None
+    };
+
+    // Extra positionals are template args; they only make sense in alias mode.
+    if alias.is_none() && !args.extra.is_empty() {
+        let joined = args.extra.join(" ");
+        match &args.prompt {
+            Some(w) => anyhow::bail!(
+                "unexpected arguments after {w:?}: {joined} ({w:?} is not an alias profile)"
+            ),
+            None => anyhow::bail!("unexpected arguments: {joined}"),
+        }
+    }
+
+    // 2. Resolve settings, low to high: defaults < profile < CR_<KEY> env < flag.
     let mut settings = Settings::default();
     if let Some(d) = &user.defaults {
         settings = settings.overlay(d);
@@ -323,8 +510,11 @@ fn run(
         settings = settings.overlay(d);
     }
 
-    // Profile selection: --profile > CR_PROFILE > project default > user default.
-    let active = if args.no_profile {
+    // Profile selection: alias name > --profile > CR_PROFILE > project default
+    // > user default. (An alias invocation is an explicit selection.)
+    let active = if let Some(name) = &alias {
+        Some(name.clone())
+    } else if args.no_profile {
         None
     } else {
         args.profile
@@ -334,39 +524,35 @@ fn run(
             .or_else(|| user.default_profile.clone())
     };
     if let Some(name) = &active {
-        let p = project
-            .profiles
-            .get(name)
-            .or_else(|| user.profiles.get(name));
-        match p {
+        match lookup_profile(project, user, name) {
             Some(p) => settings = settings.overlay(p),
             None => anyhow::bail!("unknown profile: {name}"),
         }
     }
 
-    // CLI flags override the profile.
-    if args.model.is_some() {
-        settings.model = args.model.clone();
-    }
-    if args.effort.is_some() {
-        settings.effort = args.effort.clone();
-    }
-    if args.hermetic {
-        settings.hermetic = Some(true);
-    }
-    if args.worktree || args.worktree_name.is_some() {
-        settings.worktree = Some(true);
-    }
+    // Env then flags: each wins over the layer below it, per option.
+    settings = settings.overlay(&env_settings());
+    settings = settings.overlay(&cli_settings(&args));
 
-    // 2. --save: capture and exit before doing any work.
+    // 3. --save: capture and exit before doing any work. A supplied prompt (a
+    //    positional string or -f file, but never stdin) is saved as the alias
+    //    `prompt`, so `cr "Review {{args}}" --save review` mints an alias.
     if let Some(name) = &args.save {
-        save_profile(project_path, name, &settings)?;
+        let mut to_save = settings.clone();
+        if let Some(p) = &args.prompt {
+            to_save.prompt = Some(p.clone());
+        } else if let Some(f) = &args.file {
+            to_save.prompt = Some(std::fs::read_to_string(f)?);
+        }
+        save_profile(project_path, name, &to_save)?;
         println!("saved [profiles.{name}] to {}", project_path.display());
         return Ok(std::process::ExitCode::SUCCESS);
     }
 
-    // 3. Resolve the prompt (file > positional > stdin).
-    let prompt = resolve_prompt(&args)?;
+    // 4. Resolve the prompt. Explicit sources (editor, -f, positional) win;
+    //    otherwise an active profile's `prompt` template is the default;
+    //    otherwise stdin. In alias mode the template is rendered with the args.
+    let prompt = resolve_prompt(&args, &settings, alias.is_some())?;
 
     // 4. Build the Claude client (cwd) and the query.
     let mut builder = Claude::builder();
@@ -509,21 +695,30 @@ fn stream_run(claude: &Claude, cmd: &QueryCommand) -> anyhow::Result<claude_wrap
     }
 }
 
-fn resolve_prompt(args: &RunArgs) -> anyhow::Result<String> {
+fn resolve_prompt(args: &RunArgs, settings: &Settings, alias: bool) -> anyhow::Result<String> {
     if args.editor {
-        anyhow::bail!("-e/--editor is not wired in this spike; pass a prompt or pipe stdin");
+        return compose_in_editor();
     }
     if let Some(f) = &args.file {
         return Ok(std::fs::read_to_string(f)?);
     }
+    if alias {
+        // The positional was the alias name; render its template with the args.
+        let template = settings.prompt.as_deref().unwrap_or_default();
+        return render_template(template, &args.extra);
+    }
     if let Some(p) = &args.prompt {
         return Ok(p.clone());
+    }
+    // No explicit prompt: an active profile's template is the default.
+    if let Some(template) = &settings.prompt {
+        return render_template(template, &args.extra);
     }
     use std::io::Read;
     let mut buf = String::new();
     std::io::stdin().read_to_string(&mut buf)?;
     if buf.trim().is_empty() {
-        anyhow::bail!("no prompt: pass a positional prompt, -f FILE, or pipe stdin");
+        anyhow::bail!("no prompt: pass a positional prompt, -f FILE, -e, or pipe stdin");
     }
     Ok(buf)
 }

--- a/examples/cr/CHANGELOG.md
+++ b/examples/cr/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Features
+
+- Config-driven CLI over claude-wrapper: TOML profiles with
+  `defaults < profile < CR_<KEY> env < CLI flag` layering, alias profiles with
+  `{{args}}`/`{{N}}`/`{{stdin}}` prompt templates, `-e` editor compose,
+  `--explain` dry-run, `--save` creation-by-use, and a cost/turns footer.

--- a/examples/cr/Cargo.toml
+++ b/examples/cr/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "claude-cr"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.90.0"
+authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/joshrotenberg/claude-wrapper"
+readme = "README.md"
+description = "cr: a config-driven CLI over claude-wrapper. Save profiles and prompt aliases, layer defaults across config/env/flags, re-run the same claude call."
+keywords = ["claude", "cli", "ai", "profiles", "prompt"]
+categories = ["command-line-utilities", "development-tools"]
+
+[[bin]]
+name = "cr"
+path = "src/main.rs"
+
+[dependencies]
+claude-wrapper = { version = "0.13", path = "../..", default-features = false, features = [
+    "sync",
+    "json",
+    "tempfile",
+] }
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tempfile = "3"
+toml = "1.1"

--- a/examples/cr/README.md
+++ b/examples/cr/README.md
@@ -1,0 +1,170 @@
+# cr
+
+A config-driven CLI over [`claude-wrapper`](https://crates.io/crates/claude-wrapper):
+a saved `claude -p` you can re-run. Name a bundle of flags (and optionally a
+prompt) as a profile, then repeat it with a single word. One concept, the
+profile, carries the whole surface.
+
+The crate publishes as `claude-cr`; it installs a binary named `cr`.
+
+## Install
+
+```bash
+cargo install claude-cr
+```
+
+Requires the [Claude Code CLI](https://docs.claude.com/en/docs/claude-code) on
+`PATH`. `cr` shells out to it.
+
+## Quickstart
+
+```bash
+# One-off: cr forwards a prompt to `claude -p` and prints the answer.
+cr "explain this error" 
+
+# Pick a model / effort inline.
+cr -m opus --effort high "review this design"
+
+# Pipe a prompt in.
+git diff | cr "write a commit message for this diff"
+
+# See the exact `claude` command cr would run, without spawning it.
+cr --explain "summarize this"
+```
+
+Every run ends with a footer on stderr: the model that actually billed, turns,
+cost, and wall time. `-q/--quiet` drops it.
+
+## Config and precedence
+
+`cr` reads two TOML files, low to high:
+
+1. user: `~/.config/cr/config.toml`
+2. project: `./cr.toml`
+
+Within that, each option resolves lowest to highest as:
+
+```
+defaults  <  profile  <  CR_<KEY> env var  <  CLI flag
+```
+
+An explicit flag always wins. `cr config` prints the two paths; `cr config
+--edit` opens the project file in `$EDITOR`.
+
+```toml
+# cr.toml
+default_profile = "cheap"
+
+[defaults]
+effort = "medium"
+
+[profiles.cheap]
+model = "haiku"
+effort = "low"
+```
+
+Every profile-able option has a `CR_<KEY>` environment mirror, so CI and
+scripts can override a config value without editing files:
+
+| Env var                    | Sets                    |
+| -------------------------- | ----------------------- |
+| `CR_MODEL`                 | model                   |
+| `CR_EFFORT`                | effort                  |
+| `CR_HERMETIC`              | seal ambient config     |
+| `CR_WORKTREE`              | run in a git worktree   |
+| `CR_AGENT`                 | pin a subagent          |
+| `CR_APPEND_SYSTEM_PROMPT`  | append to system prompt |
+| `CR_MAX_BUDGET_USD`        | per-run budget ceiling  |
+| `CR_ALLOWED_TOOLS`         | allowed tool patterns   |
+
+`CR_PROFILE` is separate: it selects which profile is active (below an explicit
+`--profile`, above the config's `default_profile`).
+
+## Profiles
+
+A profile is a named bundle of settings. Select one with `--profile NAME`, or
+set `default_profile` to apply it automatically. `cr profiles` lists them and
+marks the default.
+
+```bash
+cr --profile cheap "quick question"
+cr profiles
+```
+
+`--no-profile` ignores the auto-applied default for one run.
+
+### Alias profiles
+
+A profile that carries a `prompt` template is an *alias*: invoke it by name and
+pass template arguments positionally.
+
+```toml
+[profiles.review]
+model = "opus"
+effort = "high"
+prompt = "Review {{args}} for bugs and style."
+```
+
+```bash
+cr review src/main.rs        # -> "Review src/main.rs for bugs and style."
+```
+
+Template substitution:
+
+- `{{args}}` all positional arguments, space-joined
+- `{{1}}`, `{{2}}`, ... the Nth argument
+- `{{stdin}}` piped stdin (read only when referenced)
+
+A template with no placeholder appends the arguments after a blank line, so
+`[profiles.note] prompt = "Summarize the following."` plus `cr note foo bar`
+sends the prompt followed by `foo bar`.
+
+Profiles without a `prompt` stay flag-bundles, selected with `--profile`; only
+alias profiles dispatch positionally.
+
+### Creating profiles by use
+
+`--save NAME` captures the resolved settings of a run into the project
+`cr.toml`, then exits without spawning. A supplied prompt (positional or `-f`,
+never stdin) is saved as the alias `prompt`:
+
+```bash
+# Save a flag bundle.
+cr -m haiku --effort low --save cheap
+
+# Save an alias in one shot.
+cr "Review {{args}} for bugs and style." -m opus --save review
+```
+
+## Composing the prompt
+
+The prompt comes from exactly one source, in this order: `-e`, `-f FILE`, a
+positional argument, an alias template, or stdin.
+
+- `-e/--editor` opens `$VISUAL`/`$EDITOR` (fallback `vi`) on a `.md` scratch
+  file; on save the trimmed buffer is the prompt.
+- `-f/--file PATH` reads the prompt from a file.
+
+## Output
+
+- Prose by default. On a TTY the answer streams live; on a pipe it is buffered.
+  Force with `--stream` / `--no-stream`.
+- `--json` prints the full structured result envelope.
+- `--schema FILE` constrains the answer to a JSON Schema (implies `--json`).
+
+## Sessions and isolation
+
+- `--continue` resumes the most recent session in the directory; `--resume ID`
+  resumes a specific one; `--session-id UUID` mints a new session with an id you
+  choose (for scripted multi-turn).
+- `-C/--cwd PATH` runs as if from another directory.
+- `--worktree` / `--worktree-name NAME` runs in a fresh git worktree.
+- `--hermetic` seals ambient `~/.claude` config for a reproducible run.
+
+## Meta
+
+- `--explain` prints the exact `claude` command and exits, no spawn. Combine
+  with `--stream` to see the rendered prompt in the argv.
+- `--save NAME` captures a profile (see above).
+
+Run `cr --help` for the full flag reference.

--- a/examples/cr/README.md
+++ b/examples/cr/README.md
@@ -51,6 +51,10 @@ defaults  <  profile  <  CR_<KEY> env var  <  CLI flag
 An explicit flag always wins. `cr config` prints the two paths; `cr config
 --edit` opens the project file in `$EDITOR`.
 
+A fully documented starter config with a handful of useful profiles and aliases
+is in [`cr.sample.toml`](cr.sample.toml). Copy it to `./cr.toml` or
+`~/.config/cr/config.toml` and edit.
+
 ```toml
 # cr.toml
 default_profile = "cheap"

--- a/examples/cr/cr.sample.toml
+++ b/examples/cr/cr.sample.toml
@@ -1,0 +1,83 @@
+# cr.sample.toml
+# ==============
+# A documented example cr config. Copy it to `./cr.toml` (project root) or
+# `~/.config/cr/config.toml` (user-wide) and edit. `cr config --edit` opens the
+# project file in $EDITOR.
+#
+# RESOLUTION  cr reads ~/.config/cr/config.toml first, then ./cr.toml on top.
+# PRECEDENCE  per option, highest wins:
+#               defaults  <  active profile  <  CR_<KEY> env var  <  CLI flag
+# ENV MIRROR  every profile-able key has a CR_<KEY> env var (CR_MODEL,
+#             CR_EFFORT, CR_HERMETIC, CR_WORKTREE, CR_AGENT,
+#             CR_APPEND_SYSTEM_PROMPT, CR_MAX_BUDGET_USD, CR_ALLOWED_TOOLS).
+#             CR_PROFILE is separate: it selects which profile is active.
+
+# Auto-apply this profile when none is given on the CLI. Override per run with
+# --profile NAME, or ignore it with --no-profile.
+default_profile = "cheap"
+
+# ---------------------------------------------------------------------------
+# [defaults] apply to every cr run in this file's scope, under any profile.
+# ---------------------------------------------------------------------------
+[defaults]
+effort = "medium"
+# max_budget_usd = 1.00          # hard per-run ceiling
+# append_system_prompt = "Be terse. Prefer code over prose."
+
+# ===========================================================================
+# Flag-bundle profiles: named sets of settings, selected with --profile NAME.
+# ===========================================================================
+
+# Fast and cheap: quick questions where you do not need the strongest model.
+[profiles.cheap]
+model = "haiku"
+effort = "low"
+
+# The opposite: strongest model, high effort, for hard design/debug work.
+[profiles.deep]
+model = "opus"
+effort = "high"
+
+# A sandboxed profile: seal ambient ~/.claude config for a reproducible run,
+# and cap spend. Handy for CI or sharing a repeatable prompt.
+[profiles.ci]
+model = "sonnet"
+hermetic = true
+max_budget_usd = 0.50
+allowed_tools = ["Read", "Grep", "Glob"]
+
+# ===========================================================================
+# Alias profiles: a profile with a `prompt` template. Invoke it by name and
+# pass arguments positionally: `cr NAME arg1 arg2`.
+#   {{args}}      all arguments, space-joined
+#   {{1}} {{2}}   the Nth argument
+#   {{stdin}}     piped stdin (read only when referenced)
+# A template with no placeholder appends the arguments after a blank line.
+# ===========================================================================
+
+# `cr review src/main.rs`  ->  reviews that file with opus.
+[profiles.review]
+model = "opus"
+effort = "high"
+prompt = "Review {{args}} for bugs, correctness, and style. Be specific and cite lines."
+
+# `git diff --staged | cr commit`  ->  a commit message for the staged diff.
+[profiles.commit]
+model = "sonnet"
+prompt = """
+Write a conventional-commit message for this diff. One-line summary, then a
+short body if warranted. No trailing prose.
+
+{{stdin}}
+"""
+
+# `cr explain lifetimes`  ->  a plain-language explanation.
+[profiles.explain]
+model = "sonnet"
+prompt = "Explain {{args}} simply, with one short example."
+
+# `cr sh "find files larger than 100MB"`  ->  a shell one-liner, no commentary.
+[profiles.sh]
+model = "haiku"
+effort = "low"
+prompt = "Give a single shell command for: {{args}}. Output only the command, no explanation."

--- a/examples/cr/src/main.rs
+++ b/examples/cr/src/main.rs
@@ -1,13 +1,11 @@
-//! `cr` -- a spike of a minimal, config-driven CLI over `claude-wrapper`.
+//! `cr` -- a config-driven CLI over `claude-wrapper`.
 //!
-//! This is an EVALUATION PROTOTYPE, not a shipped binary. It exists to answer
-//! one question: is a curated "profiles + a handful of flags" front door over
-//! the wrapper genuinely simpler than the full roba surface, or does it just
-//! move the complexity around?
+//! A saved `claude -p` you can re-run: name a bundle of flags (and optionally a
+//! prompt) as a profile, then repeat it with a word. One concept -- the profile
+//! -- carries the whole surface.
 //!
-//! What it demonstrates:
-//! - the mocked `cr` flag surface, rendered by clap (`cr --help`)
-//! - per-option layering `defaults < profile < CR_<KEY> env < CLI flag`
+//! - per-option layering `defaults < profile < CR_<KEY> env < CLI flag`; an
+//!   explicit flag always wins
 //! - alias profiles: a `[profiles.NAME]` that carries a `prompt` template is
 //!   invocable positionally (`cr review foo.rs`), with `{{args}}`/`{{1}}`/
 //!   `{{stdin}}` substitution
@@ -17,14 +15,11 @@
 //!   prompt, into a profile)
 //! - the cost/turns footer, from the parsed `QueryResult`
 //!
-//! Deliberately NOT in the spike: worktree lifecycle, and the composition
-//! family (`--attach`/`--git-*`, file prepend/append) -- cr stays passthrough-
-//! thin and does no host-side prompt assembly beyond template substitution.
+//! Stays passthrough-thin: no host-side prompt assembly beyond template
+//! substitution (no file/git composition).
 //!
-//! Run:
-//!   cargo run --example cr --no-default-features \
-//!     --features sync,json,tempfile -- --help
-//!   cargo run --example cr ... -- --profile cheap --explain "summarize this"
+//! Install:  `cargo install claude-cr`  (installs the `cr` binary)
+//! Run:      `cr --help`  /  `cr --profile cheap --explain "summarize this"`
 
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
@@ -242,7 +237,7 @@ fn load_config(path: &Path) -> ConfigFile {
 }
 
 /// User config (`~/.config/cr/config.toml`) is the base; project (`./cr.toml`)
-/// layers on top. Two files, no walk-up in the spike.
+/// layers on top. Two files, no walk-up.
 fn config_paths() -> (Option<PathBuf>, PathBuf) {
     let user = std::env::var_os("HOME")
         .map(|h| PathBuf::from(h).join(".config/cr/config.toml"))

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -18,3 +18,16 @@ git_tag_enable = true
 git_tag_name = "v{{ version }}"
 changelog_update = true
 changelog_path = "CHANGELOG.md"
+
+# `cr`, the companion CLI (crate name `claude-cr`, binary `cr`). Versioned and
+# tagged independently of the library.
+[[package]]
+name = "claude-cr"
+semver_check = false
+release = true
+publish = true
+git_release_enable = true
+git_tag_enable = true
+git_tag_name = "cr-v{{ version }}"
+changelog_update = true
+changelog_path = "examples/cr/CHANGELOG.md"


### PR DESCRIPTION
## What

Two coupled changes to `cr` (the config-driven CLI over the wrapper):

1. **Feature work** on the CLI surface (env precedence, alias profiles, `-e`).
2. **Packaging**: promote it from a loose example into its own installable crate, `claude-cr` (binary `cr`), by converting the repo to a Cargo workspace. Follows the tower-mcp `mcp-repl` pattern.

## Feature work

- **Precedence, per option:** `defaults < profile < CR_<KEY> env < CLI flag`. Every profile-able option gets a `CR_*` env mirror; an explicit flag always wins. `CR_PROFILE` stays separate (selects a profile). Resolution is one overlay chain `defaults.overlay(profile).overlay(env).overlay(cli)`.
- **Profiles = flag-bundle + alias.** A `[profiles.NAME]` carrying a `prompt` template is invocable positionally (`cr review foo.rs`), with `{{args}}`, `{{1}}..{{N}}`, `{{stdin}}`; a placeholder-free template appends the args. Prompt-less profiles stay `--profile`-selected. `cr profiles` marks aliases.
- **`-e/--editor`:** compose in `$VISUAL`/`$EDITOR`/`vi` on a `.md` scratch file; trim; error on empty.
- **`--save`** also captures a supplied prompt as the alias `prompt`, so `cr "Review {{args}}" --save review` mints an alias in one shot.
- Stays passthrough-thin: no file/git prompt assembly.

## Packaging

- Repo becomes a Cargo **workspace**; root stays `claude-wrapper` (flat layout). New member `examples/cr` = crate **`claude-cr` 0.1.0**, `[[bin]] cr`, own `Cargo.toml`/`README.md`/`CHANGELOG.md`, `src/main.rs`.
- `cargo install claude-cr` installs the `cr` binary. (`cr` itself is taken on crates.io by an unrelated 2019 crate; the binary name is unaffected.)
- `clap` and `toml` move from the root dev-deps into the CLI crate (cr was their only user); the old `[[example]] cr` entry is removed.
- Header doc rewritten to stand on its own; spike / evaluation / roba framing removed.
- **release-plz**: `claude-cr` is a released package (tag `cr-v{version}`, own changelog), versioned independently. It depends on `claude-wrapper` by version, so a library release it needs lands first.
- **CI**: dedicated `-p claude-cr` clippy/build/MSRV steps (bare `cargo` commands only touch the root package when a workspace has a root package).
- `AGENTS.md` / `CLAUDE.md` updated for the workspace layout and release flow.

## Verification

- `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings` and `cargo clippy -p claude-cr --all-targets -- -D warnings`: clean.
- `cargo test --lib/--doc/--test '*' --all-features`: pass.
- `cargo build -p claude-cr`, `cargo publish -p claude-cr --dry-run` (packages 7 files, verify-compiles), `cargo install --path examples/cr` (produces a working `cr` binary).
- Manual smoke tests of the non-spawning paths (alias `{{args}}`/`{{1}}`/no-placeholder rendering, env-beats-file and flag-beats-env, `--save`-as-alias, `profiles` alias marking) against the installed binary.

## Not in scope

- Actually publishing to crates.io (release-plz handles that on merge).
- roba's file/git prompt composition (`--attach`/`--git-diff`/prepend/append).
- Editor history-preamble.