### PR TITLE
feat(history): make single-line entry parsing public

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -866,6 +866,38 @@ pub enum HistoryEntry {
 }
 
 impl HistoryEntry {
+    /// Parse a single transcript line into a typed entry.
+    ///
+    /// The per-line counterpart to [`HistoryRoot::read_session`]: use
+    /// this when you already hold the line -- typically a consumer
+    /// tailing append-only transcript files by byte offset, reading
+    /// only the new bytes on each pass instead of re-reading whole
+    /// session files.
+    ///
+    /// Parsing is liberal, matching `read_session`: entry types other
+    /// than `user` and `assistant` come through as [`Self::Other`]
+    /// carrying the raw value. A line that is not valid JSON is the
+    /// one `Err` case -- the same lines `read_session` skips with a
+    /// warning, left to the caller here.
+    ///
+    /// ```
+    /// use claude_wrapper::history::HistoryEntry;
+    ///
+    /// let line = r#"{"type":"user","uuid":"u1","cwd":"/work/repo","promptSource":"typed","message":{"role":"user"}}"#;
+    /// let entry = HistoryEntry::from_line(line)?;
+    /// match &entry {
+    ///     HistoryEntry::User { cwd, .. } => {
+    ///         assert_eq!(cwd.as_deref(), Some("/work/repo"));
+    ///     }
+    ///     _ => unreachable!(),
+    /// }
+    /// assert_eq!(entry.prompt_source(), Some("typed"));
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    pub fn from_line(line: &str) -> std::result::Result<Self, serde_json::Error> {
+        parse_entry(line)
+    }
+
     /// Raw access to a field by its name as Claude Code wrote it
     /// (camelCase, e.g. `"permissionMode"`).
     ///
@@ -1618,6 +1650,31 @@ mod tests {
             }
             other => panic!("expected Assistant entry, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn from_line_is_the_public_face_of_parse_entry() {
+        // Typed, unknown-type, and malformed lines all behave exactly
+        // as they do through read_session's internal parser.
+        let user = r#"{"type":"user","uuid":"u1","cwd":"/w","message":{"role":"user"}}"#;
+        match HistoryEntry::from_line(user).expect("parse") {
+            HistoryEntry::User { uuid, cwd, .. } => {
+                assert_eq!(uuid.as_deref(), Some("u1"));
+                assert_eq!(cwd.as_deref(), Some("/w"));
+            }
+            other => panic!("expected User entry, got {other:?}"),
+        }
+
+        let unknown = r#"{"type":"ai-title","title":"t"}"#;
+        match HistoryEntry::from_line(unknown).expect("parse") {
+            HistoryEntry::Other { type_tag, raw } => {
+                assert_eq!(type_tag, "ai-title");
+                assert_eq!(raw["title"], "t");
+            }
+            other => panic!("expected Other entry, got {other:?}"),
+        }
+
+        assert!(HistoryEntry::from_line("not json").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Closes #737.

## Context

`parse_entry` in `src/history.rs` is private; the only public route to a `HistoryEntry` is `HistoryRoot::read_session`, which reads a whole session file. Consumers that tail transcript files incrementally already hold the line and need a parser, not a file reader. solito currently hand-rolls a duplicate parser for this.

## Plan

1. Add `HistoryEntry::from_line(line: &str) -> Result<Self, serde_json::Error>` as a public wrapper over `parse_entry`, on the existing `impl HistoryEntry` block. A method keeps the free function private so the module internals stay free to move.
2. Doc comment covering the incremental-tailing use case, pointing at `read_session` for whole-file reads, and noting the liberal-parsing contract (unknown types land in `Other`; a malformed line is an `Err`, mirroring what `read_session` skips).
3. Doctest parsing a representative user line, plus a unit test asserting `from_line` and the internal parser agree.

No behavior change; `parse_entry` is already covered by `parse_entry_populates_rest_with_unmodeled_fields` and `parse_entry_keeps_mistyped_field_in_rest`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`