### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.0] - 2026-08-08
+
+### Bug Fixes
+
+- *(frontmatter)* Support YAML block scalars in agent, skill, and command frontmatter 
+- *(exec)* Kill the CLI child when an in-flight execute future is dropped 
+- Quote an empty argument in shell_quote 
+
+### Features
+
+- *(artifacts)* [**breaking**] Parse YAML block sequences, add typed Agent::skills 
+- Declare the tested CLI version range in the crate 
+- *(exec)* Kill the whole process group so a cancelled run leaves no subprocesses behind 
+- Add ensure_tested_cli_version as an opt-in hard version gate 
+- Tracing spans around execution, streaming, retry, and duplex sessions 
+- *(session)* TokenUsage type and per-turn token accounting 
+- Builder opt-out of the process-group split for terminal-attached hosts 
+- Opt-in SIGTERM-then-SIGKILL grace so a killed run can flush its transcript 
+- Report every spawned child's pid via an on_spawn observer 
+- Opt-in parent-death signal so a SIGKILLed supervisor leaves no orphan 
+
+### Miscellaneous
+
+- Remove the cr CLI from this repo 
+- Run the contract suite against the latest published CLI weekly 
+- Add a git-cliff config and a changelog preview workflow 
+
+### Testing
+
+- Add a CLI contract suite checking emitted flags against the binary 
+
+
+
 ## [0.13.5](https://github.com/joshrotenberg/claude-wrapper/compare/v0.13.4...v0.13.5) - 2026-07-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.13.5"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "claude-wrapper"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.13.5 -> 0.14.0 (⚠ API breaking changes)

### ⚠ `claude-wrapper` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Claude is no longer UnwindSafe, in /tmp/.tmpgSOHXz/claude-wrapper/src/lib.rs:444
  type Claude is no longer RefUnwindSafe, in /tmp/.tmpgSOHXz/claude-wrapper/src/lib.rs:444
  type DangerousClient is no longer UnwindSafe, in /tmp/.tmpgSOHXz/claude-wrapper/src/dangerous.rs:74
  type DangerousClient is no longer RefUnwindSafe, in /tmp/.tmpgSOHXz/claude-wrapper/src/dangerous.rs:74
  type ClaudeBuilder is no longer UnwindSafe, in /tmp/.tmpgSOHXz/claude-wrapper/src/lib.rs:754
  type ClaudeBuilder is no longer RefUnwindSafe, in /tmp/.tmpgSOHXz/claude-wrapper/src/lib.rs:754

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AgentSummary.skills in /tmp/.tmpgSOHXz/claude-wrapper/src/artifacts.rs:370
  field QueryResult.usage in /tmp/.tmpgSOHXz/claude-wrapper/src/types.rs:431
  field QueryResult.usage in /tmp/.tmpgSOHXz/claude-wrapper/src/types.rs:431
  field Agent.skills in /tmp/.tmpgSOHXz/claude-wrapper/src/artifacts.rs:410
  field AgentWriteInput.skills in /tmp/.tmpgSOHXz/claude-wrapper/src/artifacts.rs:267
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.0] - 2026-08-08

### Bug Fixes

- *(frontmatter)* Support YAML block scalars in agent, skill, and command frontmatter 
- *(exec)* Kill the CLI child when an in-flight execute future is dropped 
- Quote an empty argument in shell_quote 

### Features

- *(artifacts)* [**breaking**] Parse YAML block sequences, add typed Agent::skills 
- Declare the tested CLI version range in the crate 
- *(exec)* Kill the whole process group so a cancelled run leaves no subprocesses behind 
- Add ensure_tested_cli_version as an opt-in hard version gate 
- Tracing spans around execution, streaming, retry, and duplex sessions 
- *(session)* TokenUsage type and per-turn token accounting 
- Builder opt-out of the process-group split for terminal-attached hosts 
- Opt-in SIGTERM-then-SIGKILL grace so a killed run can flush its transcript 
- Report every spawned child's pid via an on_spawn observer 
- Opt-in parent-death signal so a SIGKILLed supervisor leaves no orphan 

### Miscellaneous

- Remove the cr CLI from this repo 
- Run the contract suite against the latest published CLI weekly 
- Add a git-cliff config and a changelog preview workflow 

### Testing

- Add a CLI contract suite checking emitted flags against the binary
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).