### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.5](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.4...v0.13.5) - 2026-07-30
+
+### Added
+
+- *(history)* make single-line entry parsing public ([#739](https://github.com/joshrotenberg/claude-wrapper/pull/739))
+
 ## [0.13.4](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.3...v0.13.4) - 2026-07-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "claude-wrapper"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 
 [package]
 name = "claude-wrapper"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.13.4 -> 0.13.5 (✓ API compatible changes)
* `claude-cr`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-wrapper`

<blockquote>

## [0.13.5](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.4...v0.13.5) - 2026-07-30

### Added

- *(history)* make single-line entry parsing public ([#739](https://github.com/joshrotenberg/claude-wrapper/pull/739))
</blockquote>

## `claude-cr`

<blockquote>

## [0.1.0](https://github.com/joshrotenberg/claude-wrapper/releases/tag/cr-v0.1.0) - 2026-07-30

### Added

- *(cr)* flag and config parity plus capability knobs ([#719](https://github.com/joshrotenberg/claude-wrapper/pull/719))
- *(cr)* env precedence, alias profiles, editor compose; ship as installable crate claude-cr ([#715](https://github.com/joshrotenberg/claude-wrapper/pull/715))

### Features

- Config-driven CLI over claude-wrapper: TOML profiles with
  `defaults < profile < CR_<KEY> env < CLI flag` layering, alias profiles with
  `{{args}}`/`{{N}}`/`{{stdin}}` prompt templates, `-e` editor compose,
  `--explain` dry-run, `--save` creation-by-use, and a cost/turns footer.
- Flag parity for every profile-able option, so an explicit flag always wins:
  `--agent`, `--append-system-prompt`, `--max-budget-usd`, `--allow-tool`.
- Tools, permissions, and limits as profile-able keys (flag + `CR_*` mirror):
  `--permission-mode` (with `--accept-edits`/`--plan` shortcuts),
  `--disallow-tool`, `--add-dir`, `--mcp-config`, `--fallback-model`,
  `--max-turns`.
- `cr profiles NAME` prints what a profile resolves to (defaults plus profile).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).