### PR TITLE
feat(cr): interactive repl and detached background jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "anyhow",
  "clap",
  "claude-wrapper",
+ "libc",
  "nu-ansi-term",
  "reedline",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -63,6 +72,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -121,6 +136,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -129,10 +153,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -181,9 +227,12 @@ dependencies = [
  "anyhow",
  "clap",
  "claude-wrapper",
+ "nu-ansi-term",
+ "reedline",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "toml",
 ]
 
@@ -210,6 +259,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,7 +351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -230,6 +359,23 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -394,6 +540,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,10 +588,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -440,6 +630,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -481,8 +677,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -576,6 +791,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "reedline"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826c1fc22a2b1f14c3f6a80fc3d56adfbfb913d07f170bce4246700de7adfd50"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "fd-lock",
+ "itertools",
+ "nu-ansi-term",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "thiserror",
+ "unicase",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,8 +829,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -682,6 +932,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,7 +987,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -718,6 +1004,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "syn"
@@ -757,7 +1064,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -794,7 +1101,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -908,10 +1215,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -924,6 +1249,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -956,6 +1290,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1002,10 +1381,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1015,6 +1478,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/examples/cr/CHANGELOG.md
+++ b/examples/cr/CHANGELOG.md
@@ -28,4 +28,5 @@ All notable changes to this project will be documented in this file.
   text streams live; `/model`, `/effort`, `/profile` retune and respawn with
   `--resume`; `/session new`, `/use`, `/close`, `/all` run several
   conversations at once; Ctrl-C interrupts a turn. reedline editor on a TTY,
-  plain stdin for scripting.
+  plain stdin for scripting. Tab-completes commands and profile names, suggests
+  the nearest command on a typo, and `-e/--exec` runs commands then exits.

--- a/examples/cr/CHANGELOG.md
+++ b/examples/cr/CHANGELOG.md
@@ -24,3 +24,8 @@ All notable changes to this project will be documented in this file.
   `--disallow-tool`, `--add-dir`, `--mcp-config`, `--fallback-model`,
   `--max-turns`.
 - `cr profiles NAME` prints what a profile resolves to (defaults plus profile).
+- `cr repl`: an interactive multi-turn session over `DuplexSession`. Assistant
+  text streams live; `/model`, `/effort`, `/profile` retune and respawn with
+  `--resume`; `/session new`, `/use`, `/close`, `/all` run several
+  conversations at once; Ctrl-C interrupts a turn. reedline editor on a TTY,
+  plain stdin for scripting.

--- a/examples/cr/CHANGELOG.md
+++ b/examples/cr/CHANGELOG.md
@@ -24,6 +24,13 @@ All notable changes to this project will be documented in this file.
   `--disallow-tool`, `--add-dir`, `--mcp-config`, `--fallback-model`,
   `--max-turns`.
 - `cr profiles NAME` prints what a profile resolves to (defaults plus profile).
+- Background jobs: `cr -d "<prompt>"` launches a detached `claude` run (no
+  daemon; own process group, stdout journaled under `~/.config/cr/jobs/`) and
+  returns. `cr jobs` lists them (including Claude Code's own daemon jobs,
+  read-only); `cr job <id>` renders/tails one (`--follow`, `--json`); the REPL
+  `<prompt> &` backgrounds a turn; reconnect with `cr repl --resume <id>`.
+  Launching requires a budget or turn cap (unattended tool access) unless
+  `--uncapped`.
 - `cr repl`: an interactive multi-turn session over `DuplexSession`. Assistant
   text streams live; `/model`, `/effort`, `/profile` retune and respawn with
   `--resume`; `/session new`, `/use`, `/close`, `/all` run several

--- a/examples/cr/CHANGELOG.md
+++ b/examples/cr/CHANGELOG.md
@@ -29,4 +29,5 @@ All notable changes to this project will be documented in this file.
   `--resume`; `/session new`, `/use`, `/close`, `/all` run several
   conversations at once; Ctrl-C interrupts a turn. reedline editor on a TTY,
   plain stdin for scripting. Tab-completes commands and profile names, suggests
-  the nearest command on a typo, and `-e/--exec` runs commands then exits.
+  the nearest command on a typo, `/json` prints the last turn's full result, and
+  `-e/--exec` runs commands then exits.

--- a/examples/cr/Cargo.toml
+++ b/examples/cr/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 claude-wrapper = { version = "0.13", path = "../..", default-features = false, features = [
-    "sync",
+    "async",
     "json",
     "tempfile",
 ] }
@@ -27,3 +27,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 toml = "1.1"
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "macros",
+    "signal",
+    "time",
+] }
+reedline = "0.49"
+nu-ansi-term = "0.50"

--- a/examples/cr/Cargo.toml
+++ b/examples/cr/Cargo.toml
@@ -35,3 +35,6 @@ tokio = { version = "1", features = [
 ] }
 reedline = "0.49"
 nu-ansi-term = "0.50"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/examples/cr/README.md
+++ b/examples/cr/README.md
@@ -35,6 +35,38 @@ cr --explain "summarize this"
 Every run ends with a footer on stderr: the model that actually billed, turns,
 cost, and wall time. `-q/--quiet` drops it.
 
+## Interactive session
+
+`cr repl` opens a multi-turn session: one `claude` child held open across turns,
+seeded from the same resolved settings a one-shot run uses (`cr repl --profile
+deep`, `cr repl -m opus`). Plain lines are prompts and stream as they arrive;
+lines starting with `/` are meta-commands. Ctrl-C cancels a running turn, Ctrl-D
+exits.
+
+```text
+$ cr repl -m haiku
+cr interactive session (main), model haiku. /help for commands, /exit to quit.
+main:haiku> summarize what this repo does
+...
+main:haiku> /model opus          # respawns, keeps the conversation
+main:opus> /cost
+main: 3 turns, $0.0412
+```
+
+- `/model`, `/effort`, `/profile <name>` retune the session; it respawns with
+  `--resume` so history carries over. `/new` resets to an empty context.
+- `/editor` composes a prompt in `$EDITOR`; `/history`, `/cost`, and `/explain`
+  (the exact spawn command) inspect the session.
+- Several conversations at once: `/session new <name> [profile]` opens another
+  (seeded from a profile, or cloned from the current one), `/use <name>`
+  switches, `/sessions` lists them with per-session cost, `/close [name]` ends
+  one, and `/all <prompt>` fans one prompt across every session. Each is its own
+  child, so they can run different models, tools, and permission modes in
+  parallel.
+
+On a pipe (no TTY) the editor is skipped and lines are read from stdin, so
+`printf '...\n/exit\n' | cr repl` scripts a session.
+
 ## Config and precedence
 
 `cr` reads two TOML files, low to high:

--- a/examples/cr/README.md
+++ b/examples/cr/README.md
@@ -76,6 +76,39 @@ cr repl -m haiku -e "explain this crate in one line" -e /cost
 On a pipe (no TTY) the editor is skipped and lines are read from stdin, so
 `printf '...\n/exit\n' | cr repl` also scripts a session.
 
+## Background jobs
+
+A job is a `claude` run that keeps going after cr exits, so you can fire
+long-running, mostly-mechanical agent work, disconnect, and check on it later.
+There is no daemon: cr spawns the run detached (its own process group, stdout
+captured to a journal) and records it under `~/.config/cr/jobs/<id>/`.
+
+```bash
+# Launch and return immediately.
+cr -d --max-turns 40 "find all the bugs in the codebase and file an issue for each"
+# -> job cr-1a2b3c launched, cap 40 turns
+
+# List jobs (cr's, plus Claude Code's own background jobs, read-only).
+cr jobs
+
+# Watch one to completion; --json dumps the raw stream-json.
+cr job cr-1a2b3c --follow
+
+# Reconnect to the finished session and ask about it.
+cr repl --resume <session-id>   # the id `cr job` prints
+```
+
+Because a job runs unattended with tool access, launching requires a cap:
+`--max-budget-usd` or `--max-turns` (from a flag, profile, or config), unless
+you pass `--uncapped`. Jobs are addressed by id, a unique id-prefix, or a
+`--session NAME` label (`cr -d --session nightly "..."`, then `cr --check
+--session nightly`). Inside the REPL, a trailing `&` backgrounds a prompt:
+
+```text
+main:haiku> find and fix the flaky test &
+(job cr-9f2e launched [main], cap 30 turns (default); `cr job cr-9f2e` to check)
+```
+
 ## Config and precedence
 
 `cr` reads two TOML files, low to high:

--- a/examples/cr/README.md
+++ b/examples/cr/README.md
@@ -64,8 +64,17 @@ main: 3 turns, $0.0412
   child, so they can run different models, tools, and permission modes in
   parallel.
 
+On a TTY, Tab completes `/command` names and (after `/profile`) profile names.
+Unknown commands suggest the nearest match. `-e/--exec <cmd>` runs a command
+(a prompt or a `/command`) then exits, repeatable and in order, with a non-zero
+status if any errored, so a session scripts:
+
+```bash
+cr repl -m haiku -e "explain this crate in one line" -e /cost
+```
+
 On a pipe (no TTY) the editor is skipped and lines are read from stdin, so
-`printf '...\n/exit\n' | cr repl` scripts a session.
+`printf '...\n/exit\n' | cr repl` also scripts a session.
 
 ## Config and precedence
 

--- a/examples/cr/src/jobs.rs
+++ b/examples/cr/src/jobs.rs
@@ -276,12 +276,8 @@ pub fn resolve(selector: &str) -> anyhow::Result<JobRecord> {
     }
 }
 
-/// Render the job list as a table.
+/// Render cr's jobs as rows (no header, no empty message; the caller frames it).
 pub fn render_list(jobs: &[JobRecord]) {
-    if jobs.is_empty() {
-        println!("no jobs (launch one with `cr -d \"<prompt>\"`)");
-        return;
-    }
     for j in jobs {
         let st = status(j);
         let name = j.session_name.as_deref().unwrap_or("-");
@@ -293,6 +289,38 @@ pub fn render_list(jobs: &[JobRecord]) {
             Color::DarkGray.paint(ago(j.created_secs)),
             first_line(&j.prompt),
         );
+    }
+}
+
+/// Also list Claude Code's own background jobs (read-only, via the library's
+/// `jobs` introspection). Best-effort: returns the count printed, or 0 if the
+/// daemon store is absent or unreadable. Marked `(claude)` to distinguish them.
+pub fn render_daemon() -> usize {
+    let Ok(root) = claude_wrapper::jobs::JobsRoot::home() else {
+        return 0;
+    };
+    let Ok(list) = root.list() else {
+        return 0;
+    };
+    for s in &list {
+        let intent = s.intent.as_deref().or(s.name.as_deref()).unwrap_or("");
+        println!(
+            "{:<10} {:<8} {:<10} {}  {}",
+            s.short_id,
+            daemon_state_label(&s.state),
+            "(claude)",
+            Color::DarkGray.paint(s.created_at.clone().unwrap_or_default()),
+            first_line(intent),
+        );
+    }
+    list.len()
+}
+
+fn daemon_state_label(state: &str) -> nu_ansi_term::AnsiString<'static> {
+    match state {
+        "running" => Color::Yellow.paint(state.to_string()),
+        "done" | "completed" => Color::Green.paint(state.to_string()),
+        _ => Color::Red.paint(state.to_string()),
     }
 }
 

--- a/examples/cr/src/jobs.rs
+++ b/examples/cr/src/jobs.rs
@@ -1,0 +1,440 @@
+//! Detached background jobs (Tier 0).
+//!
+//! A job is a `claude -p --output-format stream-json` process that cr spawns
+//! **detached** (its own process group, stdin nulled, stdout captured to a
+//! journal file) so it keeps running after cr exits. No daemon: the "backend"
+//! is the detached process plus a directory of files, mirroring the shape of
+//! Claude Code's own `~/.claude/jobs/<id>/` (see `claude_wrapper::jobs`).
+//!
+//! ```text
+//! ~/.config/cr/jobs/<id>/
+//!     state.json      the JobRecord below
+//!     journal.jsonl   the child's stdout (stream-json events)
+//!     stderr.log      the child's stderr
+//! ```
+//!
+//! The child also writes its normal session transcript to
+//! `~/.claude/projects/<slug>/<session-id>.jsonl`, so a finished job is
+//! resumable with `--resume <session-id>` and readable via
+//! `claude_wrapper::history`.
+
+use std::fs;
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Context;
+use claude_wrapper::Claude;
+use nu_ansi_term::Color;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Persistent record of a launched job (`state.json`). Liveness/completion are
+/// computed at read time (from the journal and the pid), not stored, so a
+/// crashed writer never leaves a stale "running".
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct JobRecord {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_name: Option<String>,
+    pub prompt: String,
+    pub cwd: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub pid: u32,
+    pub created_secs: u64,
+    /// A human note of the guardrail cap in force (e.g. "$2.00", "12 turns").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cap: Option<String>,
+}
+
+/// Where a job is in its lifecycle, computed from the journal and pid.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Status {
+    Running,
+    Done {
+        is_error: bool,
+    },
+    /// Process gone with no `result` event: crashed or was killed.
+    Stopped,
+}
+
+impl Status {
+    fn label(self) -> nu_ansi_term::AnsiString<'static> {
+        match self {
+            Status::Running => Color::Yellow.paint("running"),
+            Status::Done { is_error: false } => Color::Green.paint("done"),
+            Status::Done { is_error: true } => Color::Red.paint("error"),
+            Status::Stopped => Color::Red.paint("stopped"),
+        }
+    }
+}
+
+/// `~/.config/cr/jobs` (honours `XDG_CONFIG_HOME`).
+pub fn jobs_dir() -> anyhow::Result<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))
+        .context("no XDG_CONFIG_HOME or HOME to locate the cr job store")?;
+    Ok(base.join("cr").join("jobs"))
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// A short, collision-resistant job id from the current time and pid.
+fn new_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mix = nanos ^ ((std::process::id() as u128) << 17);
+    format!("cr-{:07x}", (mix as u64) & 0xfff_ffff)
+}
+
+/// Launch a detached job. `argv` is the full `claude` subcommand argv (from
+/// `QueryCommand::args()`), already carrying `-p --output-format stream-json`
+/// and the resolved settings. Returns the written record.
+pub fn launch(
+    claude: &Claude,
+    argv: Vec<String>,
+    cwd: Option<&Path>,
+    prompt: &str,
+    session_name: Option<String>,
+    model: Option<String>,
+    cap: Option<String>,
+) -> anyhow::Result<JobRecord> {
+    let id = new_id();
+    let dir = jobs_dir()?.join(&id);
+    fs::create_dir_all(&dir).with_context(|| format!("creating job dir {}", dir.display()))?;
+
+    let journal = fs::File::create(dir.join("journal.jsonl"))?;
+    let stderr = fs::File::create(dir.join("stderr.log"))?;
+
+    let run_cwd = cwd
+        .map(Path::to_path_buf)
+        .or_else(|| claude.working_dir().map(Path::to_path_buf))
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let mut command = std::process::Command::new(claude.binary());
+    command
+        .args(&argv)
+        .current_dir(&run_cwd)
+        // Same hygiene the library's exec layer applies, so the child does not
+        // believe it is running inside another Claude Code invocation.
+        .env_remove("CLAUDECODE")
+        .env_remove("CLAUDE_CODE_ENTRYPOINT")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(journal))
+        .stderr(std::process::Stdio::from(stderr));
+    detach(&mut command);
+
+    let child = command
+        .spawn()
+        .with_context(|| format!("spawning detached claude ({})", claude.binary().display()))?;
+
+    let record = JobRecord {
+        id,
+        session_name,
+        prompt: prompt.to_string(),
+        cwd: run_cwd.display().to_string(),
+        model,
+        pid: child.id(),
+        created_secs: now_secs(),
+        cap,
+    };
+    write_state(&dir, &record)?;
+    Ok(record)
+}
+
+/// Put the child in its own process group so a Ctrl-C or terminal-close aimed
+/// at cr's group does not reach it. Enough to outlive cr for Tier 0.
+#[cfg(unix)]
+fn detach(command: &mut std::process::Command) {
+    use std::os::unix::process::CommandExt;
+    command.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn detach(_command: &mut std::process::Command) {}
+
+fn write_state(dir: &Path, record: &JobRecord) -> anyhow::Result<()> {
+    let mut f = fs::File::create(dir.join("state.json"))?;
+    f.write_all(serde_json::to_string_pretty(record)?.as_bytes())?;
+    Ok(())
+}
+
+/// Is a pid still alive? `kill(pid, 0)` on unix; assume alive elsewhere.
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    // SAFETY: `kill` with signal 0 performs only an existence/permission check.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    true
+}
+
+/// Read a job's journal lines as parsed JSON values (best-effort; malformed or
+/// partial trailing lines are skipped).
+fn journal_events(id: &str) -> anyhow::Result<Vec<Value>> {
+    let path = jobs_dir()?.join(id).join("journal.jsonl");
+    let Ok(file) = fs::File::open(&path) else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for line in std::io::BufReader::new(file).lines().map_while(Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(&line) {
+            out.push(v);
+        }
+    }
+    Ok(out)
+}
+
+/// The final `result` event, if the job has finished.
+fn result_event(events: &[Value]) -> Option<&Value> {
+    events
+        .iter()
+        .rev()
+        .find(|e| e.get("type").and_then(Value::as_str) == Some("result"))
+}
+
+/// The session id claude assigned, from the first init event.
+pub fn session_id(id: &str) -> Option<String> {
+    let events = journal_events(id).ok()?;
+    events.iter().find_map(|e| {
+        if e.get("type").and_then(Value::as_str) == Some("system") {
+            e.get("session_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        } else {
+            None
+        }
+    })
+}
+
+pub fn status(record: &JobRecord) -> Status {
+    let events = journal_events(&record.id).unwrap_or_default();
+    if let Some(r) = result_event(&events) {
+        let is_error = r.get("is_error").and_then(Value::as_bool).unwrap_or(false)
+            || r.get("subtype").and_then(Value::as_str) == Some("error");
+        return Status::Done { is_error };
+    }
+    if pid_alive(record.pid) {
+        Status::Running
+    } else {
+        Status::Stopped
+    }
+}
+
+/// All cr jobs, newest first.
+pub fn list() -> anyhow::Result<Vec<JobRecord>> {
+    let dir = jobs_dir()?;
+    let mut jobs = Vec::new();
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return Ok(jobs);
+    };
+    for entry in entries.flatten() {
+        let state = entry.path().join("state.json");
+        if let Ok(text) = fs::read_to_string(&state)
+            && let Ok(rec) = serde_json::from_str::<JobRecord>(&text)
+        {
+            jobs.push(rec);
+        }
+    }
+    jobs.sort_by_key(|j| std::cmp::Reverse(j.created_secs));
+    Ok(jobs)
+}
+
+/// Resolve a selector to a job: exact id, unique id-prefix, or session name
+/// (newest match wins).
+pub fn resolve(selector: &str) -> anyhow::Result<JobRecord> {
+    let jobs = list()?;
+    if let Some(j) = jobs.iter().find(|j| j.id == selector) {
+        return Ok(j.clone());
+    }
+    if let Some(j) = jobs
+        .iter()
+        .find(|j| j.session_name.as_deref() == Some(selector))
+    {
+        return Ok(j.clone());
+    }
+    let matches: Vec<&JobRecord> = jobs.iter().filter(|j| j.id.starts_with(selector)).collect();
+    match matches.as_slice() {
+        [one] => Ok((*one).clone()),
+        [] => anyhow::bail!("no job matching {selector:?} (try `cr jobs`)"),
+        _ => anyhow::bail!("{selector:?} is ambiguous ({} jobs match)", matches.len()),
+    }
+}
+
+/// Render the job list as a table.
+pub fn render_list(jobs: &[JobRecord]) {
+    if jobs.is_empty() {
+        println!("no jobs (launch one with `cr -d \"<prompt>\"`)");
+        return;
+    }
+    for j in jobs {
+        let st = status(j);
+        let name = j.session_name.as_deref().unwrap_or("-");
+        println!(
+            "{:<10} {:<8} {:<10} {}  {}",
+            j.id,
+            st.label(),
+            name,
+            Color::DarkGray.paint(ago(j.created_secs)),
+            first_line(&j.prompt),
+        );
+    }
+}
+
+/// Render one job: its header, a readable pass over the journal, and the final
+/// status. With `follow`, keep tailing until a result appears. With `json`,
+/// stream the raw journal lines instead.
+pub fn render_job(record: &JobRecord, follow: bool, json: bool) -> anyhow::Result<()> {
+    let st = status(record);
+    eprintln!(
+        "{} {}  [{}]  pid {}  {}",
+        Color::Cyan.bold().paint(&record.id),
+        st.label(),
+        record.model.as_deref().unwrap_or("default"),
+        record.pid,
+        Color::DarkGray.paint(ago(record.created_secs)),
+    );
+    eprintln!("{} {}", Color::DarkGray.paint("prompt:"), record.prompt);
+    if let Some(sid) = session_id(&record.id) {
+        eprintln!(
+            "{} {}  ({})",
+            Color::DarkGray.paint("session:"),
+            sid,
+            Color::DarkGray.paint(format!("resume: cr repl --resume {sid}")),
+        );
+    }
+
+    if json {
+        return render_json(record, follow);
+    }
+
+    let mut seen = 0usize;
+    loop {
+        let events = journal_events(&record.id)?;
+        for ev in events.iter().skip(seen) {
+            if let Some(line) = render_event(ev) {
+                println!("{line}");
+            }
+        }
+        seen = events.len();
+        if !follow || result_event(&events).is_some() || !pid_alive(record.pid) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(700));
+    }
+    Ok(())
+}
+
+fn render_json(record: &JobRecord, follow: bool) -> anyhow::Result<()> {
+    let mut out = std::io::stdout();
+    let mut seen = 0usize;
+    loop {
+        let events = journal_events(&record.id)?;
+        for ev in events.iter().skip(seen) {
+            let _ = writeln!(out, "{ev}");
+        }
+        seen = events.len();
+        if !follow || result_event(&events).is_some() || !pid_alive(record.pid) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(700));
+    }
+    Ok(())
+}
+
+/// Turn one stream-json event into a readable line, or `None` to skip it.
+fn render_event(ev: &Value) -> Option<String> {
+    match ev.get("type").and_then(Value::as_str)? {
+        "assistant" => {
+            let content = ev.get("message")?.get("content")?.as_array()?;
+            let mut parts = Vec::new();
+            for block in content {
+                match block.get("type").and_then(Value::as_str) {
+                    Some("text") => {
+                        if let Some(t) = block.get("text").and_then(Value::as_str) {
+                            let t = t.trim();
+                            if !t.is_empty() {
+                                parts.push(t.to_string());
+                            }
+                        }
+                    }
+                    Some("tool_use") => {
+                        let name = block.get("name").and_then(Value::as_str).unwrap_or("tool");
+                        parts.push(
+                            Color::Blue
+                                .paint(format!("[tool] {name}{}", tool_hint(block)))
+                                .to_string(),
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            (!parts.is_empty()).then(|| parts.join("\n"))
+        }
+        "result" => {
+            let cost = ev.get("total_cost_usd").and_then(Value::as_f64);
+            let dur = ev.get("duration_ms").and_then(Value::as_u64);
+            let mut tail = String::new();
+            if let Some(c) = cost {
+                tail.push_str(&format!(" ${c:.4}"));
+            }
+            if let Some(d) = dur {
+                tail.push_str(&format!(" {:.1}s", d as f64 / 1000.0));
+            }
+            Some(Color::Green.paint(format!("[done]{tail}")).to_string())
+        }
+        _ => None,
+    }
+}
+
+/// A short hint of a tool call's target (a path or command), if obvious.
+fn tool_hint(block: &Value) -> String {
+    let input = block.get("input");
+    let hint = input
+        .and_then(|i| i.get("file_path").or_else(|| i.get("path")))
+        .or_else(|| input.and_then(|i| i.get("command")))
+        .or_else(|| input.and_then(|i| i.get("pattern")))
+        .and_then(Value::as_str);
+    match hint {
+        Some(h) => format!(" {}", first_line(h)),
+        None => String::new(),
+    }
+}
+
+fn first_line(s: &str) -> String {
+    let line = s.lines().next().unwrap_or("").trim();
+    if line.chars().count() > 72 {
+        let truncated: String = line.chars().take(71).collect();
+        format!("{truncated}…")
+    } else {
+        line.to_string()
+    }
+}
+
+fn ago(created_secs: u64) -> String {
+    let secs = now_secs().saturating_sub(created_secs);
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86400)
+    }
+}

--- a/examples/cr/src/main.rs
+++ b/examples/cr/src/main.rs
@@ -735,16 +735,14 @@ fn cmd_config(user_path: Option<&Path>, project_path: &Path, edit: bool) -> std:
 }
 
 fn cmd_jobs() -> std::process::ExitCode {
-    match jobs::list() {
-        Ok(list) => {
-            jobs::render_list(&list);
-            std::process::ExitCode::SUCCESS
-        }
-        Err(e) => {
-            eprintln!("cr: {e}");
-            std::process::ExitCode::from(1)
-        }
+    let cr_jobs = jobs::list().unwrap_or_default();
+    jobs::render_list(&cr_jobs);
+    // Also surface Claude Code's own background jobs (read-only).
+    let daemon = jobs::render_daemon();
+    if cr_jobs.is_empty() && daemon == 0 {
+        println!("no jobs (launch one with `cr -d \"<prompt>\"`)");
     }
+    std::process::ExitCode::SUCCESS
 }
 
 fn cmd_job(selector: &str, follow: bool, json: bool) -> std::process::ExitCode {

--- a/examples/cr/src/main.rs
+++ b/examples/cr/src/main.rs
@@ -84,6 +84,11 @@ struct ReplArgs {
     /// Run as if from PATH (git -C style).
     #[arg(short = 'C', long, value_name = "PATH")]
     cwd: Option<PathBuf>,
+
+    /// Run a command (a prompt or a /command) then exit; repeatable, in order.
+    /// Suppresses the banner. Exit status is non-zero if any command errored.
+    #[arg(short = 'e', long = "exec", value_name = "CMD")]
+    exec: Vec<String>,
 }
 
 #[derive(clap::Args, Debug, Default)]

--- a/examples/cr/src/main.rs
+++ b/examples/cr/src/main.rs
@@ -26,9 +26,11 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
-use claude_wrapper::streaming::{BlockDelta, PartialMessageEvent, stream_query_sync};
+use claude_wrapper::streaming::{BlockDelta, PartialMessageEvent, stream_query};
 use claude_wrapper::{Claude, Effort, OutputFormat, PermissionMode, QueryCommand};
 use serde::{Deserialize, Serialize};
+
+mod repl;
 
 /// A saved `claude -p` you can re-run: isolated, typed, repeatable.
 #[derive(Parser, Debug)]
@@ -54,6 +56,34 @@ enum Command {
         #[arg(long)]
         edit: bool,
     },
+    /// Open an interactive multi-turn session (one `claude` child held open).
+    Repl(ReplArgs),
+}
+
+/// Options that seed the initial REPL session. Everything else (tools,
+/// permissions, budget, ...) comes from the resolved profile/config/env, and
+/// can be retuned live with `/model`, `/effort`, `/profile`.
+#[derive(clap::Args, Debug, Default)]
+struct ReplArgs {
+    /// Apply a named profile to the opening session.
+    #[arg(long, value_name = "NAME")]
+    profile: Option<String>,
+
+    /// Ignore the auto-applied default profile.
+    #[arg(long)]
+    no_profile: bool,
+
+    /// sonnet | opus | haiku | full model id.
+    #[arg(short = 'm', long, value_name = "MODEL")]
+    model: Option<String>,
+
+    /// low | medium | high | xhigh | max.
+    #[arg(long, value_name = "LEVEL")]
+    effort: Option<String>,
+
+    /// Run as if from PATH (git -C style).
+    #[arg(short = 'C', long, value_name = "PATH")]
+    cwd: Option<PathBuf>,
 }
 
 #[derive(clap::Args, Debug, Default)]
@@ -321,7 +351,7 @@ impl Settings {
     }
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 struct ConfigFile {
     default_profile: Option<String>,
     defaults: Option<Settings>,
@@ -528,6 +558,8 @@ fn main() -> std::process::ExitCode {
     let user = user_path.as_deref().map(load_config).unwrap_or_default();
     let project = load_config(&project_path);
 
+    // Profiles/config are synchronous; the run and repl paths need the async
+    // runtime (the library's execute/stream/duplex API is tokio-backed).
     match cli.command {
         Some(Command::Profiles { name }) => {
             return cmd_profiles(&user, &project, name.as_deref());
@@ -535,10 +567,25 @@ fn main() -> std::process::ExitCode {
         Some(Command::Config { edit }) => {
             return cmd_config(user_path.as_deref(), &project_path, edit);
         }
-        None => {}
+        _ => {}
     }
 
-    match run(cli.run, &user, &project, &project_path) {
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("cr: failed to start async runtime: {e}");
+            return std::process::ExitCode::from(1);
+        }
+    };
+
+    let result = rt.block_on(async {
+        match cli.command {
+            Some(Command::Repl(args)) => repl::run(args, &user, &project, &project_path).await,
+            _ => run(cli.run, &user, &project, &project_path).await,
+        }
+    });
+
+    match result {
         Ok(code) => code,
         Err(e) => {
             eprintln!("cr: {e}");
@@ -636,7 +683,7 @@ fn cmd_config(user_path: Option<&Path>, project_path: &Path, edit: bool) -> std:
     std::process::ExitCode::SUCCESS
 }
 
-fn run(
+async fn run(
     args: RunArgs,
     user: &ConfigFile,
     project: &ConfigFile,
@@ -812,9 +859,9 @@ fn run(
 
     // 6. Run and render.
     let result = if streaming {
-        stream_run(&claude, &cmd)?
+        stream_run(&claude, &cmd).await?
     } else {
-        cmd.execute_json_sync(&claude)?
+        cmd.execute_json(&claude).await?
     };
 
     // Streaming already wrote the answer live; buffered/JSON prints it now.
@@ -840,14 +887,17 @@ fn run(
 
 /// Stream a run, writing assistant text deltas to stdout as they arrive, and
 /// return the final `result` event decoded as a `QueryResult` (for the footer).
-fn stream_run(claude: &Claude, cmd: &QueryCommand) -> anyhow::Result<claude_wrapper::QueryResult> {
+async fn stream_run(
+    claude: &Claude,
+    cmd: &QueryCommand,
+) -> anyhow::Result<claude_wrapper::QueryResult> {
     use std::io::Write;
 
     let mut out = std::io::stdout();
     let mut final_result: Option<claude_wrapper::QueryResult> = None;
     let mut wrote_any = false;
 
-    stream_query_sync(claude, cmd, |ev| {
+    stream_query(claude, cmd, |ev| {
         if let Some(PartialMessageEvent::BlockDelta {
             delta: BlockDelta::Text(t),
             ..
@@ -860,7 +910,8 @@ fn stream_run(claude: &Claude, cmd: &QueryCommand) -> anyhow::Result<claude_wrap
         if ev.is_result() {
             final_result = serde_json::from_value(ev.data.clone()).ok();
         }
-    })?;
+    })
+    .await?;
 
     if wrote_any {
         let _ = writeln!(out);

--- a/examples/cr/src/main.rs
+++ b/examples/cr/src/main.rs
@@ -27,9 +27,10 @@ use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 use claude_wrapper::streaming::{BlockDelta, PartialMessageEvent, stream_query};
-use claude_wrapper::{Claude, Effort, OutputFormat, PermissionMode, QueryCommand};
+use claude_wrapper::{Claude, ClaudeCommand, Effort, OutputFormat, PermissionMode, QueryCommand};
 use serde::{Deserialize, Serialize};
 
+mod jobs;
 mod repl;
 
 /// A saved `claude -p` you can re-run: isolated, typed, repeatable.
@@ -58,6 +59,19 @@ enum Command {
     },
     /// Open an interactive multi-turn session (one `claude` child held open).
     Repl(ReplArgs),
+    /// List background jobs (cr's detached jobs and Claude Code's own).
+    Jobs,
+    /// Show one background job: its progress, cost, and resume command.
+    Job {
+        /// Job id (or a unique prefix), or a session name.
+        selector: String,
+        /// Tail the journal until the job finishes.
+        #[arg(short, long)]
+        follow: bool,
+        /// Print the raw stream-json journal instead of a rendered view.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Options that seed the initial REPL session. Everything else (tools,
@@ -84,6 +98,10 @@ struct ReplArgs {
     /// Run as if from PATH (git -C style).
     #[arg(short = 'C', long, value_name = "PATH")]
     cwd: Option<PathBuf>,
+
+    /// Reconnect to an existing session id (e.g. a finished job's session).
+    #[arg(long, value_name = "ID")]
+    resume: Option<String>,
 
     /// Run a command (a prompt or a /command) then exit; repeatable, in order.
     /// Suppresses the banner. Exit status is non-zero if any command errored.
@@ -251,6 +269,27 @@ struct RunArgs {
     /// Ignore the auto-applied default profile.
     #[arg(long, help_heading = "Profile")]
     no_profile: bool,
+
+    /// Launch this run as a detached background job, then exit (see `cr jobs`).
+    #[arg(short = 'd', long, help_heading = "Background")]
+    detach: bool,
+
+    /// Name/label a detached job, or address one for --check.
+    #[arg(long, value_name = "NAME", help_heading = "Background")]
+    session: Option<String>,
+
+    /// Allow a detached job with no budget or turn cap (unattended, risky).
+    #[arg(long, help_heading = "Background")]
+    uncapped: bool,
+
+    /// Show a background job instead of running: by --session NAME or a
+    /// positional id, or list all if neither is given.
+    #[arg(long, help_heading = "Background")]
+    check: bool,
+
+    /// With --check or a detached run, tail the job until it finishes.
+    #[arg(long, help_heading = "Background")]
+    follow: bool,
 
     /// Print the exact `claude` command it would run, then exit.
     #[arg(long, help_heading = "Meta")]
@@ -572,6 +611,13 @@ fn main() -> std::process::ExitCode {
         Some(Command::Config { edit }) => {
             return cmd_config(user_path.as_deref(), &project_path, edit);
         }
+        // Job inspection reads the on-disk store; no async runtime needed.
+        Some(Command::Jobs) => return cmd_jobs(),
+        Some(Command::Job {
+            ref selector,
+            follow,
+            json,
+        }) => return cmd_job(selector, follow, json),
         _ => {}
     }
 
@@ -688,12 +734,115 @@ fn cmd_config(user_path: Option<&Path>, project_path: &Path, edit: bool) -> std:
     std::process::ExitCode::SUCCESS
 }
 
+fn cmd_jobs() -> std::process::ExitCode {
+    match jobs::list() {
+        Ok(list) => {
+            jobs::render_list(&list);
+            std::process::ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("cr: {e}");
+            std::process::ExitCode::from(1)
+        }
+    }
+}
+
+fn cmd_job(selector: &str, follow: bool, json: bool) -> std::process::ExitCode {
+    match jobs::resolve(selector).and_then(|rec| jobs::render_job(&rec, follow, json)) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("cr: {e}");
+            std::process::ExitCode::from(1)
+        }
+    }
+}
+
+/// Build the profile-able subset of a `QueryCommand` for a detached job:
+/// stream-json output (the journal), plus the resolved settings.
+fn build_detach_query(prompt: &str, s: &Settings) -> anyhow::Result<QueryCommand> {
+    let mut cmd = QueryCommand::new(prompt.to_string())
+        .output_format(OutputFormat::StreamJson)
+        .verbose(true);
+    if let Some(m) = &s.model {
+        cmd = cmd.model(m);
+    }
+    if let Some(e) = &s.effort {
+        cmd = cmd.effort(parse_effort(e)?);
+    }
+    if s.hermetic == Some(true) {
+        cmd = cmd.hermetic();
+    }
+    if s.worktree == Some(true) {
+        cmd = cmd.worktree();
+    }
+    if let Some(a) = &s.agent {
+        cmd = cmd.agent(a);
+    }
+    if let Some(sp) = &s.append_system_prompt {
+        cmd = cmd.append_system_prompt(sp);
+    }
+    if let Some(b) = s.max_budget_usd {
+        cmd = cmd.max_budget_usd(b);
+    }
+    if !s.allowed_tools.is_empty() {
+        cmd = cmd.allowed_tools(s.allowed_tools.iter().map(String::as_str));
+    }
+    if !s.disallowed_tools.is_empty() {
+        cmd = cmd.disallowed_tools(s.disallowed_tools.iter().map(String::as_str));
+    }
+    if let Some(n) = s.max_turns {
+        cmd = cmd.max_turns(n);
+    }
+    if let Some(pm) = &s.permission_mode {
+        cmd = cmd.permission_mode(parse_permission_mode(pm)?);
+    }
+    if let Some(fm) = &s.fallback_model {
+        cmd = cmd.fallback_model(fm);
+    }
+    if let Some(mc) = &s.mcp_config {
+        cmd = cmd.mcp_config(mc);
+    }
+    for d in &s.add_dir {
+        cmd = cmd.add_dir(d);
+    }
+    Ok(cmd)
+}
+
+/// A human note of the cap in force, for the job record and the launch line.
+fn cap_note(s: &Settings) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(b) = s.max_budget_usd {
+        parts.push(format!("${b:.2}"));
+    }
+    if let Some(n) = s.max_turns {
+        parts.push(format!("{n} turns"));
+    }
+    (!parts.is_empty()).then(|| parts.join(", "))
+}
+
 async fn run(
     args: RunArgs,
     user: &ConfigFile,
     project: &ConfigFile,
     project_path: &Path,
 ) -> anyhow::Result<std::process::ExitCode> {
+    // 0. --check: show a background job (by --session/positional) instead of
+    //    running, or list all if no selector was given.
+    if args.check {
+        let selector = args.session.clone().or_else(|| args.prompt.clone());
+        return match selector {
+            Some(sel) => {
+                let rec = jobs::resolve(&sel)?;
+                jobs::render_job(&rec, args.follow, args.json)?;
+                Ok(std::process::ExitCode::SUCCESS)
+            }
+            None => {
+                jobs::render_list(&jobs::list()?);
+                Ok(std::process::ExitCode::SUCCESS)
+            }
+        };
+    }
+
     // 1. Alias dispatch: a bare first positional that names a profile carrying
     //    a `prompt` template runs that profile, with the rest as template args.
     //    Only when nothing else already fixes the prompt or the profile.
@@ -777,6 +926,43 @@ async fn run(
         builder = builder.working_dir(cwd);
     }
     let claude = builder.build()?;
+
+    // 4b. --detach: launch a background job and exit. Unattended agent work
+    //     with tool access, so require a cap unless --uncapped.
+    if args.detach {
+        let cap = cap_note(&settings);
+        if cap.is_none() && !args.uncapped {
+            anyhow::bail!(
+                "detached jobs run unattended: set a cap (--max-budget-usd or --max-turns, \
+                 or a profile/config default), or pass --uncapped to override"
+            );
+        }
+        let cmd = build_detach_query(&prompt, &settings)?;
+        let record = jobs::launch(
+            &claude,
+            cmd.args(),
+            args.cwd.as_deref(),
+            &prompt,
+            args.session.clone(),
+            settings.model.clone(),
+            cap.clone(),
+        )?;
+        let label = record
+            .session_name
+            .as_deref()
+            .map(|n| format!(" [{n}]"))
+            .unwrap_or_default();
+        let cap_str = match &cap {
+            Some(c) => format!(", cap {c}"),
+            None => " (uncapped)".to_string(),
+        };
+        println!("job {}{label} launched{cap_str}", record.id);
+        eprintln!(
+            "  cr job {}   (add --follow to tail; cr jobs to list)",
+            record.id
+        );
+        return Ok(std::process::ExitCode::SUCCESS);
+    }
 
     // Streaming vs buffered. Structured output can't token-stream, and
     // --no-stream forces buffered; otherwise --stream forces it on, else auto

--- a/examples/cr/src/repl.rs
+++ b/examples/cr/src/repl.rs
@@ -48,14 +48,24 @@ struct Session {
 }
 
 impl Session {
-    async fn spawn(claude: &Claude, name: String, settings: Settings) -> anyhow::Result<Self> {
-        let inner = DuplexSession::spawn(claude, duplex_options(&settings)?).await?;
+    async fn spawn(
+        claude: &Claude,
+        name: String,
+        settings: Settings,
+        resume: Option<String>,
+    ) -> anyhow::Result<Self> {
+        let mut opts = duplex_options(&settings)?;
+        if let Some(id) = &resume {
+            opts = opts.resume(id);
+        }
+        let inner = DuplexSession::spawn(claude, opts).await?;
         Ok(Session {
             name,
             settings,
             inner,
-            session_id: None,
-            resume_id: None,
+            // A resumed session keeps its id so a later /model respawn re-resumes.
+            session_id: resume.clone(),
+            resume_id: resume,
             cost: 0.0,
             turns: 0,
             history: Vec::new(),
@@ -209,7 +219,8 @@ pub async fn run(
     }
     let claude = builder.build()?;
 
-    let session = Session::spawn(&claude, "main".to_string(), settings).await?;
+    let session =
+        Session::spawn(&claude, "main".to_string(), settings, args.resume.clone()).await?;
 
     // -e/--exec: run the given commands in order, then exit. No editor, no
     // banner, so output stays scriptable.
@@ -607,7 +618,7 @@ impl Repl {
             Some(profile) => resolve_settings(&self.user, &self.project, Some(profile))?,
             None => self.cur().settings.clone(),
         };
-        let session = Session::spawn(&self.claude, name.clone(), settings).await?;
+        let session = Session::spawn(&self.claude, name.clone(), settings, None).await?;
         self.sessions.push(session);
         self.current = self.sessions.len() - 1;
         eprintln!(

--- a/examples/cr/src/repl.rs
+++ b/examples/cr/src/repl.rs
@@ -12,7 +12,11 @@ use std::path::{Path, PathBuf};
 use claude_wrapper::Claude;
 use claude_wrapper::duplex::{DuplexOptions, DuplexSession, InboundEvent};
 use nu_ansi_term::Color;
-use reedline::{DefaultPrompt, DefaultPromptSegment, FileBackedHistory, Reedline, Signal};
+use reedline::{
+    ColumnarMenu, Completer, DefaultPrompt, DefaultPromptSegment, Emacs, FileBackedHistory,
+    KeyCode, KeyModifiers, MenuBuilder, Reedline, ReedlineEvent, ReedlineMenu, Signal, Span,
+    Suggestion, default_emacs_keybindings,
+};
 
 use crate::{ConfigFile, ReplArgs, Settings};
 
@@ -33,6 +37,9 @@ struct Session {
     /// The CLI-assigned session id from the last turn, for `--resume` on a
     /// respawn. `None` until the first turn completes.
     session_id: Option<String>,
+    /// The `--resume <id>` the live child was actually spawned with, if any, so
+    /// `/explain` reflects the running command rather than a fresh spawn.
+    resume_id: Option<String>,
     cost: f64,
     turns: u32,
     history: Vec<(String, String)>,
@@ -46,6 +53,7 @@ impl Session {
             settings,
             inner,
             session_id: None,
+            resume_id: None,
             cost: 0.0,
             turns: 0,
             history: Vec::new(),
@@ -82,6 +90,7 @@ impl Session {
             settings: new_settings,
             inner,
             session_id: if reset { None } else { session_id },
+            resume_id: resume,
             cost: if reset { 0.0 } else { cost },
             turns: if reset { 0 } else { turns },
             history: if reset { Vec::new() } else { history },
@@ -197,8 +206,40 @@ pub async fn run(
 
     let session = Session::spawn(&claude, "main".to_string(), settings).await?;
 
+    // -e/--exec: run the given commands in order, then exit. No editor, no
+    // banner, so output stays scriptable.
+    if !args.exec.is_empty() {
+        let mut state = Repl {
+            claude,
+            user: user.clone(),
+            project: project.clone(),
+            sessions: vec![session],
+            current: 0,
+            input: Input::Plain,
+        };
+        let mut had_err = false;
+        for cmd in &args.exec {
+            match state.handle_line(cmd).await {
+                Ok(true) => break,
+                Ok(false) => {}
+                Err(e) => {
+                    eprintln!("{}: {e}", Color::Red.paint("cr"));
+                    had_err = true;
+                }
+            }
+        }
+        for s in state.sessions.drain(..) {
+            let _ = s.inner.close().await;
+        }
+        return Ok(if had_err {
+            std::process::ExitCode::from(1)
+        } else {
+            std::process::ExitCode::SUCCESS
+        });
+    }
+
     let input = if std::io::stdin().is_terminal() {
-        Input::Editor(Box::new(build_editor()))
+        Input::Editor(Box::new(build_editor(profile_names(user, project))))
     } else {
         Input::Plain
     };
@@ -214,6 +255,19 @@ pub async fn run(
 
     state.banner();
     state.loop_().await
+}
+
+/// Every profile name known to either config, for command completion.
+fn profile_names(user: &ConfigFile, project: &ConfigFile) -> Vec<String> {
+    let mut names: Vec<String> = user
+        .profiles
+        .keys()
+        .chain(project.profiles.keys())
+        .cloned()
+        .collect();
+    names.sort();
+    names.dedup();
+    names
 }
 
 /// The interactive state: the client, a snapshot of config for `/profile`
@@ -276,26 +330,30 @@ impl Repl {
         }
     }
 
+    /// Handle one input line: a `/command` (returns `Ok(true)` to exit) or a
+    /// prompt turn. Shared by the interactive loop and `-e/--exec`.
+    async fn handle_line(&mut self, line: &str) -> anyhow::Result<bool> {
+        let line = line.trim();
+        if line.is_empty() {
+            return Ok(false);
+        }
+        if let Some(rest) = line.strip_prefix('/') {
+            return self.command(rest).await;
+        }
+        self.turn(line.to_string()).await?;
+        Ok(false)
+    }
+
     async fn loop_(&mut self) -> anyhow::Result<std::process::ExitCode> {
         loop {
             let prompt = self.prompt();
             let Some(line) = self.next_line(&prompt) else {
                 break;
             };
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-            if let Some(rest) = line.strip_prefix('/') {
-                match self.command(rest).await {
-                    Ok(true) => break,
-                    Ok(false) => {}
-                    Err(e) => eprintln!("{}: {e}", Color::Red.paint("cr")),
-                }
-                continue;
-            }
-            if let Err(e) = self.turn(line.to_string()).await {
-                eprintln!("{}: {e}", Color::Red.paint("cr"));
+            match self.handle_line(&line).await {
+                Ok(true) => break,
+                Ok(false) => {}
+                Err(e) => eprintln!("{}: {e}", Color::Red.paint("cr")),
             }
         }
         // Close every session cleanly on the way out.
@@ -394,10 +452,13 @@ impl Repl {
             "history" => self.cmd_history(),
             "sessions" => self.cmd_sessions(),
             "explain" => {
-                // Rebuild the options from the current settings; this is the
-                // spawn command for a fresh child (a live respawn also adds
-                // --resume <id>).
-                let opts = duplex_options(&self.cur().settings)?;
+                // Rebuild the options from the current settings and reflect the
+                // live child's --resume, so this matches what is actually running.
+                let s = self.cur();
+                let mut opts = duplex_options(&s.settings)?;
+                if let Some(id) = &s.resume_id {
+                    opts = opts.resume(id);
+                }
                 println!("{}", opts.to_command_string(&self.claude));
             }
             "new" => {
@@ -436,7 +497,10 @@ impl Repl {
                 let prompt = crate::compose_in_editor()?;
                 self.turn(prompt).await?;
             }
-            other => anyhow::bail!("unknown command: /{other} (try /help)"),
+            other => match nearest_command(other) {
+                Some(sug) => anyhow::bail!("unknown command: /{other} (did you mean /{sug}?)"),
+                None => anyhow::bail!("unknown command: /{other} (try /help)"),
+            },
         }
         Ok(false)
     }
@@ -595,15 +659,108 @@ impl Repl {
     }
 }
 
-fn build_editor() -> Reedline {
-    let editor = Reedline::create();
+/// The meta-command words, for did-you-mean and completion.
+const COMMANDS: &[&str] = &[
+    "help", "exit", "quit", "cost", "history", "sessions", "explain", "new", "model", "effort",
+    "profile", "session", "use", "close", "all", "editor",
+];
+
+/// Tab-completion: command words after `/`, and profile names after `/profile`.
+struct CrCompleter {
+    profiles: Vec<String>,
+}
+
+impl Completer for CrCompleter {
+    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let end = pos.min(line.len());
+        let prefix = &line[..end];
+        let Some(rest) = prefix.strip_prefix('/') else {
+            return Vec::new();
+        };
+        match rest.split_once(char::is_whitespace) {
+            // No space yet: complete the command word (span starts after '/').
+            None => COMMANDS
+                .iter()
+                .filter(|c| c.starts_with(rest))
+                .map(|c| suggestion(c, 1, end))
+                .collect(),
+            // `/profile <partial>`: complete profile names on the last word.
+            Some(("profile", _)) => {
+                let start = prefix.rfind(char::is_whitespace).map_or(0, |i| i + 1);
+                let word = &prefix[start..];
+                self.profiles
+                    .iter()
+                    .filter(|p| p.starts_with(word))
+                    .map(|p| suggestion(p, start, end))
+                    .collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+fn suggestion(value: &str, start: usize, end: usize) -> Suggestion {
+    Suggestion {
+        value: value.to_string(),
+        span: Span { start, end },
+        append_whitespace: true,
+        ..Suggestion::default()
+    }
+}
+
+fn build_editor(profiles: Vec<String>) -> Reedline {
+    let completer = Box::new(CrCompleter { profiles });
+    let menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
+    let mut keybindings = default_emacs_keybindings();
+    keybindings.add_binding(
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::Menu("completion_menu".to_string()),
+            ReedlineEvent::MenuNext,
+        ]),
+    );
+    let mut editor = Reedline::create()
+        .with_completer(completer)
+        .with_menu(ReedlineMenu::EngineCompleter(menu))
+        .with_edit_mode(Box::new(Emacs::new(keybindings)));
     if let Some(home) = std::env::var_os("HOME") {
         let path = PathBuf::from(home).join(".cr_history");
         if let Ok(history) = FileBackedHistory::with_file(2000, path) {
-            return editor.with_history(Box::new(history));
+            editor = editor.with_history(Box::new(history));
         }
     }
     editor
+}
+
+/// The nearest command word to `input` by edit distance, if close enough to be
+/// a plausible typo (scaled to the input length).
+fn nearest_command(input: &str) -> Option<&'static str> {
+    let mut best: Option<(&'static str, usize)> = None;
+    for &c in COMMANDS {
+        let d = levenshtein(input, c);
+        if best.is_none_or(|(_, bd)| d < bd) {
+            best = Some((c, d));
+        }
+    }
+    best.filter(|(_, d)| *d <= 2.max(input.len() / 3))
+        .map(|(c, _)| c)
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
 }
 
 /// Extract an assistant text delta from a streaming event, if it is one.

--- a/examples/cr/src/repl.rs
+++ b/examples/cr/src/repl.rs
@@ -43,6 +43,8 @@ struct Session {
     cost: f64,
     turns: u32,
     history: Vec<(String, String)>,
+    /// The raw `result` JSON of the last turn, for `/json`.
+    last_result: Option<serde_json::Value>,
 }
 
 impl Session {
@@ -57,6 +59,7 @@ impl Session {
             cost: 0.0,
             turns: 0,
             history: Vec::new(),
+            last_result: None,
         })
     }
 
@@ -75,6 +78,7 @@ impl Session {
             cost,
             turns,
             history,
+            last_result,
             inner,
             ..
         } = self;
@@ -94,6 +98,7 @@ impl Session {
             cost: if reset { 0.0 } else { cost },
             turns: if reset { 0 } else { turns },
             history: if reset { Vec::new() } else { history },
+            last_result: if reset { None } else { last_result },
         })
     }
 }
@@ -368,6 +373,9 @@ impl Repl {
     async fn turn(&mut self, prompt: String) -> anyhow::Result<()> {
         use std::io::Write;
         let idx = self.current;
+        if !self.sessions[idx].inner.is_alive() {
+            anyhow::bail!("this session's child has exited; /new to restart it");
+        }
         let echo = prompt.clone();
         let mut printed_any = false;
         let result = {
@@ -436,6 +444,7 @@ impl Repl {
             s.session_id = Some(id.to_string());
         }
         s.history.push((echo, answer));
+        s.last_result = Some(turn.result.clone());
         eprintln!("{}", Color::DarkGray.paint(turn_footer(&turn)));
         Ok(())
     }
@@ -449,6 +458,7 @@ impl Repl {
             "help" | "?" => print_help(),
             "exit" | "quit" | "q" => return Ok(true),
             "cost" => self.cmd_cost(),
+            "json" => self.cmd_json()?,
             "history" => self.cmd_history(),
             "sessions" => self.cmd_sessions(),
             "explain" => {
@@ -539,6 +549,14 @@ impl Repl {
             let total: f64 = self.sessions.iter().map(|s| s.cost).sum();
             println!("total across {} sessions: ${total:.4}", self.sessions.len());
         }
+    }
+
+    fn cmd_json(&self) -> anyhow::Result<()> {
+        match &self.cur().last_result {
+            Some(v) => println!("{}", serde_json::to_string_pretty(v)?),
+            None => println!("(no turns yet)"),
+        }
+        Ok(())
     }
 
     fn cmd_history(&self) {
@@ -661,8 +679,8 @@ impl Repl {
 
 /// The meta-command words, for did-you-mean and completion.
 const COMMANDS: &[&str] = &[
-    "help", "exit", "quit", "cost", "history", "sessions", "explain", "new", "model", "effort",
-    "profile", "session", "use", "close", "all", "editor",
+    "help", "exit", "quit", "cost", "json", "history", "sessions", "explain", "new", "model",
+    "effort", "profile", "session", "use", "close", "all", "editor",
 ];
 
 /// Tab-completion: command words after `/`, and profile names after `/profile`.
@@ -814,6 +832,7 @@ commands:
   /new                  reset the conversation (same settings, empty context)
   /editor               compose a prompt in $EDITOR
   /cost                 turns and cost for this session
+  /json                 the last turn's full result as JSON
   /history              prompts and answers so far
   /explain              print the `claude` command this session was spawned with
 

--- a/examples/cr/src/repl.rs
+++ b/examples/cr/src/repl.rs
@@ -1,0 +1,512 @@
+//! `cr repl` -- an interactive multi-turn session.
+//!
+//! Holds one `claude` child open across turns via `DuplexSession`, seeded from
+//! the same resolved `Settings` (defaults < profile < env < flags) the one-shot
+//! path uses. Plain lines are prompts; `/`-prefixed lines are meta-commands.
+//! Retuning a knob (`/model`, `/effort`, `/profile`) respawns the child with
+//! `--resume` so the conversation history carries over.
+
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use claude_wrapper::Claude;
+use claude_wrapper::duplex::{DuplexOptions, DuplexSession};
+use nu_ansi_term::Color;
+use reedline::{DefaultPrompt, DefaultPromptSegment, FileBackedHistory, Reedline, Signal};
+
+use crate::{ConfigFile, ReplArgs, Settings};
+
+/// Where prompt lines come from. On a TTY it is the reedline editor (history,
+/// hints, line editing); on a pipe it is plain stdin, so a scripted
+/// `printf '...\n/exit\n' | cr repl` works with no editor.
+enum Input {
+    Editor(Box<Reedline>),
+    Plain,
+}
+
+/// One open conversation: a live child plus the host-side bookkeeping the
+/// duplex layer does not accumulate (cost, turn count, a prompt/answer log).
+struct Session {
+    name: String,
+    settings: Settings,
+    inner: DuplexSession,
+    /// The CLI-assigned session id from the last turn, for `--resume` on a
+    /// respawn. `None` until the first turn completes.
+    session_id: Option<String>,
+    cost: f64,
+    turns: u32,
+    history: Vec<(String, String)>,
+}
+
+impl Session {
+    async fn spawn(claude: &Claude, name: String, settings: Settings) -> anyhow::Result<Self> {
+        let inner = DuplexSession::spawn(claude, duplex_options(&settings)?).await?;
+        Ok(Session {
+            name,
+            settings,
+            inner,
+            session_id: None,
+            cost: 0.0,
+            turns: 0,
+            history: Vec::new(),
+        })
+    }
+
+    /// Close the child and open a fresh one with `new_settings`, resuming the
+    /// same session id so history carries over. Cost/turns/log are preserved.
+    /// `reset` drops the resume (a `/new`: same settings, empty context).
+    async fn respawn(
+        self,
+        claude: &Claude,
+        new_settings: Settings,
+        reset: bool,
+    ) -> anyhow::Result<Self> {
+        let Session {
+            name,
+            session_id,
+            cost,
+            turns,
+            history,
+            inner,
+            ..
+        } = self;
+        let resume = if reset { None } else { session_id.clone() };
+        let _ = inner.close().await;
+        let mut opts = duplex_options(&new_settings)?;
+        if let Some(id) = &resume {
+            opts = opts.resume(id);
+        }
+        let inner = DuplexSession::spawn(claude, opts).await?;
+        Ok(Session {
+            name,
+            settings: new_settings,
+            inner,
+            session_id: if reset { None } else { session_id },
+            cost: if reset { 0.0 } else { cost },
+            turns: if reset { 0 } else { turns },
+            history: if reset { Vec::new() } else { history },
+        })
+    }
+}
+
+/// Map a resolved `Settings` onto a `DuplexOptions`. Mirrors the one-shot
+/// command build in `main::run`, minus the per-run/output knobs.
+fn duplex_options(settings: &Settings) -> anyhow::Result<DuplexOptions> {
+    let mut opts = DuplexOptions::default();
+    if let Some(m) = &settings.model {
+        opts = opts.model(m);
+    }
+    if let Some(e) = &settings.effort {
+        opts = opts.effort(crate::parse_effort(e)?);
+    }
+    if let Some(a) = &settings.agent {
+        opts = opts.agent(a);
+    }
+    if let Some(sp) = &settings.append_system_prompt {
+        opts = opts.append_system_prompt(sp);
+    }
+    if let Some(pm) = &settings.permission_mode {
+        opts = opts.permission_mode(crate::parse_permission_mode(pm)?);
+    }
+    if !settings.allowed_tools.is_empty() {
+        opts = opts.allowed_tools(settings.allowed_tools.iter().map(String::as_str));
+    }
+    if !settings.disallowed_tools.is_empty() {
+        opts = opts.disallowed_tools(settings.disallowed_tools.iter().map(String::as_str));
+    }
+    if let Some(n) = settings.max_turns {
+        opts = opts.max_turns(n);
+    }
+    if let Some(b) = settings.max_budget_usd {
+        opts = opts.max_budget_usd(b);
+    }
+    if let Some(fm) = &settings.fallback_model {
+        opts = opts.fallback_model(fm);
+    }
+    if let Some(mc) = &settings.mcp_config {
+        opts = opts.mcp_config(mc);
+    }
+    for d in &settings.add_dir {
+        opts = opts.add_dir(d);
+    }
+    if settings.hermetic == Some(true) {
+        opts = opts.hermetic();
+    }
+    if settings.worktree == Some(true) {
+        opts = opts.worktree(None::<String>);
+    }
+    Ok(opts)
+}
+
+pub async fn run(
+    args: ReplArgs,
+    user: &ConfigFile,
+    project: &ConfigFile,
+    _project_path: &Path,
+) -> anyhow::Result<std::process::ExitCode> {
+    // Resolve the opening session's settings: defaults < profile < env < flags.
+    let active = if args.no_profile {
+        None
+    } else {
+        args.profile
+            .clone()
+            .or_else(|| std::env::var("CR_PROFILE").ok().filter(|s| !s.is_empty()))
+            .or_else(|| project.default_profile.clone())
+            .or_else(|| user.default_profile.clone())
+    };
+    let mut settings = Settings::default();
+    if let Some(d) = &user.defaults {
+        settings = settings.overlay(d);
+    }
+    if let Some(d) = &project.defaults {
+        settings = settings.overlay(d);
+    }
+    if let Some(name) = &active {
+        match crate::lookup_profile(project, user, name) {
+            Some(p) => settings = settings.overlay(p),
+            None => anyhow::bail!("unknown profile: {name}"),
+        }
+    }
+    settings = settings.overlay(&crate::env_settings());
+    // Repl flag overrides (only the seed knobs are exposed as flags here).
+    if args.model.is_some() {
+        settings.model = args.model.clone();
+    }
+    if args.effort.is_some() {
+        settings.effort = args.effort.clone();
+    }
+    // A saved prompt template is meaningless for an interactive session.
+    settings.prompt = None;
+
+    let mut builder = Claude::builder();
+    if let Some(cwd) = &args.cwd {
+        builder = builder.working_dir(cwd);
+    }
+    let claude = builder.build()?;
+
+    let session = Session::spawn(&claude, "main".to_string(), settings).await?;
+
+    let input = if std::io::stdin().is_terminal() {
+        Input::Editor(Box::new(build_editor()))
+    } else {
+        Input::Plain
+    };
+
+    let mut state = Repl {
+        claude,
+        user: user.clone(),
+        project: project.clone(),
+        sessions: vec![session],
+        current: 0,
+        input,
+    };
+
+    state.banner();
+    state.loop_().await
+}
+
+/// The interactive state: the client, a snapshot of config for `/profile`
+/// lookups, and the session list with a current pointer.
+struct Repl {
+    claude: Claude,
+    user: ConfigFile,
+    project: ConfigFile,
+    sessions: Vec<Session>,
+    current: usize,
+    input: Input,
+}
+
+impl Repl {
+    fn cur(&self) -> &Session {
+        &self.sessions[self.current]
+    }
+
+    fn banner(&self) {
+        let s = self.cur();
+        let model = s.settings.model.as_deref().unwrap_or("default");
+        eprintln!(
+            "{} interactive session ({}), model {}. /help for commands, /exit to quit.",
+            Color::Green.bold().paint("cr"),
+            s.name,
+            Color::Cyan.paint(model),
+        );
+    }
+
+    fn prompt(&self) -> DefaultPrompt {
+        let s = self.cur();
+        let model = s.settings.model.as_deref().unwrap_or("default");
+        DefaultPrompt::new(
+            DefaultPromptSegment::Basic(format!("{}:{model}", s.name)),
+            DefaultPromptSegment::Empty,
+        )
+    }
+
+    /// Read the next input line. `None` ends the REPL (Ctrl-D or EOF); an empty
+    /// string means "skip" (Ctrl-C on an editor line).
+    fn next_line(&mut self, prompt: &DefaultPrompt) -> Option<String> {
+        match &mut self.input {
+            Input::Editor(editor) => match editor.read_line(prompt) {
+                Ok(Signal::Success(line)) => Some(line),
+                Ok(Signal::CtrlC) => Some(String::new()),
+                Ok(Signal::CtrlD) => None,
+                Ok(_) => Some(String::new()),
+                Err(e) => {
+                    eprintln!("cr: input error: {e}");
+                    None
+                }
+            },
+            Input::Plain => {
+                let mut line = String::new();
+                match std::io::stdin().read_line(&mut line) {
+                    Ok(0) | Err(_) => None,
+                    Ok(_) => Some(line),
+                }
+            }
+        }
+    }
+
+    async fn loop_(&mut self) -> anyhow::Result<std::process::ExitCode> {
+        loop {
+            let prompt = self.prompt();
+            let Some(line) = self.next_line(&prompt) else {
+                break;
+            };
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix('/') {
+                match self.command(rest).await {
+                    Ok(true) => break,
+                    Ok(false) => {}
+                    Err(e) => eprintln!("{}: {e}", Color::Red.paint("cr")),
+                }
+                continue;
+            }
+            if let Err(e) = self.turn(line.to_string()).await {
+                eprintln!("{}: {e}", Color::Red.paint("cr"));
+            }
+        }
+        // Close every session cleanly on the way out.
+        for s in self.sessions.drain(..) {
+            let _ = s.inner.close().await;
+        }
+        Ok(std::process::ExitCode::SUCCESS)
+    }
+
+    /// Run one prompt turn against the current session, cancellable with Ctrl-C.
+    async fn turn(&mut self, prompt: String) -> anyhow::Result<()> {
+        let idx = self.current;
+        let echo = prompt.clone();
+        let result = {
+            let session = &self.sessions[idx].inner;
+            tokio::select! {
+                res = session.send(prompt) => Some(res?),
+                _ = tokio::signal::ctrl_c() => {
+                    eprintln!("\n{}", Color::DarkGray.paint("(interrupting...)"));
+                    let _ = session.interrupt().await;
+                    None
+                }
+            }
+        };
+        let Some(turn) = result else {
+            return Ok(());
+        };
+
+        let answer = turn.result_text().unwrap_or("").to_string();
+        println!("{answer}");
+        let s = &mut self.sessions[idx];
+        s.turns += 1;
+        if let Some(c) = turn.total_cost_usd() {
+            s.cost += c;
+        }
+        if let Some(id) = turn.session_id() {
+            s.session_id = Some(id.to_string());
+        }
+        s.history.push((echo, answer));
+        eprintln!("{}", Color::DarkGray.paint(turn_footer(&turn)));
+        Ok(())
+    }
+
+    /// Dispatch a `/command`. Returns `Ok(true)` to exit the REPL.
+    async fn command(&mut self, line: &str) -> anyhow::Result<bool> {
+        let mut parts = line.split_whitespace();
+        let cmd = parts.next().unwrap_or("");
+        let arg = line[cmd.len()..].trim();
+        match cmd {
+            "help" | "?" => print_help(),
+            "exit" | "quit" | "q" => return Ok(true),
+            "cost" => self.cmd_cost(),
+            "history" => self.cmd_history(),
+            "sessions" => self.cmd_sessions(),
+            "explain" => {
+                // Rebuild the options from the current settings; this is the
+                // spawn command for a fresh child (a live respawn also adds
+                // --resume <id>).
+                let opts = duplex_options(&self.cur().settings)?;
+                println!("{}", opts.to_command_string(&self.claude));
+            }
+            "new" => {
+                let s = self.cur().settings.clone();
+                self.reconfigure(s, true).await?;
+            }
+            "model" => {
+                if arg.is_empty() {
+                    anyhow::bail!("usage: /model <name>");
+                }
+                let mut s = self.cur().settings.clone();
+                s.model = Some(arg.to_string());
+                self.reconfigure(s, false).await?;
+            }
+            "effort" => {
+                if arg.is_empty() {
+                    anyhow::bail!("usage: /effort <low|medium|high|xhigh|max>");
+                }
+                crate::parse_effort(arg)?; // validate before respawn
+                let mut s = self.cur().settings.clone();
+                s.effort = Some(arg.to_string());
+                self.reconfigure(s, false).await?;
+            }
+            "profile" => {
+                if arg.is_empty() {
+                    anyhow::bail!("usage: /profile <name>");
+                }
+                let profile = crate::lookup_profile(&self.project, &self.user, arg)
+                    .ok_or_else(|| anyhow::anyhow!("unknown profile: {arg}"))?
+                    .clone();
+                let mut s = Settings::default();
+                if let Some(d) = &self.user.defaults {
+                    s = s.overlay(d);
+                }
+                if let Some(d) = &self.project.defaults {
+                    s = s.overlay(d);
+                }
+                s = s.overlay(&profile);
+                s.prompt = None;
+                self.reconfigure(s, false).await?;
+            }
+            "editor" => {
+                let prompt = crate::compose_in_editor()?;
+                self.turn(prompt).await?;
+            }
+            other => anyhow::bail!("unknown command: /{other} (try /help)"),
+        }
+        Ok(false)
+    }
+
+    /// Respawn the current session with new settings (see `Session::respawn`).
+    async fn reconfigure(&mut self, settings: Settings, reset: bool) -> anyhow::Result<()> {
+        let idx = self.current;
+        let old = self.sessions.remove(idx);
+        let label = settings.model.clone().unwrap_or_else(|| "default".into());
+        match old.respawn(&self.claude, settings, reset).await {
+            Ok(new) => {
+                self.sessions.insert(idx, new);
+                let note = if reset {
+                    "reset context"
+                } else {
+                    "reconfigured"
+                };
+                eprintln!(
+                    "{}",
+                    Color::DarkGray.paint(format!("({note}, model {label})"))
+                );
+                Ok(())
+            }
+            Err(e) => {
+                // The old session is already closed; drop the slot rather than
+                // leave a dangling index. A fresh /profile or /model can reopen.
+                anyhow::bail!("respawn failed, session closed: {e}");
+            }
+        }
+    }
+
+    fn cmd_cost(&self) {
+        let s = self.cur();
+        println!("{}: {} turns, ${:.4}", s.name, s.turns, s.cost);
+        if self.sessions.len() > 1 {
+            let total: f64 = self.sessions.iter().map(|s| s.cost).sum();
+            println!("total across {} sessions: ${total:.4}", self.sessions.len());
+        }
+    }
+
+    fn cmd_history(&self) {
+        let s = self.cur();
+        if s.history.is_empty() {
+            println!("(no turns yet)");
+            return;
+        }
+        for (i, (prompt, answer)) in s.history.iter().enumerate() {
+            println!(
+                "{} {}",
+                Color::Cyan.paint(format!("{}.", i + 1)),
+                first_line(prompt)
+            );
+            println!("   {}", first_line(answer));
+        }
+    }
+
+    fn cmd_sessions(&self) {
+        for (i, s) in self.sessions.iter().enumerate() {
+            let star = if i == self.current { "*" } else { " " };
+            let model = s.settings.model.as_deref().unwrap_or("default");
+            println!(
+                "{star} {}  [{}]  {} turns  ${:.4}",
+                s.name, model, s.turns, s.cost
+            );
+        }
+    }
+}
+
+fn build_editor() -> Reedline {
+    let editor = Reedline::create();
+    if let Some(home) = std::env::var_os("HOME") {
+        let path = PathBuf::from(home).join(".cr_history");
+        if let Ok(history) = FileBackedHistory::with_file(2000, path) {
+            return editor.with_history(Box::new(history));
+        }
+    }
+    editor
+}
+
+fn turn_footer(turn: &claude_wrapper::duplex::TurnResult) -> String {
+    let mut parts = Vec::new();
+    if let Some(c) = turn.total_cost_usd() {
+        parts.push(format!("${c:.4}"));
+    }
+    if let Some(d) = turn.duration_ms() {
+        parts.push(format!("{:.1}s", d as f64 / 1000.0));
+    }
+    parts.join(" · ")
+}
+
+fn first_line(s: &str) -> String {
+    let line = s.lines().next().unwrap_or("");
+    if line.chars().count() > 80 {
+        let truncated: String = line.chars().take(79).collect();
+        format!("{truncated}…")
+    } else {
+        line.to_string()
+    }
+}
+
+fn print_help() {
+    println!(
+        "\
+commands:
+  /help                 this list
+  /exit, /quit          close the session and leave
+  /model <name>         switch model (respawns, keeps history)
+  /effort <level>       switch effort (respawns, keeps history)
+  /profile <name>       apply a profile's settings (respawns, keeps history)
+  /new                  reset the conversation (same settings, empty context)
+  /editor               compose a prompt in $EDITOR
+  /cost                 turns and cost for this session
+  /history              prompts and answers so far
+  /sessions             list open sessions
+  /explain              print the `claude` command this session was spawned with
+
+Anything not starting with / is sent as a prompt. Ctrl-C cancels a running
+turn; Ctrl-D exits."
+    );
+}

--- a/examples/cr/src/repl.rs
+++ b/examples/cr/src/repl.rs
@@ -10,7 +10,7 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use claude_wrapper::Claude;
-use claude_wrapper::duplex::{DuplexOptions, DuplexSession};
+use claude_wrapper::duplex::{DuplexOptions, DuplexSession, InboundEvent};
 use nu_ansi_term::Color;
 use reedline::{DefaultPrompt, DefaultPromptSegment, FileBackedHistory, Reedline, Signal};
 
@@ -294,27 +294,70 @@ impl Repl {
         Ok(std::process::ExitCode::SUCCESS)
     }
 
-    /// Run one prompt turn against the current session, cancellable with Ctrl-C.
+    /// Run one prompt turn against the current session. Assistant text streams
+    /// to stdout as it arrives; Ctrl-C cancels the turn via `interrupt()`.
     async fn turn(&mut self, prompt: String) -> anyhow::Result<()> {
+        use std::io::Write;
         let idx = self.current;
         let echo = prompt.clone();
+        let mut printed_any = false;
         let result = {
             let session = &self.sessions[idx].inner;
-            tokio::select! {
-                res = session.send(prompt) => Some(res?),
-                _ = tokio::signal::ctrl_c() => {
-                    eprintln!("\n{}", Color::DarkGray.paint("(interrupting...)"));
-                    let _ = session.interrupt().await;
-                    None
+            // Subscribe before the send is polled so no early delta is missed.
+            let mut rx = session.subscribe();
+            let send_fut = session.send(prompt);
+            tokio::pin!(send_fut);
+            let mut out = std::io::stdout();
+            let mut turn = None;
+            loop {
+                tokio::select! {
+                    // Prefer draining text deltas over taking the result, so the
+                    // streamed output is complete before the turn is finalized.
+                    biased;
+                    ev = rx.recv() => {
+                        if let Ok(ev) = ev
+                            && let Some(t) = stream_text_delta(&ev)
+                        {
+                            let _ = write!(out, "{t}");
+                            let _ = out.flush();
+                            printed_any = true;
+                        }
+                    }
+                    res = &mut send_fut => {
+                        turn = Some(res?);
+                        while let Ok(ev) = rx.try_recv() {
+                            if let Some(t) = stream_text_delta(&ev) {
+                                let _ = write!(out, "{t}");
+                                let _ = out.flush();
+                                printed_any = true;
+                            }
+                        }
+                        break;
+                    }
+                    _ = tokio::signal::ctrl_c() => {
+                        eprintln!("\n{}", Color::DarkGray.paint("(interrupting...)"));
+                        let _ = session.interrupt().await;
+                        break;
+                    }
                 }
             }
+            turn
         };
         let Some(turn) = result else {
+            if printed_any {
+                println!();
+            }
             return Ok(());
         };
 
         let answer = turn.result_text().unwrap_or("").to_string();
-        println!("{answer}");
+        if printed_any {
+            // Terminate the streamed line.
+            println!();
+        } else {
+            // No partial deltas were emitted; print the buffered answer.
+            println!("{answer}");
+        }
         let s = &mut self.sessions[idx];
         s.turns += 1;
         if let Some(c) = turn.total_cost_usd() {
@@ -467,6 +510,24 @@ fn build_editor() -> Reedline {
         }
     }
     editor
+}
+
+/// Extract an assistant text delta from a streaming event, if it is one.
+/// The duplex spawn runs with partial messages on, so a turn's assistant text
+/// arrives as a run of `content_block_delta`/`text_delta` stream events.
+fn stream_text_delta(ev: &InboundEvent) -> Option<String> {
+    let InboundEvent::StreamEvent(v) = ev else {
+        return None;
+    };
+    let event = v.get("event")?;
+    if event.get("type")?.as_str()? != "content_block_delta" {
+        return None;
+    }
+    let delta = event.get("delta")?;
+    if delta.get("type")?.as_str()? != "text_delta" {
+        return None;
+    }
+    Some(delta.get("text")?.as_str()?.to_string())
 }
 
 fn turn_footer(turn: &claude_wrapper::duplex::TurnResult) -> String {

--- a/examples/cr/src/repl.rs
+++ b/examples/cr/src/repl.rs
@@ -9,8 +9,8 @@
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
-use claude_wrapper::Claude;
 use claude_wrapper::duplex::{DuplexOptions, DuplexSession, InboundEvent};
+use claude_wrapper::{Claude, ClaudeCommand};
 use nu_ansi_term::Color;
 use reedline::{
     ColumnarMenu, Completer, DefaultPrompt, DefaultPromptSegment, Emacs, FileBackedHistory,
@@ -356,8 +356,50 @@ impl Repl {
         if let Some(rest) = line.strip_prefix('/') {
             return self.command(rest).await;
         }
+        // Shell-style backgrounding: `<prompt> &` launches a detached job.
+        if let Some(bg) = line.strip_suffix('&') {
+            let prompt = bg.trim();
+            if prompt.is_empty() {
+                anyhow::bail!("nothing to run before &");
+            }
+            self.launch_detached(prompt)?;
+            return Ok(false);
+        }
         self.turn(line.to_string()).await?;
         Ok(false)
+    }
+
+    /// Launch the current session's prompt as a detached job (the `&` suffix).
+    /// Inherits the session's settings; if it carries no cap, a conservative
+    /// default is applied since the job runs unattended with tool access.
+    fn launch_detached(&self, prompt: &str) -> anyhow::Result<()> {
+        let s = self.cur();
+        let mut settings = s.settings.clone();
+        let cap = match crate::cap_note(&settings) {
+            Some(c) => c,
+            None => {
+                settings.max_turns = Some(30);
+                "30 turns (default)".to_string()
+            }
+        };
+        let cmd = crate::build_detach_query(prompt, &settings)?;
+        let record = crate::jobs::launch(
+            &self.claude,
+            cmd.args(),
+            None,
+            prompt,
+            Some(s.name.clone()),
+            settings.model.clone(),
+            Some(cap.clone()),
+        )?;
+        eprintln!(
+            "{}",
+            Color::DarkGray.paint(format!(
+                "(job {} launched [{}], cap {}; `cr job {}` to check)",
+                record.id, s.name, cap, record.id
+            ))
+        );
+        Ok(())
     }
 
     async fn loop_(&mut self) -> anyhow::Result<std::process::ExitCode> {
@@ -854,7 +896,8 @@ sessions (run several conversations at once):
   /close [name]                   close a session (current by default)
   /all <prompt>                   send one prompt to every session
 
-Anything not starting with / is sent as a prompt. Ctrl-C cancels a running
-turn; Ctrl-D exits."
+Anything not starting with / is sent as a prompt; end it with ` &` to run it
+as a detached background job (see `cr jobs`). Ctrl-C cancels a running turn;
+Ctrl-D exits."
     );
 }

--- a/examples/cr/src/repl.rs
+++ b/examples/cr/src/repl.rs
@@ -89,6 +89,32 @@ impl Session {
     }
 }
 
+/// Resolve `defaults < profile < CR_<KEY> env` into a `Settings` for a session.
+/// (CLI-flag overrides are layered on by the caller.) A saved prompt template
+/// is dropped, since an interactive session has no template to render.
+fn resolve_settings(
+    user: &ConfigFile,
+    project: &ConfigFile,
+    active: Option<&str>,
+) -> anyhow::Result<Settings> {
+    let mut s = Settings::default();
+    if let Some(d) = &user.defaults {
+        s = s.overlay(d);
+    }
+    if let Some(d) = &project.defaults {
+        s = s.overlay(d);
+    }
+    if let Some(name) = active {
+        match crate::lookup_profile(project, user, name) {
+            Some(p) => s = s.overlay(p),
+            None => anyhow::bail!("unknown profile: {name}"),
+        }
+    }
+    s = s.overlay(&crate::env_settings());
+    s.prompt = None;
+    Ok(s)
+}
+
 /// Map a resolved `Settings` onto a `DuplexOptions`. Mirrors the one-shot
 /// command build in `main::run`, minus the per-run/output knobs.
 fn duplex_options(settings: &Settings) -> anyhow::Result<DuplexOptions> {
@@ -154,20 +180,7 @@ pub async fn run(
             .or_else(|| project.default_profile.clone())
             .or_else(|| user.default_profile.clone())
     };
-    let mut settings = Settings::default();
-    if let Some(d) = &user.defaults {
-        settings = settings.overlay(d);
-    }
-    if let Some(d) = &project.defaults {
-        settings = settings.overlay(d);
-    }
-    if let Some(name) = &active {
-        match crate::lookup_profile(project, user, name) {
-            Some(p) => settings = settings.overlay(p),
-            None => anyhow::bail!("unknown profile: {name}"),
-        }
-    }
-    settings = settings.overlay(&crate::env_settings());
+    let mut settings = resolve_settings(user, project, active.as_deref())?;
     // Repl flag overrides (only the seed knobs are exposed as flags here).
     if args.model.is_some() {
         settings.model = args.model.clone();
@@ -175,8 +188,6 @@ pub async fn run(
     if args.effort.is_some() {
         settings.effort = args.effort.clone();
     }
-    // A saved prompt template is meaningless for an interactive session.
-    settings.prompt = None;
 
     let mut builder = Claude::builder();
     if let Some(cwd) = &args.cwd {
@@ -414,20 +425,13 @@ impl Repl {
                 if arg.is_empty() {
                     anyhow::bail!("usage: /profile <name>");
                 }
-                let profile = crate::lookup_profile(&self.project, &self.user, arg)
-                    .ok_or_else(|| anyhow::anyhow!("unknown profile: {arg}"))?
-                    .clone();
-                let mut s = Settings::default();
-                if let Some(d) = &self.user.defaults {
-                    s = s.overlay(d);
-                }
-                if let Some(d) = &self.project.defaults {
-                    s = s.overlay(d);
-                }
-                s = s.overlay(&profile);
-                s.prompt = None;
+                let s = resolve_settings(&self.user, &self.project, Some(arg))?;
                 self.reconfigure(s, false).await?;
             }
+            "session" => self.cmd_session_new(arg).await?,
+            "use" => self.cmd_use(arg)?,
+            "close" => self.cmd_close(arg).await?,
+            "all" => self.cmd_all(arg).await?,
             "editor" => {
                 let prompt = crate::compose_in_editor()?;
                 self.turn(prompt).await?;
@@ -499,6 +503,96 @@ impl Repl {
             );
         }
     }
+
+    /// `/session new <name> [profile]`: open a second (or Nth) conversation and
+    /// select it. With a profile, seed from it; otherwise clone the current
+    /// session's settings.
+    async fn cmd_session_new(&mut self, arg: &str) -> anyhow::Result<()> {
+        let mut it = arg.split_whitespace();
+        match it.next() {
+            Some("new") => {}
+            Some(other) => anyhow::bail!("unknown: /session {other} (only `/session new`)"),
+            None => anyhow::bail!("usage: /session new <name> [profile]"),
+        }
+        let name = it
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("usage: /session new <name> [profile]"))?
+            .to_string();
+        if self.sessions.iter().any(|s| s.name == name) {
+            anyhow::bail!("session {name:?} already exists");
+        }
+        let settings = match it.next() {
+            Some(profile) => resolve_settings(&self.user, &self.project, Some(profile))?,
+            None => self.cur().settings.clone(),
+        };
+        let session = Session::spawn(&self.claude, name.clone(), settings).await?;
+        self.sessions.push(session);
+        self.current = self.sessions.len() - 1;
+        eprintln!(
+            "{}",
+            Color::DarkGray.paint(format!("(opened {name} and selected it)"))
+        );
+        Ok(())
+    }
+
+    /// `/use <name>`: make an existing session current.
+    fn cmd_use(&mut self, arg: &str) -> anyhow::Result<()> {
+        if arg.is_empty() {
+            anyhow::bail!("usage: /use <name>");
+        }
+        let idx = self
+            .sessions
+            .iter()
+            .position(|s| s.name == arg)
+            .ok_or_else(|| anyhow::anyhow!("no session named {arg:?} (see /sessions)"))?;
+        self.current = idx;
+        Ok(())
+    }
+
+    /// `/close [name]`: close a session (the current one by default). The last
+    /// open session cannot be closed; use `/exit` to leave.
+    async fn cmd_close(&mut self, arg: &str) -> anyhow::Result<()> {
+        if self.sessions.len() == 1 {
+            anyhow::bail!("can't close the last session; use /exit to leave");
+        }
+        let idx = if arg.is_empty() {
+            self.current
+        } else {
+            self.sessions
+                .iter()
+                .position(|s| s.name == arg)
+                .ok_or_else(|| anyhow::anyhow!("no session named {arg:?}"))?
+        };
+        let s = self.sessions.remove(idx);
+        let name = s.name.clone();
+        let _ = s.inner.close().await;
+        if idx < self.current {
+            self.current -= 1;
+        }
+        if self.current >= self.sessions.len() {
+            self.current = self.sessions.len() - 1;
+        }
+        eprintln!("{}", Color::DarkGray.paint(format!("(closed {name})")));
+        Ok(())
+    }
+
+    /// `/all <prompt>`: send the same prompt to every session in turn.
+    async fn cmd_all(&mut self, arg: &str) -> anyhow::Result<()> {
+        if arg.is_empty() {
+            anyhow::bail!("usage: /all <prompt>");
+        }
+        let saved = self.current;
+        for i in 0..self.sessions.len() {
+            self.current = i;
+            let name = self.sessions[i].name.clone();
+            eprintln!("{}", Color::Cyan.bold().paint(format!("── {name} ──")));
+            if let Err(e) = self.turn(arg.to_string()).await {
+                eprintln!("{}: {e}", Color::Red.paint("cr"));
+            }
+        }
+        self.current = saved.min(self.sessions.len().saturating_sub(1));
+        Ok(())
+    }
 }
 
 fn build_editor() -> Reedline {
@@ -564,8 +658,14 @@ commands:
   /editor               compose a prompt in $EDITOR
   /cost                 turns and cost for this session
   /history              prompts and answers so far
-  /sessions             list open sessions
   /explain              print the `claude` command this session was spawned with
+
+sessions (run several conversations at once):
+  /session new <name> [profile]   open another session and select it
+  /use <name>                     switch to a session
+  /sessions                       list open sessions
+  /close [name]                   close a session (current by default)
+  /all <prompt>                   send one prompt to every session
 
 Anything not starting with / is sent as a prompt. Ctrl-C cancels a running
 turn; Ctrl-D exits."


### PR DESCRIPTION
Adds two surfaces to `cr` on top of the existing one-shot path, both fed by the
same resolved `Settings` (`defaults < profile < CR_* < flag`).

## `cr repl`

An interactive multi-turn session over `DuplexSession`: one `claude` child held
open across turns, seeded from the same settings a one-shot run resolves.

- Assistant text streams live as `content_block_delta` events arrive.
- `/model`, `/effort`, `/profile` retune the session and respawn with `--resume`,
  so history carries over. `/new` resets to an empty context.
- Several conversations at once: `/session new <name> [profile]`, `/use`,
  `/sessions`, `/close`, and `/all <prompt>` to fan one prompt across all of them.
  Each is its own child, so they can differ in model, tools, and permission mode.
- `/cost`, `/json`, `/history`, `/explain`, `/editor` for inspection and composition.
- reedline editor on a TTY (file-backed history, Tab completion for command words
  and profile names, nearest-match suggestion on a typo); plain stdin on a pipe so
  `printf '...\n/exit\n' | cr repl` scripts a session.
- `-e/--exec <cmd>` runs commands in order then exits, non-zero if any errored.
- Ctrl-C interrupts a running turn via `DuplexSession::interrupt`; Ctrl-D exits.

## Background jobs

A job is a `claude` run that keeps going after `cr` exits. There is no daemon:
the run is spawned detached (own process group, stdin nulled, stdout captured to
a journal) and recorded under `~/.config/cr/jobs/<id>/`, mirroring the shape of
Claude Code's own `~/.claude/jobs/<id>/`.

- `cr -d "<prompt>"` launches and returns. `cr jobs` lists them, including Claude
  Code's own daemon jobs read-only via `claude_wrapper::jobs`. `cr job <id>`
  renders or tails one (`--follow`, `--json`).
- Jobs are addressed by id, unique id-prefix, or a `--session NAME` label.
- Liveness and completion are computed at read time from the journal and the pid,
  so a crashed writer never leaves a stale `running`.
- Launching requires a cap (`--max-budget-usd` or `--max-turns`, from flag,
  profile, or config) unless `--uncapped`, since a job runs unattended with tool
  access.
- In the REPL, a trailing `&` backgrounds a prompt.
- A finished job's session id is printed, so `cr repl --resume <id>` reconnects.

## Notes

The crate moves from the library's `sync` feature to `async`, since
`DuplexSession` is async-only. New deps: tokio, reedline, nu-ansi-term, and libc
on unix.

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and
`cargo test --all-features --workspace` are green.

## Known gaps, draft until addressed

- No tests in the `cr` crate. Testable without spawning `claude`: settings
  overlay precedence, prompt template substitution, `jobs::resolve` (prefix vs
  session name vs ambiguous), `status()` off a synthetic journal, `render_event`,
  `nearest_command`.
- Three hand-written copies of the `Settings` to command-options mapping
  (`duplex_options` in repl.rs, `build_detach_query` in main.rs, the inline
  builder in `run`). They already differ on `worktree` handling. Should collapse
  to one.
- `cr job <id> --follow` and `cr --check --session NAME --follow` do the same
  thing two ways. One should go.
- No job lifecycle: no kill, no prune, no way to read `stderr.log` when a job
  goes `stopped`. Job directories accumulate.
- The REPL can launch a job with `&` but cannot list or inspect one without
  exiting.