### PR TITLE
fix: remove remaining no-default-features build warnings

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -17,7 +17,9 @@ pub mod version;
 #[cfg(feature = "async")]
 use std::future::Future;
 
+#[cfg(any(feature = "async", feature = "sync"))]
 use crate::Claude;
+#[cfg(any(feature = "async", feature = "sync"))]
 use crate::error::Result;
 
 /// Trait implemented by all claude CLI command builders.

--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -11,6 +11,7 @@
 use crate::Claude;
 use crate::command::ClaudeCommand;
 use crate::command::spawn_args::{SharedSpawnArgs, shell_quote};
+#[cfg(any(feature = "async", feature = "sync"))]
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
 use crate::tool_pattern::ToolPattern;

--- a/src/dangerous.rs
+++ b/src/dangerous.rs
@@ -53,9 +53,12 @@
 use crate::Claude;
 #[cfg(feature = "async")]
 use crate::command::ClaudeCommand;
+#[cfg(any(feature = "async", feature = "sync"))]
 use crate::command::query::QueryCommand;
 use crate::error::{Error, Result};
+#[cfg(any(feature = "async", feature = "sync"))]
 use crate::exec::CommandOutput;
+#[cfg(any(feature = "async", feature = "sync"))]
 #[allow(deprecated)]
 use crate::types::PermissionMode;
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -8,15 +8,18 @@
 //! [`from_command_failure`](crate::error::Error::from_command_failure).
 //! Both the async (tokio) and blocking (`sync` feature) paths live here.
 
+#[cfg(any(feature = "async", feature = "sync"))]
 use std::time::Duration;
 
 #[cfg(feature = "async")]
 use tokio::io::AsyncReadExt;
 #[cfg(feature = "async")]
 use tokio::process::Command;
+#[cfg(any(feature = "async", feature = "sync"))]
 use tracing::{debug, warn};
 
 use crate::Claude;
+#[cfg(any(feature = "async", feature = "sync"))]
 use crate::error::{Error, Result};
 
 /// Assemble the full argv passed to the CLI binary: the client's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,9 +418,16 @@ pub use version::{CliVersion, CliVersionStatus, VersionParseError};
 pub struct Claude {
     pub(crate) binary: PathBuf,
     pub(crate) working_dir: Option<PathBuf>,
+    // env, timeout, and retry_policy are written by the builder under
+    // every feature combination but read only by the feature-gated
+    // exec paths, so they are "never read" with neither `async` nor
+    // `sync` feature.
+    #[allow(dead_code)]
     pub(crate) env: HashMap<String, String>,
     pub(crate) global_args: Vec<String>,
+    #[allow(dead_code)]
     pub(crate) timeout: Option<Duration>,
+    #[allow(dead_code)]
     pub(crate) retry_policy: Option<RetryPolicy>,
     pub(crate) tested_cli_version_range: Option<(CliVersion, CliVersion)>,
 }

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -285,6 +285,8 @@ impl TempMcpConfig {
 
 #[cfg(test)]
 mod tests {
+    // Every test in this module requires `json`.
+    #[cfg(feature = "json")]
     use super::*;
 
     #[test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -7,6 +7,7 @@
 
 use std::time::Duration;
 
+#[cfg(any(feature = "async", feature = "sync"))]
 use tracing::warn;
 
 use crate::error::Error;
@@ -119,6 +120,7 @@ impl RetryPolicy {
     }
 
     /// Calculate the delay for a given attempt (0-indexed).
+    #[allow(dead_code)] // unused with neither `async` nor `sync` feature; unit tests cover it
     pub(crate) fn delay_for_attempt(&self, attempt: u32) -> Duration {
         let delay = match self.backoff_strategy {
             BackoffStrategy::Fixed => self.initial_backoff,
@@ -130,6 +132,7 @@ impl RetryPolicy {
     }
 
     /// Check if the given error should be retried.
+    #[allow(dead_code)] // unused with neither `async` nor `sync` feature; unit tests cover it
     pub(crate) fn should_retry(&self, error: &Error) -> bool {
         match error {
             Error::Timeout { .. } => self.retry_on_timeout,


### PR DESCRIPTION
## Context

`cargo build --no-default-features` (a combination CI builds) emits 12 warnings. PR #735 fixed the sync-only combination; this PR fixes the remaining no-feature and json-only cases. Every warning traces to an item used only by code gated on the `async` or `sync` feature.

## Plan

Gate imports whose only uses are feature-gated, following the precedent set in `src/command/auth.rs` (#735). All gates are `#[cfg(any(feature = "async", feature = "sync"))]` because each import feeds both the async and the sync execution paths:

- `src/command/query.rs`: `crate::error::Result` (used by `execute`, `execute_sync`, `execute_json`, `execute_json_sync`)
- `src/command/mod.rs`: `crate::Claude`, `crate::error::Result` (used by the async trait method and the sync extension trait)
- `src/dangerous.rs`: `QueryCommand`, `CommandOutput`, `PermissionMode` (used by `query_bypass` / `query_bypass_sync`)
- `src/exec.rs`: `std::time::Duration`, `tracing::{debug, warn}`, `crate::error::{Error, Result}` (used by the async and sync exec paths)
- `src/retry.rs`: `tracing::warn` (used by `with_retry` / `with_retry_sync`)

Use `#[allow(dead_code)]` with an explanatory comment, following the `warn_on_drift` precedent in `src/lib.rs`, for items that ungated unit tests exercise under every combination:

- `src/lib.rs`: `Claude` fields `env`, `timeout`, `retry_policy` (written by the builder under all combos, read only by the gated exec paths)
- `src/retry.rs`: `RetryPolicy::delay_for_attempt` and `RetryPolicy::should_retry` (called by the gated retry loops and by ungated unit tests)

## Verification

- `cargo build --no-default-features` warning-free
- `cargo build --no-default-features --features sync` warning-free
- `cargo build --no-default-features --features json` warning-free
- `cargo build --no-default-features --features "json sync"` warning-free
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --lib --no-default-features`

## Added during implementation

`cargo test --lib --no-default-features` surfaced one more pre-existing warning of the same class: the `mcp_config.rs` test module's `use super::*` is unused when `json` is off, because every test in that module is `json`-gated. The import now carries the same `#[cfg(feature = "json")]` gate.
