### PR TITLE
fix(exec): kill the CLI child when an in-flight execute future is dropped

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -39,6 +39,11 @@ pub trait ClaudeCommand: Send + Sync {
     fn args(&self) -> Vec<String>;
 
     /// Execute the command using the given claude client.
+    ///
+    /// Dropping the returned future mid-flight kills the spawned CLI
+    /// process (SIGKILL): a caller that races `execute` against
+    /// cancellation (e.g. `tokio::select!`) does not leave an abandoned
+    /// run executing in the background.
     #[cfg(feature = "async")]
     fn execute(&self, claude: &Claude) -> impl Future<Output = Result<Self::Output>> + Send;
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -7,6 +7,12 @@
 //! maps failures onto [`Error`] via
 //! [`from_command_failure`](crate::error::Error::from_command_failure).
 //! Both the async (tokio) and blocking (`sync` feature) paths live here.
+//!
+//! Every async spawn sets `kill_on_drop(true)`: dropping an in-flight
+//! execute future (a lost `tokio::select!` race, a caller-side timeout)
+//! kills the child rather than leaving the CLI running unattended with
+//! nobody reading the result. The blocking paths cannot be dropped
+//! mid-flight, so they need no equivalent.
 
 #[cfg(any(feature = "async", feature = "sync"))]
 use std::time::Duration;
@@ -52,12 +58,18 @@ pub struct CommandOutput {
 /// If the [`Claude`] client has a retry policy set, transient errors will be
 /// retried according to that policy. A per-command retry policy can be passed
 /// to override the client default.
+///
+/// Dropping the returned future mid-flight kills the spawned `claude`
+/// process (SIGKILL): an abandoned run does not keep executing in the
+/// background.
 #[cfg(feature = "async")]
 pub async fn run_claude(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
     run_claude_with_retry(claude, args, None).await
 }
 
 /// Run a claude command with an optional per-command retry policy override.
+///
+/// Dropping the returned future kills the child; see [`run_claude`].
 #[cfg(feature = "async")]
 pub async fn run_claude_with_retry(
     claude: &Claude,
@@ -79,6 +91,8 @@ pub async fn run_claude_with_retry(
 ///
 /// stdin mode does not retry -- the stdin pipe is consumed after the first
 /// attempt and cannot be rewound for a subsequent try.
+///
+/// Dropping the returned future kills the child; see [`run_claude`].
 #[cfg(feature = "async")]
 pub async fn run_claude_with_stdin_prompt(
     claude: &Claude,
@@ -132,6 +146,9 @@ async fn run_internal_stdin(
     cmd.stdin(std::process::Stdio::piped());
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
+    // Dropping the in-flight future must kill the child, not leave the
+    // CLI running unattended (see the module docs).
+    cmd.kill_on_drop(true);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
@@ -215,6 +232,9 @@ async fn run_with_timeout_stdin(
     cmd.stdin(std::process::Stdio::piped());
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
+    // Dropping the in-flight future must kill the child, not leave the
+    // CLI running unattended (see the module docs).
+    cmd.kill_on_drop(true);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
@@ -337,6 +357,8 @@ async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOu
 }
 
 /// Run a claude command and allow specific non-zero exit codes.
+///
+/// Dropping the returned future kills the child; see [`run_claude`].
 #[cfg(feature = "async")]
 pub async fn run_claude_allow_exit_codes(
     claude: &Claude,
@@ -373,6 +395,11 @@ async fn run_internal(
 
     // Prevent child from inheriting/blocking on parent's stdin.
     cmd.stdin(std::process::Stdio::null());
+
+    // Dropping the in-flight future must kill the child, not leave the
+    // CLI running unattended (see the module docs). The flag carries
+    // into the child spawned inside `Command::output` below.
+    cmd.kill_on_drop(true);
 
     // Remove Claude Code env vars to prevent nested session detection
     cmd.env_remove("CLAUDECODE");
@@ -440,6 +467,9 @@ async fn run_with_timeout(
     cmd.stdin(std::process::Stdio::null());
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
+    // Dropping the in-flight future must kill the child, not leave the
+    // CLI running unattended (see the module docs).
+    cmd.kill_on_drop(true);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
@@ -1456,6 +1486,118 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, Error::Timeout { .. }), "got: {err:?}");
+    }
+
+    /// Drive `fut` just long enough for the fake script to write its pid
+    /// file, then drop it mid-flight (on return) and hand back the pid.
+    #[cfg(feature = "async")]
+    async fn drop_in_flight_and_capture_pid<F>(fut: F, pid_path: &std::path::Path) -> u32
+    where
+        F: std::future::Future,
+        F::Output: std::fmt::Debug,
+    {
+        tokio::pin!(fut);
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Some(pid) = std::fs::read_to_string(pid_path)
+                .ok()
+                .and_then(|s| s.trim().parse().ok())
+            {
+                // Returning drops the pinned future here, mid-flight.
+                return pid;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child never wrote its pid file"
+            );
+            tokio::select! {
+                out = &mut fut => panic!("future completed before drop: {out:?}"),
+                _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+            }
+        }
+    }
+
+    /// Poll until `pid` is dead or a zombie awaiting reap. `kill_on_drop`
+    /// SIGKILLs at drop time, but reaping happens asynchronously on the
+    /// runtime's process driver, so a transient zombie counts as killed.
+    #[cfg(feature = "async")]
+    async fn assert_pid_killed(pid: u32) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let out = std::process::Command::new("ps")
+                .args(["-o", "stat=", "-p", &pid.to_string()])
+                .output()
+                .expect("run ps");
+            let stat = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !out.status.success() || stat.is_empty() || stat.starts_with('Z') {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child {pid} still alive (stat {stat}) after future drop"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    // Dropping an in-flight execute future must kill the spawned child:
+    // every async spawn site sets kill_on_drop(true), so a caller racing
+    // execute against cancellation (tokio::select!, timeout) cannot leak
+    // a headless CLI run. `exec` keeps the recorded pid the direct child,
+    // so the SIGKILL lands on the process the test watches.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_dropping_in_flight_future_kills_child() {
+        let workdir = tempfile::tempdir().expect("workdir");
+        let pid_path = workdir.path().join("pid");
+        let (_dir, path) = fake_script(&format!(
+            r#"echo $$ > "{}"; exec sleep 30"#,
+            pid_path.display()
+        ));
+        let claude = client(&path);
+        let pid = drop_in_flight_and_capture_pid(run_claude(&claude, vec![]), &pid_path).await;
+        assert_pid_killed(pid).await;
+    }
+
+    // Same guarantee on the timeout path, which holds a Child from
+    // spawn_retrying_txtbsy rather than going through Command::output.
+    // The configured timeout is far longer than the test; the drop is
+    // what kills the child.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_dropping_in_flight_future_kills_child_with_timeout() {
+        let workdir = tempfile::tempdir().expect("workdir");
+        let pid_path = workdir.path().join("pid");
+        let (_dir, path) = fake_script(&format!(
+            r#"echo $$ > "{}"; exec sleep 30"#,
+            pid_path.display()
+        ));
+        let claude = Claude::builder()
+            .binary(&path)
+            .timeout(Duration::from_secs(120))
+            .build()
+            .expect("build");
+        let pid = drop_in_flight_and_capture_pid(run_claude(&claude, vec![]), &pid_path).await;
+        assert_pid_killed(pid).await;
+    }
+
+    // Same guarantee for the stdin-prompt path.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_dropping_in_flight_stdin_future_kills_child() {
+        let workdir = tempfile::tempdir().expect("workdir");
+        let pid_path = workdir.path().join("pid");
+        let (_dir, path) = fake_script(&format!(
+            r#"echo $$ > "{}"; exec sleep 30"#,
+            pid_path.display()
+        ));
+        let claude = client(&path);
+        let pid = drop_in_flight_and_capture_pid(
+            run_claude_with_stdin_prompt(&claude, vec![], "x".into()),
+            &pid_path,
+        )
+        .await;
+        assert_pid_killed(pid).await;
     }
 
     #[cfg(feature = "async")]

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -272,6 +272,11 @@ fn parse_block_delta(delta: &serde_json::Value) -> BlockDelta {
 /// as a JSON event and passing it to the handler. Useful for progress tracking
 /// and real-time output processing.
 ///
+/// Dropping the returned future mid-flight kills the spawned `claude`
+/// process (SIGKILL): an abandoned run does not keep executing in the
+/// background. Events already dispatched to the handler are not rolled
+/// back.
+///
 /// # Example
 ///
 /// ```no_run
@@ -346,7 +351,10 @@ where
         .envs(&claude.env)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
-        .stdin(std::process::Stdio::null());
+        .stdin(std::process::Stdio::null())
+        // Dropping the in-flight future must kill the child, not leave
+        // the CLI running unattended (see the `exec` module docs).
+        .kill_on_drop(true);
 
     if let Some(ref dir) = claude.working_dir {
         cmd.current_dir(dir);

--- a/tests/fake-claude.sh
+++ b/tests/fake-claude.sh
@@ -14,6 +14,9 @@
 #       generated in-process. Use for large-output tests: passing a big
 #       string via FAKE_CLAUDE_OUTPUT hits Linux's 128KB per-env-string
 #       limit (MAX_ARG_STRLEN) and fails execve with E2BIG.
+#   FAKE_CLAUDE_PID_FILE    - if set, write this process's pid there before
+#       any delay or output, so tests can observe the process itself
+#       (e.g. that dropping an in-flight future kills it).
 #
 # Output format is selected by --output-format argument:
 #   stream-json  ->  three NDJSON lines (system/assistant/result)
@@ -33,6 +36,12 @@ ERROR_MSG="${FAKE_CLAUDE_ERROR_MSG:-command failed}"
 DELAY="${FAKE_CLAUDE_DELAY:-0}"
 COST_USD="${FAKE_CLAUDE_COST_USD:-0.0}"
 NUM_TURNS="${FAKE_CLAUDE_NUM_TURNS:-1}"
+
+# Record the pid before any delay so tests can watch the process from
+# the moment it starts.
+if [[ -n "${FAKE_CLAUDE_PID_FILE:-}" ]]; then
+    echo $$ > "$FAKE_CLAUDE_PID_FILE"
+fi
 
 # Optional delay before any output - used to test timeouts.
 if [[ "$DELAY" -gt 0 ]]; then

--- a/tests/fake_claude.rs
+++ b/tests/fake_claude.rs
@@ -719,3 +719,106 @@ async fn working_dir_set_on_subprocess() {
         .expect("should succeed");
     assert!(output.success);
 }
+
+// ── Cancellation: dropping an in-flight future kills the child ──────
+
+/// Drive `fut` just long enough for fake-claude.sh to write its pid file
+/// (FAKE_CLAUDE_PID_FILE), then drop it mid-flight (on return) and hand
+/// back the pid. Unix-only helpers: the assertions shell out to `ps`.
+#[cfg(unix)]
+async fn drop_in_flight_and_capture_pid<F>(fut: F, pid_path: &std::path::Path) -> u32
+where
+    F: std::future::Future,
+    F::Output: std::fmt::Debug,
+{
+    tokio::pin!(fut);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if let Some(pid) = std::fs::read_to_string(pid_path)
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+        {
+            // Returning drops the pinned future here, mid-flight.
+            return pid;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "child never wrote its pid file"
+        );
+        tokio::select! {
+            out = &mut fut => panic!("future completed before drop: {out:?}"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
+        }
+    }
+}
+
+/// Poll until `pid` is dead or a zombie awaiting reap. `kill_on_drop`
+/// SIGKILLs at drop time, but reaping happens asynchronously on the
+/// runtime's process driver, so a transient zombie counts as killed.
+#[cfg(unix)]
+async fn assert_pid_killed(pid: u32) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let out = std::process::Command::new("ps")
+            .args(["-o", "stat=", "-p", &pid.to_string()])
+            .output()
+            .expect("run ps");
+        let stat = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !out.status.success() || stat.is_empty() || stat.starts_with('Z') {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "child {pid} still alive (stat {stat}) after future drop"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
+/// Dropping an in-flight execute future kills the CLI child instead of
+/// leaving it to run to completion in the background. This is the MCP
+/// server shape: execute_json raced against client cancellation with
+/// tokio::select!. FAKE_CLAUDE_DELAY keeps the child alive far longer
+/// than the test; the drop is what kills it.
+#[cfg(unix)]
+#[tokio::test]
+async fn dropping_in_flight_execute_kills_child() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pid_path = dir.path().join("pid");
+    let claude = claude_with_env(&[
+        ("FAKE_CLAUDE_DELAY", "30"),
+        (
+            "FAKE_CLAUDE_PID_FILE",
+            pid_path.to_str().expect("utf8 path"),
+        ),
+    ]);
+
+    let cmd = QueryCommand::new("slow query").no_session_persistence();
+    let pid = drop_in_flight_and_capture_pid(cmd.execute(&claude), &pid_path).await;
+    assert_pid_killed(pid).await;
+}
+
+/// Same guarantee for the streaming path.
+#[cfg(unix)]
+#[tokio::test]
+async fn dropping_in_flight_stream_query_kills_child() {
+    use claude_wrapper::streaming::{StreamEvent, stream_query};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pid_path = dir.path().join("pid");
+    let claude = claude_with_env(&[
+        ("FAKE_CLAUDE_DELAY", "30"),
+        (
+            "FAKE_CLAUDE_PID_FILE",
+            pid_path.to_str().expect("utf8 path"),
+        ),
+    ]);
+
+    let cmd = QueryCommand::new("slow stream")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+    let pid =
+        drop_in_flight_and_capture_pid(stream_query(&claude, &cmd, |_: StreamEvent| {}), &pid_path)
+            .await;
+    assert_pid_killed(pid).await;
+}


### PR DESCRIPTION
## Problem

The async one-shot exec path spawned the `claude` CLI child via tokio without `kill_on_drop(true)`. A caller that dropped an execute future mid-flight (for example an MCP server racing `execute_json` against client cancellation with `tokio::select!`) left the child running to completion at real dollar cost, with nobody reading the result.

Before this change, `grep -rn kill_on_drop src/` hit only `src/duplex.rs`, which manages child shutdown explicitly through its actor loop and is not affected.

## Changes

1. Set `kill_on_drop(true)` on the tokio `Command` at every async one-shot spawn site:
   - `src/exec.rs`: `run_internal_stdin`, `run_with_timeout_stdin`, `run_internal` (the flag carries into the child spawned inside `Command::output`), `run_with_timeout`
   - `src/streaming.rs`: `stream_query_impl`
2. Documented the behavior change: dropping an in-flight execute or stream future now SIGKILLs the child. Updated the `exec` module doc, the public `run_claude*` doc comments, `stream_query`, and the `ClaudeCommand::execute` trait doc.
3. Regression tests:
   - Unit tests in `src/exec.rs` drive a future until the fake script records its pid (then `exec sleep`s), drop the future, and poll until the pid is dead or a zombie awaiting reap. Three tests cover the `Command::output` path, the timeout path, and the stdin-prompt path.
   - Integration tests in `tests/fake_claude.rs` cover the `QueryCommand::execute` and `stream_query` shapes via a new `FAKE_CLAUDE_PID_FILE` hook in `tests/fake-claude.sh`.
   - Verified the tests are regression-sensitive: with the flag removed from the `Command::output` site, the test fails with "child still alive (stat S) after future drop".

The sync (`std::process`) path blocks and cannot be dropped mid-flight, so it is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`, plus clippy on default features and on `--no-default-features --features "json,sync"`
- `cargo test --lib --all-features` (594 passed), `cargo test --doc --all-features` (88 passed)
- `cargo test --test fake_claude --all-features` (33 passed), `cargo test --test fake_claude_sync --all-features` (14 passed)
- CI: all 9 checks green (ubuntu stable/beta, macOS, Windows, MSRV, docs, release build, security audit, quick checks)