### PR TITLE
fix(frontmatter): support YAML block scalars in agent, skill, and command frontmatter

### DIFF
--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -39,6 +39,23 @@
 //! survive a round trip. Frontmatter is optional -- a body-only file
 //! parses fine, with `name` defaulting to the file stem.
 //!
+//! YAML block scalars are supported for any key, which is how
+//! multi-line descriptions are usually written:
+//!
+//! ```text
+//! ---
+//! name: auditor
+//! description: >-
+//!   Use when surveying a codebase against a rubric. Read-only:
+//!   never edits files, opens PRs, or commits.
+//! ---
+//! ```
+//!
+//! `>` folds the block into one line (blank lines become newlines),
+//! `|` preserves the line breaks, and the chomping indicator
+//! (`-` / none / `+`) controls the trailing newline. Continuation
+//! lines are part of the value even when they contain a colon.
+//!
 //! # Example
 //!
 //! ```no_run
@@ -242,23 +259,53 @@ pub struct AgentWriteInput {
 fn render_agent_markdown(file_stem: &str, input: &AgentWriteInput) -> String {
     let name = input.name.as_deref().unwrap_or(file_stem);
     let mut out = String::from("---\n");
-    out.push_str(&format!("name: {name}\n"));
+    push_frontmatter_field(&mut out, "name", name);
     if let Some(desc) = &input.description {
-        out.push_str(&format!("description: {desc}\n"));
+        push_frontmatter_field(&mut out, "description", desc);
     }
     if !input.tools.is_empty() {
-        out.push_str(&format!("tools: {}\n", input.tools.join(", ")));
+        push_frontmatter_field(&mut out, "tools", &input.tools.join(", "));
     }
     if let Some(model) = &input.model {
-        out.push_str(&format!("model: {model}\n"));
+        push_frontmatter_field(&mut out, "model", model);
     }
     for (k, v) in &input.extra {
-        out.push_str(&format!("{k}: {v}\n"));
+        push_frontmatter_field(&mut out, k, v);
     }
     out.push_str("---\n\n");
     out.push_str(input.body.trim());
     out.push('\n');
     out
+}
+
+/// Render one frontmatter field.
+///
+/// Single-line values are written as plain `key: value`. Multi-line
+/// values go out as a literal block scalar, with the chomping
+/// indicator chosen to preserve the exact trailing newlines: a bare
+/// `key: value` would leave the continuation lines at the top level,
+/// where the reader takes them for new keys.
+fn push_frontmatter_field(out: &mut String, key: &str, value: &str) {
+    let core = value.trim_end_matches('\n');
+    if !value.contains('\n') || core.is_empty() {
+        out.push_str(&format!("{key}: {core}\n"));
+        return;
+    }
+    let trailing = value.len() - core.len();
+    let indicator = match trailing {
+        0 => "|-",
+        1 => "|",
+        _ => "|+",
+    };
+    out.push_str(&format!("{key}: {indicator}\n"));
+    for line in core.lines() {
+        if line.is_empty() {
+            out.push('\n');
+        } else {
+            out.push_str(&format!("  {line}\n"));
+        }
+    }
+    out.push_str(&"\n".repeat(trailing.saturating_sub(1)));
 }
 
 fn validate_stem(stem: &str) -> Result<()> {
@@ -351,17 +398,8 @@ fn parse_agent_file(path: &Path, file_stem: &str) -> Result<Agent> {
     let mut extra = BTreeMap::new();
 
     if let Some(fm) = frontmatter {
-        for line in fm.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            let Some((k, v)) = trimmed.split_once(':') else {
-                continue;
-            };
-            let key = k.trim();
-            let value = v.trim().to_string();
-            match key {
+        for (key, value) in frontmatter_entries(fm) {
+            match key.as_str() {
                 "name" if !value.is_empty() => name = value,
                 "description" if !value.is_empty() => description = Some(value),
                 "tools" if !value.is_empty() => {
@@ -372,10 +410,9 @@ fn parse_agent_file(path: &Path, file_stem: &str) -> Result<Agent> {
                         .collect();
                 }
                 "model" if !value.is_empty() => model = Some(value),
-                _ if !key.is_empty() => {
-                    extra.insert(key.to_string(), value);
+                _ => {
+                    extra.insert(key, value);
                 }
-                _ => {}
             }
         }
     }
@@ -390,6 +427,221 @@ fn parse_agent_file(path: &Path, file_stem: &str) -> Result<Agent> {
         body: body.trim().to_string(),
         extra,
     })
+}
+
+/// Parse a frontmatter block into ordered `(key, value)` pairs.
+///
+/// Shared by the agent, skill, and command readers so all three
+/// artifact types accept the same frontmatter shapes.
+///
+/// The parser stays permissive and flat: every `key: value` line at
+/// any indentation becomes an entry, and lines without a colon are
+/// skipped. Duplicate keys are returned in file order, so callers
+/// that fold into a map get last-wins.
+///
+/// The one structural feature it understands is the YAML block
+/// scalar. A value of `>`, `>-`, `>+`, `|`, `|-`, or `|+` (with an
+/// optional explicit indentation digit and an optional trailing
+/// comment) consumes the indented block that follows:
+///
+/// - `>` folds line breaks into spaces; a blank line becomes a
+///   newline, and more-indented lines keep their breaks.
+/// - `|` preserves line breaks verbatim.
+/// - The chomping indicator sets the trailing newline: `-` strips
+///   it, the default clips to one, `+` keeps every one.
+///
+/// Without this, a folded `description` yields the indicator itself
+/// as the value and its continuation lines leak out as bogus keys
+/// (any line containing a colon) or vanish (any line without one).
+pub(crate) fn frontmatter_entries(fm: &str) -> Vec<(String, String)> {
+    let lines: Vec<&str> = fm.lines().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        i += 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some((k, v)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let key = k.trim();
+        if key.is_empty() {
+            continue;
+        }
+        match parse_block_header(v.trim()) {
+            Some(header) => {
+                let (value, consumed) = read_block_scalar(&lines[i..], indent_width(line), header);
+                i += consumed;
+                out.push((key.to_string(), value));
+            }
+            None => out.push((key.to_string(), v.trim().to_string())),
+        }
+    }
+    out
+}
+
+/// How a block scalar treats trailing line breaks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Chomp {
+    /// `-`: drop the trailing line break entirely.
+    Strip,
+    /// Default: keep exactly one trailing line break.
+    Clip,
+    /// `+`: keep every trailing line break.
+    Keep,
+}
+
+/// A parsed block-scalar header (`>` / `|` plus modifiers).
+#[derive(Debug, Clone, Copy)]
+struct BlockHeader {
+    /// `|` preserves line breaks; `>` folds them into spaces.
+    literal: bool,
+    chomp: Chomp,
+    /// Explicit indentation indicator, relative to the key's indent.
+    indent: Option<usize>,
+}
+
+/// Recognize a block-scalar header. Returns `None` for anything that
+/// isn't one, so plain values (including a value that merely starts
+/// with `>`) fall through to the flat path unchanged.
+fn parse_block_header(rest: &str) -> Option<BlockHeader> {
+    // A header is the indicator plus modifiers, optionally followed
+    // by whitespace and a `#` comment. Anything else is a plain value.
+    let (head, tail) = match rest.split_once(char::is_whitespace) {
+        Some((h, t)) => (h, t.trim_start()),
+        None => (rest, ""),
+    };
+    if !tail.is_empty() && !tail.starts_with('#') {
+        return None;
+    }
+
+    let mut chars = head.chars();
+    let literal = match chars.next()? {
+        '|' => true,
+        '>' => false,
+        _ => return None,
+    };
+    let mut chomp = Chomp::Clip;
+    let mut indent = None;
+    for c in chars {
+        match c {
+            '-' | '+' if chomp == Chomp::Clip => {
+                chomp = if c == '-' { Chomp::Strip } else { Chomp::Keep };
+            }
+            '1'..='9' if indent.is_none() => indent = Some(c as usize - '0' as usize),
+            _ => return None,
+        }
+    }
+    Some(BlockHeader {
+        literal,
+        chomp,
+        indent,
+    })
+}
+
+/// Read the block that follows a block-scalar header.
+///
+/// `lines` starts at the line after the header. Returns the scalar
+/// value and how many lines it consumed. The block is every
+/// following line that is blank or indented deeper than
+/// `parent_indent` (the indentation of the key line itself).
+fn read_block_scalar(lines: &[&str], parent_indent: usize, header: BlockHeader) -> (String, usize) {
+    let consumed = lines
+        .iter()
+        .take_while(|l| l.trim().is_empty() || indent_width(l) > parent_indent)
+        .count();
+    let block = &lines[..consumed];
+
+    // Content indentation: the explicit indicator if given, else the
+    // indentation of the first non-blank line.
+    let content_indent = match header.indent {
+        Some(n) => parent_indent + n,
+        None => block
+            .iter()
+            .find(|l| !l.trim().is_empty())
+            .map(|l| indent_width(l))
+            .unwrap_or(parent_indent + 1),
+    };
+    let stripped: Vec<&str> = block
+        .iter()
+        .map(|l| &l[indent_width(l).min(content_indent)..])
+        .collect();
+
+    // Trailing blank lines are the chomping tail, not content.
+    let end = stripped
+        .iter()
+        .rposition(|l| !l.trim().is_empty())
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let trailing_blanks = stripped.len() - end;
+    let content = &stripped[..end];
+
+    let mut value = if header.literal {
+        content
+            .iter()
+            .map(|l| l.trim_end())
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        fold_block(content)
+    };
+    match header.chomp {
+        Chomp::Strip => {}
+        Chomp::Clip => {
+            if !value.is_empty() {
+                value.push('\n');
+            }
+        }
+        Chomp::Keep => {
+            let n = if value.is_empty() {
+                trailing_blanks
+            } else {
+                trailing_blanks + 1
+            };
+            value.push_str(&"\n".repeat(n));
+        }
+    }
+    (value, consumed)
+}
+
+/// Fold a `>` block: line breaks between plain lines become spaces,
+/// blank lines become newlines, and breaks adjacent to a
+/// more-indented line stay newlines.
+fn fold_block(lines: &[&str]) -> String {
+    let mut out = String::new();
+    let mut blank_run = 0usize;
+    let mut have_content = false;
+    let mut prev_more_indented = false;
+    for line in lines {
+        if line.trim().is_empty() {
+            blank_run += 1;
+            continue;
+        }
+        let more_indented = line.starts_with([' ', '\t']);
+        if blank_run > 0 {
+            out.push_str(&"\n".repeat(blank_run));
+        } else if have_content {
+            if more_indented || prev_more_indented {
+                out.push('\n');
+            } else {
+                out.push(' ');
+            }
+        }
+        out.push_str(line.trim_end());
+        blank_run = 0;
+        have_content = true;
+        prev_more_indented = more_indented;
+    }
+    out
+}
+
+/// Width of a line's leading whitespace. Spaces and tabs are one
+/// column each; YAML forbids tabs in indentation anyway.
+fn indent_width(line: &str) -> usize {
+    line.len() - line.trim_start_matches([' ', '\t']).len()
 }
 
 /// Split a markdown file into (optional frontmatter body, content
@@ -586,6 +838,174 @@ mod tests {
         assert_eq!(body, raw);
     }
 
+    // -- block scalars -------------------------------------------------
+
+    /// The exact shape that motivated block-scalar support: a folded
+    /// description whose continuation lines contain colons. Before,
+    /// the value was the `>-` indicator itself, `Read-only` leaked
+    /// into `extra`, and the colon-free line was dropped.
+    #[test]
+    fn folded_description_with_colons_is_one_value() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_agent(
+            tmp.path(),
+            "auditor",
+            concat!(
+                "---\n",
+                "name: auditor\n",
+                "description: >-\n",
+                "  Use when surveying a codebase against a rubric and generating a backlog of\n",
+                "  GitHub issues. Read-only: never edits files, opens PRs, or commits. Accepts:\n",
+                "  \"audit <domain> in <repo>\", dispatched by dispatcher for audit+remediate shape.\n",
+                "tools: Read, Glob, Grep, Bash\n",
+                "model: sonnet\n",
+                "---\n\nBody.\n",
+            ),
+        );
+        let root = AgentsRoot::at(tmp.path());
+        let agent = root.get("auditor").expect("get");
+        assert_eq!(
+            agent.description.as_deref(),
+            Some(
+                "Use when surveying a codebase against a rubric and generating a backlog of \
+                 GitHub issues. Read-only: never edits files, opens PRs, or commits. Accepts: \
+                 \"audit <domain> in <repo>\", dispatched by dispatcher for audit+remediate shape."
+            )
+        );
+        // Continuation lines must not leak out as keys.
+        assert!(agent.extra.is_empty(), "extra: {:?}", agent.extra);
+        // Keys after the block still parse.
+        assert_eq!(agent.tools, vec!["Read", "Glob", "Grep", "Bash"]);
+        assert_eq!(agent.model.as_deref(), Some("sonnet"));
+        assert_eq!(agent.body, "Body.");
+    }
+
+    #[test]
+    fn literal_block_preserves_newlines() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_agent(
+            tmp.path(),
+            "lit",
+            "---\nname: lit\ndescription: |-\n  first line\n  second: line\n\n  after blank\nmodel: sonnet\n---\nbody\n",
+        );
+        let root = AgentsRoot::at(tmp.path());
+        let agent = root.get("lit").expect("get");
+        assert_eq!(
+            agent.description.as_deref(),
+            Some("first line\nsecond: line\n\nafter blank")
+        );
+        assert_eq!(agent.model.as_deref(), Some("sonnet"));
+    }
+
+    #[test]
+    fn plain_single_line_values_are_unchanged() {
+        let entries = frontmatter_entries("name: x\ndescription: a: b\nmodel: sonnet\n");
+        assert_eq!(
+            entries,
+            vec![
+                ("name".to_string(), "x".to_string()),
+                // Only the first colon splits; the rest is the value.
+                ("description".to_string(), "a: b".to_string()),
+                ("model".to_string(), "sonnet".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn values_starting_with_indicator_char_are_not_blocks() {
+        // `> not an indicator` is a plain value, not a block header.
+        let entries = frontmatter_entries("description: > plain text\nmodel: sonnet\n");
+        assert_eq!(
+            entries,
+            vec![
+                ("description".to_string(), "> plain text".to_string()),
+                ("model".to_string(), "sonnet".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn chomping_controls_trailing_newline() {
+        let cases = [
+            (">-", "one two"),
+            (">", "one two\n"),
+            (">+", "one two\n\n\n"),
+            ("|-", "one\ntwo"),
+            ("|", "one\ntwo\n"),
+            ("|+", "one\ntwo\n\n\n"),
+        ];
+        for (indicator, expected) in cases {
+            let fm = format!("description: {indicator}\n  one\n  two\n\n\nmodel: sonnet\n");
+            let entries = frontmatter_entries(&fm);
+            assert_eq!(
+                entries,
+                vec![
+                    ("description".to_string(), expected.to_string()),
+                    ("model".to_string(), "sonnet".to_string()),
+                ],
+                "indicator {indicator:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn folded_block_keeps_more_indented_lines_on_their_own_lines() {
+        let entries = frontmatter_entries(
+            "description: >-\n  intro line\n    indented literal\n  tail line\n",
+        );
+        assert_eq!(
+            entries,
+            vec![(
+                "description".to_string(),
+                "intro line\n  indented literal\ntail line".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn explicit_indentation_indicator_is_honored() {
+        // `|4` sets the content indent explicitly, so the two extra
+        // spaces on the second line are part of the value.
+        let entries = frontmatter_entries("description: |4-\n    one\n      two\n");
+        assert_eq!(
+            entries,
+            vec![("description".to_string(), "one\n  two".to_string())]
+        );
+    }
+
+    #[test]
+    fn block_scalar_at_end_of_frontmatter() {
+        let entries = frontmatter_entries("name: x\ndescription: >-\n  only value\n");
+        assert_eq!(
+            entries,
+            vec![
+                ("name".to_string(), "x".to_string()),
+                ("description".to_string(), "only value".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_block_scalar_yields_empty_value() {
+        let entries = frontmatter_entries("description: >-\nmodel: sonnet\n");
+        assert_eq!(
+            entries,
+            vec![
+                ("description".to_string(), String::new()),
+                ("model".to_string(), "sonnet".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn block_header_trailing_comment_is_ignored() {
+        let entries = frontmatter_entries("description: >- # why\n  folded text\n");
+        assert_eq!(
+            entries,
+            vec![("description".to_string(), "folded text".to_string())]
+        );
+    }
+
     #[test]
     fn empty_value_keys_dont_overwrite_defaults() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -760,6 +1180,46 @@ mod tests {
                 err.to_string().to_lowercase().contains("file_stem"),
                 "bad stem {bad:?} not rejected: {err}"
             );
+        }
+    }
+
+    #[test]
+    fn write_round_trips_multi_line_description() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = AgentsRoot::at(tmp.path());
+        // A description with embedded newlines and a colon: written
+        // as a plain `key: value` it would corrupt the frontmatter.
+        let desc = "first line\nsecond: line\n\nafter blank";
+        let input = AgentWriteInput {
+            description: Some(desc.into()),
+            model: Some("sonnet".into()),
+            body: "b".into(),
+            ..Default::default()
+        };
+        root.write("multi", input).expect("write");
+
+        let raw = std::fs::read_to_string(tmp.path().join("multi.md")).expect("read");
+        assert!(raw.contains("description: |-\n"), "raw: {raw}");
+
+        let agent = root.get("multi").expect("get");
+        assert_eq!(agent.description.as_deref(), Some(desc));
+        assert_eq!(agent.model.as_deref(), Some("sonnet"));
+        assert!(agent.extra.is_empty(), "extra: {:?}", agent.extra);
+    }
+
+    #[test]
+    fn write_round_trips_trailing_newlines_in_description() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = AgentsRoot::at(tmp.path());
+        for desc in ["a\nb", "a\nb\n", "a\nb\n\n\n"] {
+            let input = AgentWriteInput {
+                description: Some(desc.into()),
+                body: "b".into(),
+                ..Default::default()
+            };
+            root.write("chomp", input).expect("write");
+            let agent = root.get("chomp").expect("get");
+            assert_eq!(agent.description.as_deref(), Some(desc), "desc {desc:?}");
         }
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -55,6 +55,13 @@
 //! Frontmatter is optional -- a body-only file parses fine, with
 //! `description` left `None`.
 //!
+//! YAML block scalars (`>`, `>-`, `>+`, `|`, `|-`, `|+`) are
+//! supported for any key, which is how multi-line descriptions are
+//! usually written. `>` folds the block into one line, `|` preserves
+//! the line breaks, and the chomping indicator controls the trailing
+//! newline. Continuation lines are part of the value even when they
+//! contain a colon.
+//!
 //! Note the dashes in `argument-hint` / `allowed-tools` /
 //! `disable-model-invocation`: that's how Claude Code spells the
 //! keys on disk. The typed fields use Rust-friendly snake_case
@@ -80,7 +87,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::artifacts::split_frontmatter;
+use crate::artifacts::{frontmatter_entries, split_frontmatter};
 use crate::error::{Error, Result};
 
 /// Root directory of one set of slash command definitions
@@ -252,17 +259,8 @@ fn parse_command_file(path: &Path, file_stem: &str) -> Result<Command> {
     let mut extra = BTreeMap::new();
 
     if let Some(fm) = frontmatter {
-        for line in fm.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            let Some((k, v)) = trimmed.split_once(':') else {
-                continue;
-            };
-            let key = k.trim();
-            let value = v.trim().to_string();
-            match key {
+        for (key, value) in frontmatter_entries(fm) {
+            match key.as_str() {
                 "description" if !value.is_empty() => description = Some(value),
                 "argument-hint" if !value.is_empty() => argument_hint = Some(value),
                 "allowed-tools" if !value.is_empty() => {
@@ -275,14 +273,13 @@ fn parse_command_file(path: &Path, file_stem: &str) -> Result<Command> {
                 "model" if !value.is_empty() => model = Some(value),
                 "disable-model-invocation" if !value.is_empty() => {
                     disable_model_invocation = Some(matches!(
-                        value.to_ascii_lowercase().as_str(),
+                        value.trim().to_ascii_lowercase().as_str(),
                         "true" | "yes" | "1"
                     ));
                 }
-                _ if !key.is_empty() => {
-                    extra.insert(key.to_string(), value);
+                _ => {
+                    extra.insert(key, value);
                 }
-                _ => {}
             }
         }
     }
@@ -436,6 +433,50 @@ mod tests {
         let root = CommandsRoot::at(tmp.path());
         let cmd = root.get("weird").expect("get");
         assert_eq!(cmd.disable_model_invocation, Some(true));
+    }
+
+    #[test]
+    fn folded_description_with_colons_is_one_value() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_command(
+            tmp.path(),
+            "folded",
+            concat!(
+                "---\n",
+                "description: >-\n",
+                "  Open a PR for the current branch. Note: pushes first, then\n",
+                "  opens the PR as a draft.\n",
+                "allowed-tools: Bash(git *), Bash(gh *)\n",
+                "disable-model-invocation: true\n",
+                "---\n\nBody.\n",
+            ),
+        );
+        let root = CommandsRoot::at(tmp.path());
+        let cmd = root.get("folded").expect("get");
+        assert_eq!(
+            cmd.description.as_deref(),
+            Some(
+                "Open a PR for the current branch. Note: pushes first, then opens the PR as a draft."
+            )
+        );
+        assert!(cmd.extra.is_empty(), "extra: {:?}", cmd.extra);
+        assert_eq!(cmd.allowed_tools, vec!["Bash(git *)", "Bash(gh *)"]);
+        assert_eq!(cmd.disable_model_invocation, Some(true));
+        assert_eq!(cmd.body, "Body.");
+    }
+
+    #[test]
+    fn literal_description_preserves_newlines() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_command(
+            tmp.path(),
+            "lit",
+            "---\ndescription: |-\n  one\n  two: three\nmodel: sonnet\n---\nbody\n",
+        );
+        let root = CommandsRoot::at(tmp.path());
+        let cmd = root.get("lit").expect("get");
+        assert_eq!(cmd.description.as_deref(), Some("one\ntwo: three"));
+        assert_eq!(cmd.model.as_deref(), Some("sonnet"));
     }
 
     #[test]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -25,6 +25,13 @@
 //! (as plain strings); every other frontmatter key lands in
 //! [`Memory::extra`] verbatim.
 //!
+//! YAML block scalars (`>`, `>-`, `>+`, `|`, `|-`, `|+`) are
+//! supported for any key, which is how multi-line descriptions are
+//! usually written. `>` folds the block into one line, `|` preserves
+//! the line breaks, and the chomping indicator controls the trailing
+//! newline. Continuation lines are part of the value even when they
+//! contain a colon.
+//!
 //! Three levels of granularity:
 //!
 //! - [`MemoryRoot::list_projects_with_memory`] -- which projects
@@ -56,7 +63,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::artifacts::split_frontmatter;
+use crate::artifacts::{frontmatter_entries, split_frontmatter};
 use crate::error::{Error, Result};
 
 /// Root directory of Claude Code's per-project state. Defaults to
@@ -285,25 +292,17 @@ fn parse_memory_file(file_path: &Path) -> Result<Memory> {
     let mut extra = BTreeMap::new();
 
     if let Some(fm) = frontmatter {
-        for line in fm.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            let Some((k, v)) = trimmed.split_once(':') else {
-                continue;
-            };
-            let key = k.trim();
-            let value = unquote(v.trim()).to_string();
-            match key {
+        for (key, value) in frontmatter_entries(fm) {
+            let value = unquote(&value).to_string();
+            match key.as_str() {
                 "name" if !value.is_empty() => name = value,
                 "description" if !value.is_empty() => description = Some(value),
                 // The line-based parse flattens the nested
                 // `metadata:` block, so its `type:` arrives as a
                 // bare key.
                 "type" if !value.is_empty() => memory_type = Some(value),
-                _ if !key.is_empty() && !value.is_empty() => {
-                    extra.insert(key.to_string(), value);
+                _ if !value.is_empty() => {
+                    extra.insert(key, value);
                 }
                 _ => {}
             }
@@ -480,5 +479,38 @@ mod tests {
         assert_eq!(m.extra.get("custom").map(String::as_str), Some("kept"));
         // The bare `metadata:` container line has no value; dropped.
         assert!(!m.extra.contains_key("metadata"));
+    }
+
+    #[test]
+    fn folded_description_with_colons_is_one_value() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_memory(
+            tmp.path(),
+            "-slug",
+            "folded",
+            concat!(
+                "---\n",
+                "name: folded\n",
+                "description: >-\n",
+                "  Restarting as its own repo: MCP server plus CLI over one router,\n",
+                "  SQLite persistence.\n",
+                "metadata:\n",
+                "  type: project\n",
+                "---\n\nBody.\n",
+            ),
+        );
+        let root = MemoryRoot::at(tmp.path());
+        let m = root.get("-slug", "folded").expect("get");
+        assert_eq!(
+            m.description.as_deref(),
+            Some(
+                "Restarting as its own repo: MCP server plus CLI over one router, \
+                 SQLite persistence."
+            )
+        );
+        // The nested `metadata:` block still flattens to a bare `type`.
+        assert_eq!(m.memory_type.as_deref(), Some("project"));
+        assert!(m.extra.is_empty(), "extra: {:?}", m.extra);
+        assert_eq!(m.body, "Body.");
     }
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -39,6 +39,13 @@
 //! body-only `SKILL.md` parses fine, with `name` defaulting to the
 //! directory stem.
 //!
+//! YAML block scalars (`>`, `>-`, `>+`, `|`, `|-`, `|+`) are
+//! supported for any key, which is how multi-line descriptions are
+//! usually written. `>` folds the block into one line, `|` preserves
+//! the line breaks, and the chomping indicator controls the trailing
+//! newline. Continuation lines are part of the value even when they
+//! contain a colon.
+//!
 //! # Example
 //!
 //! ```no_run
@@ -78,7 +85,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::artifacts::split_frontmatter;
+use crate::artifacts::{frontmatter_entries, split_frontmatter};
 use crate::error::{Error, Result};
 
 /// Root directory of Claude Code's user-level skill definitions.
@@ -265,23 +272,13 @@ fn parse_skill_file(file_path: &Path, dir_path: &Path, dir_stem: &str) -> Result
     let mut extra = BTreeMap::new();
 
     if let Some(fm) = frontmatter {
-        for line in fm.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            let Some((k, v)) = trimmed.split_once(':') else {
-                continue;
-            };
-            let key = k.trim();
-            let value = v.trim().to_string();
-            match key {
+        for (key, value) in frontmatter_entries(fm) {
+            match key.as_str() {
                 "name" if !value.is_empty() => name = value,
                 "description" if !value.is_empty() => description = Some(value),
-                _ if !key.is_empty() => {
-                    extra.insert(key.to_string(), value);
+                _ => {
+                    extra.insert(key, value);
                 }
-                _ => {}
             }
         }
     }
@@ -473,6 +470,47 @@ mod tests {
             skill.extra.get("custom_key").map(String::as_str),
             Some("custom_value")
         );
+    }
+
+    #[test]
+    fn folded_description_with_colons_is_one_value() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_skill(
+            tmp.path(),
+            "folded",
+            concat!(
+                "---\n",
+                "name: folded\n",
+                "description: >-\n",
+                "  Use when surveying a codebase against a rubric. Read-only: never\n",
+                "  edits files, opens PRs, or commits.\n",
+                "---\n\nBody.\n",
+            ),
+        );
+        let root = SkillsRoot::at(tmp.path());
+        let skill = root.get("folded").expect("get");
+        assert_eq!(
+            skill.description.as_deref(),
+            Some(
+                "Use when surveying a codebase against a rubric. Read-only: never \
+                 edits files, opens PRs, or commits."
+            )
+        );
+        assert!(skill.extra.is_empty(), "extra: {:?}", skill.extra);
+        assert_eq!(skill.body, "Body.");
+    }
+
+    #[test]
+    fn literal_description_preserves_newlines() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_skill(
+            tmp.path(),
+            "lit",
+            "---\nname: lit\ndescription: |-\n  one\n  two: three\n---\nbody\n",
+        );
+        let root = SkillsRoot::at(tmp.path());
+        let skill = root.get("lit").expect("get");
+        assert_eq!(skill.description.as_deref(), Some("one\ntwo: three"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The frontmatter parsers in `src/artifacts.rs`, `src/skills.rs`, `src/commands.rs`, and `src/memory.rs` each ran the same flat, line-by-line loop: trim the line, `split_once(':')`, treat the left side as a key and the right side as the whole value. That has no notion of YAML block scalars (`>`, `>-`, `>+`, `|`, `|-`, `|+`), which are the natural way to write a multi-line description.

Given a real agent using a folded description:

```
---
name: auditor
description: >-
  Use when surveying a codebase against a rubric and generating a backlog of
  GitHub issues. Read-only: never edits files, opens PRs, or commits. Accepts:
  "audit <domain> in <repo>", dispatched by dispatcher for audit+remediate shape.
tools: Read, Glob, Grep, Bash
model: sonnet
---
```

`AgentsRoot::home()?.list()` returned `description: Some(">-")`. Two distinct failures:

1. The folded text was lost. The value was the block-scalar indicator itself.
2. Continuation lines containing a colon were parsed as new keys. `Read-only: never edits files, opens PRs, or commits. Accepts` became an `extra` entry keyed `Read-only`. Continuation lines without a colon were silently dropped.

Agent descriptions drive dispatch decisions, so a truncated or corrupted description changes behavior.

## Change

`frontmatter_entries` in `src/artifacts.rs`, alongside the existing `split_frontmatter` that the other readers already import. It returns ordered `(key, value)` pairs. All four readers now go through it, so agents, skills, commands, and memories accept the same frontmatter shapes.

Plain values behave exactly as before: any `key: value` line at any indentation is an entry, lines without a colon are skipped, duplicate keys are last-wins. On top of that:

- `>` folds the block into one line. Blank lines become newlines; more-indented lines keep their breaks.
- `|` preserves line breaks verbatim.
- The chomping indicator sets the trailing newline: `-` strips it, the default clips to one, `+` keeps every one.
- An explicit indentation indicator (`|4-`) and a trailing `#` comment on the header are honored.
- A value that merely starts with `>` or `|` (`description: > plain text`) is not a header and still parses as plain text.

`render_agent_markdown` now emits a literal block for any value containing a newline, with the chomping indicator picked to preserve the exact trailing newlines. Without that, `AgentsRoot::write` could produce frontmatter its own reader would then mis-parse.

## Not covered

Nested block sequences still flatten to an empty value:

```
skills:
  - sandbox-preflight
  - durable-context
```

parses as `extra["skills"] = ""` with the items dropped, as it did before. Representing a list needs a non-string value type in `extra`, which is a separate design call.

## Tests

Unit tests on `frontmatter_entries` cover folding, literal blocks, all six chomping/indicator combinations, more-indented lines inside a folded block, the explicit indentation indicator, a header comment, an empty block, a block at end of frontmatter, and the plain single-line path (including a value with an embedded colon and a value starting with `>`).

End-to-end reader tests cover the exact reproducer above for agents, plus folded and literal descriptions for skills, commands, and memories, asserting the keys after the block still parse and nothing leaks into `extra`. The memory test also confirms the nested `metadata:` block still flattens to a bare `type`, which that reader relies on. Two write tests cover multi-line round trips, including trailing-newline counts.

Verified against the real `~/.claude/agents`: `auditor` now returns the full folded description with `extra` empty.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo clippy --all-targets -- -D warnings
cargo clippy --all-targets --no-default-features --features "json,sync" -- -D warnings
cargo clippy -p claude-cr --all-targets -- -D warnings
cargo test --all-features
```

All green: 591 lib, 31 + 14 integration, 88 doc.