### PR TITLE
fix: gate feature-dependent imports so all feature combos build warning-free

### DIFF
--- a/src/command/auth.rs
+++ b/src/command/auth.rs
@@ -5,10 +5,14 @@
 //! [`SetupTokenCommand`]. For detecting which auth strategy the CLI
 //! will use without invoking it, see [`crate::auth`].
 
+#[cfg(any(feature = "async", all(feature = "sync", feature = "json")))]
 use crate::Claude;
 use crate::command::ClaudeCommand;
+#[cfg(any(feature = "async", all(feature = "sync", feature = "json")))]
 use crate::error::Result;
-use crate::exec::{self, CommandOutput};
+#[cfg(any(feature = "async", all(feature = "sync", feature = "json")))]
+use crate::exec;
+use crate::exec::CommandOutput;
 
 /// Check authentication status.
 ///

--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -757,6 +757,7 @@ impl QueryCommand {
     /// the end, so the late flag becomes positional and is eaten as
     /// part of the prompt. We clone-and-set instead so the flag
     /// lands in its proper slot before `--`.
+    #[allow(dead_code)] // unused without `json` plus `async` or `sync`; tests always call it
     fn build_args_with_forced_json(&self) -> Vec<String> {
         if self.output_format.is_some() {
             return self.build_args();


### PR DESCRIPTION
## Context

`cargo build --no-default-features --features sync` emits warnings. In `src/command/auth.rs`, the imports of `Claude`, `Result`, and `exec` (the `self` in `exec::{self, CommandOutput}`) are only used by methods gated on `async` or on `sync` + `json`, so a sync-only build flags all three as unused. The same build also flags `QueryCommand::build_args_with_forced_json` in `src/command/query.rs` as dead code, since its only non-test callers are `execute_json` (`json` + `async`) and `execute_json_sync` (`json` + `sync`).

## Plan

1. In `src/command/auth.rs`, gate the `Claude`, `Result`, and `exec` imports on `any(feature = "async", all(feature = "sync", feature = "json"))`, splitting `exec::{self, CommandOutput}` into two use statements so the always-used `CommandOutput` stays ungated. Mirrors the existing pattern in `src/command/agents.rs`.
2. In `src/command/query.rs`, add `#[allow(dead_code)]` with an explanatory comment to `build_args_with_forced_json`, following the precedent at `src/lib.rs` (`warn_on_drift`). A cfg gate is not usable here because unit tests call the method under every feature combination, including `--no-default-features`, which CI exercises.

## Verification

- `cargo build --no-default-features --features sync` (warning-free)
- `cargo build --no-default-features --features "json sync"` (warning-free)
- `cargo build --no-default-features` (warning-free)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`