### PR TITLE
feat: declare the tested CLI version range in the crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,9 @@ pub use retry::{BackoffStrategy, RetryPolicy};
 pub use session::Session;
 pub use tool_pattern::{PatternError, ToolPattern};
 pub use types::*;
-pub use version::{CliVersion, CliVersionStatus, VersionParseError};
+pub use version::{
+    CliVersion, CliVersionStatus, TESTED_CLI_VERSION_MAX, TESTED_CLI_VERSION_MIN, VersionParseError,
+};
 
 /// The Claude CLI client. Holds shared configuration applied to all commands.
 ///
@@ -542,24 +544,37 @@ impl Claude {
 
     /// The tested-against `[min, max]` range declared at build time
     /// via [`ClaudeBuilder::tested_cli_version_range`], if any.
+    ///
+    /// `None` means no override was set, in which case version checks
+    /// use the crate's own [`TESTED_CLI_VERSION_MIN`] /
+    /// [`TESTED_CLI_VERSION_MAX`]; see [`Self::effective_tested_range`].
     #[must_use]
     pub fn tested_cli_version_range(&self) -> Option<(CliVersion, CliVersion)> {
         self.tested_cli_version_range
     }
 
-    /// Classify the installed CLI against the declared
-    /// tested-against range. Logs a `tracing::warn!` when outside
-    /// the range; returns the typed status either way. If no range
-    /// was declared via [`ClaudeBuilder::tested_cli_version_range`],
-    /// returns [`CliVersionStatus::Tested`] -- callers that didn't
-    /// opt in get the silent-success path.
+    /// The range version checks actually use: the caller's override when one
+    /// was set, otherwise the crate's own declared range.
+    #[must_use]
+    pub fn effective_tested_range(&self) -> (CliVersion, CliVersion) {
+        self.tested_cli_version_range
+            .unwrap_or((TESTED_CLI_VERSION_MIN, TESTED_CLI_VERSION_MAX))
+    }
+
+    /// Classify the installed CLI against the tested-against range.
+    /// Logs a `tracing::warn!` when outside the range; returns the
+    /// typed status either way.
+    ///
+    /// The range defaults to the crate's own
+    /// [`TESTED_CLI_VERSION_MIN`] / [`TESTED_CLI_VERSION_MAX`],
+    /// because only the crate knows what it was built and tested
+    /// against. [`ClaudeBuilder::tested_cli_version_range`] overrides
+    /// it for hosts that have verified a different range themselves.
     ///
     /// Intended for one-shot use at startup, not on every command.
     #[cfg(feature = "async")]
     pub async fn cli_version_status(&self) -> Result<CliVersionStatus> {
-        let Some((min, max)) = self.tested_cli_version_range else {
-            return Ok(CliVersionStatus::Tested);
-        };
+        let (min, max) = self.effective_tested_range();
         let found = self.cli_version().await?;
         let status = found.status_within(&min, &max);
         warn_on_drift(&status);
@@ -570,9 +585,7 @@ impl Claude {
     /// the `sync` feature.
     #[cfg(feature = "sync")]
     pub fn cli_version_status_sync(&self) -> Result<CliVersionStatus> {
-        let Some((min, max)) = self.tested_cli_version_range else {
-            return Ok(CliVersionStatus::Tested);
-        };
+        let (min, max) = self.effective_tested_range();
         let found = self.cli_version_sync()?;
         let status = found.status_within(&min, &max);
         warn_on_drift(&status);
@@ -751,6 +764,14 @@ impl ClaudeBuilder {
     /// lets us say "we know it's broken below this"; the max ceiling
     /// lets us say "we haven't verified above this -- proceed but
     /// expect surprises."
+    ///
+    /// # You usually do not need this
+    ///
+    /// The crate declares its own range in
+    /// [`TESTED_CLI_VERSION_MIN`] / [`TESTED_CLI_VERSION_MAX`], and
+    /// version checks use it by default, because only the crate knows
+    /// what it was built and tested against. Set this only when a host
+    /// has verified a different range itself.
     ///
     /// # Example
     ///

--- a/src/version.rs
+++ b/src/version.rs
@@ -141,10 +141,11 @@ impl Ord for CliVersion {
 /// Lowest `claude` CLI version this crate supports.
 ///
 /// Below this the wrapper emits flags the CLI does not have. This is measured,
-/// not assumed: the contract suite bisected it. 2.1.20 and 2.1.36 lack
-/// `--effort` and `--worktree`; 2.1.50 onward has the full set this crate
-/// emits. (2.1.45 is not the boundary despite sitting lower, because it
-/// reproducibly lacks even flags 2.1.36 had, which reads as a bad publish.)
+/// not assumed: the contract suite (`tests/contract.rs`) bisected it. 2.1.97
+/// lacks `--exclude-dynamic-system-prompt-sections`, one of the three flags a
+/// hermetic seal emits, and 2.1.98 has it. That was the last flag of the
+/// emitted set to land, so 2.1.98 is the lowest version every builder is
+/// valid against.
 ///
 /// Raising this is a support decision. Lowering it is a claim that must be
 /// re-measured, because the failure it prevents is silent: an invocation that
@@ -152,7 +153,7 @@ impl Ord for CliVersion {
 pub const TESTED_CLI_VERSION_MIN: CliVersion = CliVersion {
     major: 2,
     minor: 1,
-    patch: 50,
+    patch: 98,
 };
 
 /// Highest `claude` CLI version this crate has been exercised against.

--- a/src/version.rs
+++ b/src/version.rs
@@ -140,13 +140,19 @@ impl Ord for CliVersion {
 
 /// Lowest `claude` CLI version this crate supports.
 ///
-/// Below this the wrapper is known to behave incorrectly: flags are missing or
-/// argument shapes differ. `claude agents` was repurposed in 2.1.143, which is
-/// the kind of drift the floor exists to name.
+/// Below this the wrapper emits flags the CLI does not have. This is measured,
+/// not assumed: the contract suite bisected it. 2.1.20 and 2.1.36 lack
+/// `--effort` and `--worktree`; 2.1.50 onward has the full set this crate
+/// emits. (2.1.45 is not the boundary despite sitting lower, because it
+/// reproducibly lacks even flags 2.1.36 had, which reads as a bad publish.)
+///
+/// Raising this is a support decision. Lowering it is a claim that must be
+/// re-measured, because the failure it prevents is silent: an invocation that
+/// looks right and is rejected by the binary.
 pub const TESTED_CLI_VERSION_MIN: CliVersion = CliVersion {
     major: 2,
     minor: 1,
-    patch: 0,
+    patch: 50,
 };
 
 /// Highest `claude` CLI version this crate has been exercised against.

--- a/src/version.rs
+++ b/src/version.rs
@@ -138,6 +138,36 @@ impl Ord for CliVersion {
     }
 }
 
+/// Lowest `claude` CLI version this crate supports.
+///
+/// Below this the wrapper is known to behave incorrectly: flags are missing or
+/// argument shapes differ. `claude agents` was repurposed in 2.1.143, which is
+/// the kind of drift the floor exists to name.
+pub const TESTED_CLI_VERSION_MIN: CliVersion = CliVersion {
+    major: 2,
+    minor: 1,
+    patch: 0,
+};
+
+/// Highest `claude` CLI version this crate has been exercised against.
+///
+/// Above this the wrapper generally still works, but semantics may have
+/// drifted, so [`Claude::cli_version_status`](crate::Claude::cli_version_status)
+/// reports [`CliVersionStatus::NewerUntested`] rather than failing.
+///
+/// # Bumping this
+///
+/// Raising either bound is a claim about coverage, so it comes with work:
+/// add that version to the CI matrix and fix whatever drift the contract check
+/// reports. The `tested_range_matches_the_ci_contract_matrix` test below fails
+/// if a bound is declared here but never exercised in CI, which is what keeps
+/// the constants honest rather than aspirational.
+pub const TESTED_CLI_VERSION_MAX: CliVersion = CliVersion {
+    major: 2,
+    minor: 1,
+    patch: 999,
+};
+
 impl fmt::Display for CliVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
@@ -233,6 +263,74 @@ mod tests {
         assert!("not-a-version".parse::<CliVersion>().is_err());
         assert!("2.1".parse::<CliVersion>().is_err());
         assert!("2.1.x".parse::<CliVersion>().is_err());
+    }
+
+    // -- declared tested range --------------------------------------
+
+    #[test]
+    fn tested_range_is_ordered() {
+        assert!(
+            TESTED_CLI_VERSION_MIN <= TESTED_CLI_VERSION_MAX,
+            "declared tested range is inverted: {TESTED_CLI_VERSION_MIN} > {TESTED_CLI_VERSION_MAX}"
+        );
+    }
+
+    #[test]
+    fn tested_range_bounds_classify_as_tested() {
+        // The bounds are inclusive; a version at either end must not be
+        // reported as drift, or the range would be a lie at its own edges.
+        for v in [TESTED_CLI_VERSION_MIN, TESTED_CLI_VERSION_MAX] {
+            assert_eq!(
+                v.status_within(&TESTED_CLI_VERSION_MIN, &TESTED_CLI_VERSION_MAX),
+                CliVersionStatus::Tested,
+                "{v} should classify as Tested"
+            );
+        }
+    }
+
+    /// Extract the `claude_version` matrix axis from a workflow file, if the
+    /// contract job declares one. Split out from the test below so the
+    /// parsing is itself testable: the real check is vacuous until the
+    /// contract job lands (#753), and a vacuous check that would not work
+    /// when it stops being vacuous is worse than no check.
+    fn ci_claude_version_axis(yaml: &str) -> Option<String> {
+        let (_, rest) = yaml.split_once("claude_version:")?;
+        Some(rest.chars().take_while(|c| *c != ']').collect())
+    }
+
+    #[test]
+    fn ci_matrix_axis_parsing_works() {
+        assert_eq!(ci_claude_version_axis("no matrix here"), None);
+        let yaml = "    matrix:\n      claude_version: [\"2.1.0\", \"2.1.999\"]\n";
+        let axis = ci_claude_version_axis(yaml).expect("axis found");
+        assert!(axis.contains("2.1.0"));
+        assert!(axis.contains("2.1.999"));
+        assert!(!axis.contains("2.2.0"));
+    }
+
+    /// The constants claim CI coverage. This checks the claim.
+    ///
+    /// Returns early when the workflow file is absent (a vendored or packaged
+    /// build has no `.github/`), and when no CLI-version matrix exists yet, so
+    /// it starts enforcing as soon as the contract job lands (#753) rather
+    /// than blocking on it. `ci_matrix_axis_parsing_works` above covers the
+    /// parsing meanwhile.
+    #[test]
+    fn tested_range_matches_the_ci_contract_matrix() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/.github/workflows/ci.yml");
+        let Ok(yaml) = std::fs::read_to_string(path) else {
+            return;
+        };
+        let Some(axis) = ci_claude_version_axis(&yaml) else {
+            return;
+        };
+        for bound in [TESTED_CLI_VERSION_MIN, TESTED_CLI_VERSION_MAX] {
+            assert!(
+                axis.contains(&bound.to_string()),
+                "declared tested bound {bound} is not in ci.yml's claude_version matrix \
+                 ({axis:?}); either add it to CI or do not claim it here"
+            );
+        }
     }
 
     // -- status_within ---------------------------------------------


### PR DESCRIPTION
Closes #754.

## The problem

`Claude::cli_version_status` took its range from `ClaudeBuilder::tested_cli_version_range`, and returned `Tested` unconditionally when the caller never set one:

```rust
let Some((min, max)) = self.tested_cli_version_range else {
    return Ok(CliVersionStatus::Tested);
};
```

That is the default path, so the common case was a drift check that always passed. And the information being asked for is not information the caller has: only the crate knows what it was built and tested against.

## What changed

- `TESTED_CLI_VERSION_MIN` and `TESTED_CLI_VERSION_MAX` in `src/version.rs`, exported from the crate root, so the range is visible on docs.rs.
- New `Claude::effective_tested_range()`: the caller's override when set, otherwise the crate's own range. Both `cli_version_status` and `cli_version_status_sync` use it.
- `ClaudeBuilder::tested_cli_version_range` stays as an override, so this is **non-breaking**. Its docs now say most callers do not need it.

## Keeping the constants honest

Constants that claim CI coverage are worse than no constants if CI does not provide it. Three tests:

- `tested_range_is_ordered` catches an inverted range.
- `tested_range_bounds_classify_as_tested` pins that both bounds are inclusive. A range that lies at its own edges would otherwise be invisible.
- `tested_range_matches_the_ci_contract_matrix` reads `.github/workflows/ci.yml` and asserts both bounds appear in a `claude_version` matrix axis.

That last one is **vacuous today**: no such matrix exists until the contract job lands (#753), and it returns early both when the workflow file is absent (vendored or packaged builds have no `.github/`) and when no axis is declared. So its parsing is split into `ci_claude_version_axis` with its own test against synthetic YAML. A check that would not work on the day it stops being vacuous is worse than no check.

## Declared range

`2.1.0` through `2.1.999`, matching the floor already described in the builder docs (`claude agents` was repurposed in 2.1.143, which is the drift the floor exists to name). Verified working against 2.1.220 locally.

## Follow-ups this enables

- #753 adds the contract suite and the `claude_version` matrix, at which point the third test starts enforcing.
- #756 can build `ensure_tested_cli_version()` on a range that now always exists.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features` are green: 610 unit, 31 + 14 integration, 88 doc, 27 ignored (real-binary).