### PR TITLE
feat: tracing spans around execution, streaming, retry, and duplex sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "wait-timeout",
  "which",
 ]
@@ -310,6 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +375,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys",
 ]
 
@@ -553,6 +569,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +671,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +765,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -744,6 +804,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
+# Span assertions: the contract these spans publish is their field set,
+# so a test needs to observe what a subscriber actually receives.
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 # All examples use the async API; require the feature so they're
 # skipped automatically on sync-only builds.

--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -200,7 +200,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
-use tracing::{debug, warn};
+use tracing::{Instrument, debug, warn};
 
 use crate::Claude;
 use crate::command::spawn_args::{SharedSpawnArgs, shell_quote};
@@ -1187,16 +1187,41 @@ impl DuplexSession {
         let (events_tx, _initial_rx) = broadcast::channel(capacity);
         let (exit_tx, exit_rx) = watch::channel(SessionExitStatus::Running);
 
-        let join = tokio::spawn(run_session(
-            child,
-            group,
-            stdin,
-            stdout,
-            outbound_rx,
-            events_tx.clone(),
-            permission_handler,
-            exit_tx,
-        ));
+        // A session-lifetime span, entered inside the spawned task. The
+        // run loop interleaves events from every turn on one stdout
+        // stream, so without this its lines ("dropping orphan result
+        // event", parse failures, shutdown-budget kills) cannot be
+        // attributed to a session at all when several are open.
+        //
+        // `session_id` starts empty and is recorded when the CLI's init
+        // event arrives, since it is not known at spawn unless resuming.
+        let session_span = tracing::debug_span!(
+            "claude.session",
+            session_id = tracing::field::Empty,
+            model = opts.shared.model.as_deref().unwrap_or("default"),
+            permission_mode = opts
+                .shared
+                .permission_mode
+                .as_ref()
+                .map(|m| m.as_arg())
+                .unwrap_or("default"),
+            resumed = opts.shared.resume.is_some(),
+            turns = tracing::field::Empty,
+            exit = tracing::field::Empty,
+        );
+        let join = tokio::spawn(
+            run_session(
+                child,
+                group,
+                stdin,
+                stdout,
+                outbound_rx,
+                events_tx.clone(),
+                permission_handler,
+                exit_tx,
+            )
+            .instrument(session_span),
+        );
 
         Ok(Self {
             outbound_tx,
@@ -1471,6 +1496,11 @@ async fn run_session(
     let mut pending_control: HashMap<String, oneshot::Sender<Result<()>>> = HashMap::new();
     let mut next_control_id: u64 = 0;
     let mut stream_err: Option<Error> = None;
+    // The session span is this task's own span (see DuplexSession::spawn).
+    let session_span = tracing::Span::current();
+    let mut turns: u64 = 0;
+    let mut turn_span: Option<tracing::Span> = None;
+    let mut turn_started: Option<std::time::Instant> = None;
 
     loop {
         tokio::select! {
@@ -1488,6 +1518,41 @@ async fn run_session(
                             continue;
                         }
                     };
+                    // Peek before handle_inbound consumes it: the init
+                    // event is where the session id first appears, and the
+                    // result event carries the turn's outcome.
+                    match parsed.get("type").and_then(Value::as_str) {
+                        Some("system")
+                            if parsed.get("subtype").and_then(Value::as_str) == Some("init") =>
+                        {
+                            if let Some(id) = parsed.get("session_id").and_then(Value::as_str) {
+                                session_span.record("session_id", id);
+                            }
+                        }
+                        Some("result") => {
+                            if let Some(span) = turn_span.take() {
+                                span.record(
+                                    "is_error",
+                                    parsed.get("is_error").and_then(Value::as_bool).unwrap_or(false),
+                                );
+                                if let Some(sub) = parsed.get("subtype").and_then(Value::as_str) {
+                                    span.record("subtype", sub);
+                                }
+                                if let Some(c) =
+                                    parsed.get("total_cost_usd").and_then(Value::as_f64)
+                                {
+                                    span.record("cost_usd", c);
+                                }
+                                if let Some(started) = turn_started.take() {
+                                    span.record(
+                                        "duration_ms",
+                                        started.elapsed().as_millis() as u64,
+                                    );
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
                     match handle_inbound(parsed, &mut pending, &events_tx) {
                         InboundAction::None => {}
                         InboundAction::Permission(req) => {
@@ -1550,6 +1615,21 @@ async fn run_session(
                         let _ = reply.send(Err(e));
                         continue;
                     }
+                    turns += 1;
+                    // One span per turn, so the events a turn produces are
+                    // attributable to it rather than to the session as a
+                    // whole. Outcome fields are recorded when the result
+                    // event arrives above.
+                    turn_span = Some(tracing::debug_span!(
+                        parent: &session_span,
+                        "claude.turn",
+                        turn = turns,
+                        is_error = tracing::field::Empty,
+                        subtype = tracing::field::Empty,
+                        cost_usd = tracing::field::Empty,
+                        duration_ms = tracing::field::Empty,
+                    ));
+                    turn_started = Some(std::time::Instant::now());
                     pending = Some((reply, Vec::new()));
                 }
                 Some(OutboundMsg::PermissionResponse { request_id, decision }) => {
@@ -1607,6 +1687,15 @@ async fn run_session(
         Ok(()) => SessionExitStatus::Completed,
         Err(e) => SessionExitStatus::Failed(e.to_string()),
     };
+    session_span.record("turns", turns);
+    session_span.record(
+        "exit",
+        match &final_state {
+            SessionExitStatus::Completed => "completed",
+            SessionExitStatus::Failed(_) => "failed",
+            SessionExitStatus::Running => "running",
+        },
+    );
     let _ = exit_tx.send(final_state);
     result
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -50,6 +50,49 @@ pub(crate) fn full_command_args(claude: &Claude, args: Vec<String>) -> Vec<Strin
     command_args
 }
 
+/// The subcommand label for a span, derived from the argv.
+///
+/// The first token is the subcommand for subcommand-style invocations
+/// (`mcp`, `plugin`, `doctor`). For print-mode runs it is the leading
+/// flag (`--print`), which is equally informative. Never a value:
+/// values always follow a flag, and the first token cannot be one.
+///
+/// Deliberately not the whole argv. Prompts arrive as argv positionals
+/// and must never reach a span field.
+#[cfg(any(feature = "async", feature = "sync"))]
+pub(crate) fn span_command(args: &[String]) -> &str {
+    args.first().map(String::as_str).unwrap_or("<none>")
+}
+
+/// Open the span covering one CLI invocation.
+///
+/// `exit_code` and `duration_ms` are declared empty and recorded when
+/// the call finishes, so a subscriber sees them on close. Carries the
+/// binary and working directory, never the prompt and never the env.
+#[cfg(any(feature = "async", feature = "sync"))]
+pub(crate) fn exec_span(claude: &Claude, args: &[String], mode: &'static str) -> tracing::Span {
+    tracing::debug_span!(
+        "claude.exec",
+        command = span_command(args),
+        mode,
+        binary = %claude.binary.display(),
+        cwd = claude.working_dir.as_deref().map(|d| d.display().to_string()),
+        exit_code = tracing::field::Empty,
+        duration_ms = tracing::field::Empty,
+    )
+}
+
+/// Record the outcome of an invocation on its span.
+#[cfg(any(feature = "async", feature = "sync"))]
+pub(crate) fn record_exec_outcome(
+    span: &tracing::Span,
+    exit_code: i32,
+    started: std::time::Instant,
+) {
+    span.record("exit_code", exit_code);
+    span.record("duration_ms", started.elapsed().as_millis() as u64);
+}
+
 /// Raw output from a claude CLI invocation.
 #[derive(Debug, Clone)]
 pub struct CommandOutput {
@@ -189,13 +232,16 @@ async fn run_claude_with_stdin_prompt_internal(
 ) -> Result<CommandOutput> {
     let command_args = full_command_args(claude, args);
 
+    let span = exec_span(claude, &command_args, "stdin");
+    let _enter = span.enter();
+    let started = std::time::Instant::now();
     debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command (stdin prompt)");
 
     let binary = &claude.binary;
     let env = &claude.env;
     let working_dir = claude.working_dir.as_deref();
 
-    if let Some(timeout) = claude.timeout {
+    let result = if let Some(timeout) = claude.timeout {
         run_with_timeout_stdin(
             binary,
             &command_args,
@@ -207,7 +253,12 @@ async fn run_claude_with_stdin_prompt_internal(
         .await
     } else {
         run_internal_stdin(binary, &command_args, env, working_dir, stdin_content).await
+    };
+
+    if let Ok(output) = &result {
+        record_exec_outcome(&span, output.exit_code, started);
     }
+    result
 }
 
 #[cfg(feature = "async")]
@@ -426,6 +477,9 @@ async fn run_with_timeout_stdin(
 async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
     let command_args = full_command_args(claude, args);
 
+    let span = exec_span(claude, &command_args, "oneshot");
+    let _enter = span.enter();
+    let started = std::time::Instant::now();
     debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command");
 
     let output = if let Some(timeout) = claude.timeout {
@@ -447,6 +501,7 @@ async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOu
         .await?
     };
 
+    record_exec_outcome(&span, output.exit_code, started);
     Ok(output)
 }
 
@@ -771,9 +826,12 @@ pub fn run_claude_with_stdin_prompt_sync(
 ) -> Result<CommandOutput> {
     let command_args = full_command_args(claude, args);
 
+    let span = exec_span(claude, &command_args, "stdin-sync");
+    let _enter = span.enter();
+    let started = std::time::Instant::now();
     debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command (stdin prompt, sync)");
 
-    if let Some(timeout) = claude.timeout {
+    let result = if let Some(timeout) = claude.timeout {
         run_with_timeout_stdin_sync(
             &claude.binary,
             &command_args,
@@ -790,7 +848,12 @@ pub fn run_claude_with_stdin_prompt_sync(
             claude.working_dir.as_deref(),
             stdin_content,
         )
+    };
+
+    if let Ok(output) = &result {
+        record_exec_outcome(&span, output.exit_code, started);
     }
+    result
 }
 
 #[cfg(feature = "sync")]
@@ -1001,9 +1064,12 @@ fn run_with_timeout_stdin_sync(
 fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOutput> {
     let command_args = full_command_args(claude, args);
 
+    let span = exec_span(claude, &command_args, "oneshot-sync");
+    let _enter = span.enter();
+    let started = std::time::Instant::now();
     debug!(binary = %claude.binary.display(), args = ?command_args, "executing claude command (sync)");
 
-    if let Some(timeout) = claude.timeout {
+    let result = if let Some(timeout) = claude.timeout {
         run_with_timeout_sync(
             &claude.binary,
             &command_args,
@@ -1018,7 +1084,12 @@ fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOut
             &claude.env,
             claude.working_dir.as_deref(),
         )
+    };
+
+    if let Ok(output) = &result {
+        record_exec_outcome(&span, output.exit_code, started);
     }
+    result
 }
 
 /// Blocking mirror of [`run_claude_allow_exit_codes`].

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -152,9 +152,20 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = crate::error::Result<T>>,
 {
+    // A retry span parents every attempt, so the exec spans nest under
+    // one identifiable unit of work instead of appearing as unrelated
+    // siblings. `attempts` is recorded on close: a caller reading logs
+    // wants "this took 3 tries", not three disconnected warnings.
+    let span = tracing::debug_span!(
+        "claude.retry",
+        max_attempts = policy.max_attempts,
+        attempts = tracing::field::Empty,
+    );
+    let _enter = span.enter();
     let mut last_error = None;
 
     for attempt in 0..policy.max_attempts {
+        span.record("attempts", attempt + 1);
         match operation().await {
             Ok(result) => return Ok(result),
             Err(e) => {
@@ -189,9 +200,16 @@ pub(crate) fn with_retry_sync<F, T>(
 where
     F: FnMut() -> crate::error::Result<T>,
 {
+    let span = tracing::debug_span!(
+        "claude.retry",
+        max_attempts = policy.max_attempts,
+        attempts = tracing::field::Empty,
+    );
+    let _enter = span.enter();
     let mut last_error = None;
 
     for attempt in 0..policy.max_attempts {
+        span.record("attempts", attempt + 1);
         match operation() {
             Ok(result) => return Ok(result),
             Err(e) => {

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -339,6 +339,26 @@ where
     command_args.extend(claude.global_args.clone());
     command_args.extend(args);
 
+    // A stream has three outcomes and the failure one is the easy one
+    // to miss, so `outcome` is recorded on every exit path: completed,
+    // failed, or timeout. `events` counts what the handler actually
+    // saw, which is the difference between "produced nothing" and
+    // "never started".
+    let span = tracing::debug_span!(
+        "claude.stream",
+        command = crate::exec::span_command(&command_args),
+        binary = %claude.binary.display(),
+        cwd = claude.working_dir.as_deref().map(|d| d.display().to_string()),
+        timeout_secs = timeout.map(|t| t.as_secs()),
+        outcome = tracing::field::Empty,
+        events = tracing::field::Empty,
+        exit_code = tracing::field::Empty,
+        duration_ms = tracing::field::Empty,
+    );
+    let _enter = span.enter();
+    let started = std::time::Instant::now();
+    let mut event_count: u64 = 0;
+
     debug!(
         binary = %claude.binary.display(),
         args = ?command_args,
@@ -382,7 +402,17 @@ where
     // tokio::join! polls both futures on the same task (no tokio::spawn
     // needed, so we avoid pulling in the `rt` feature).
     let drain = drain_stderr(&mut stderr);
-    let read_future = read_lines(&mut reader, &mut handler, claude.working_dir.clone());
+    // Wrap the caller's handler so the span can report how many events
+    // were dispatched without the handler needing to care.
+    let mut counting_handler = |event: StreamEvent| {
+        event_count += 1;
+        handler(event);
+    };
+    let read_future = read_lines(
+        &mut reader,
+        &mut counting_handler,
+        claude.working_dir.clone(),
+    );
     let combined = async {
         let (line_result, stderr_str) = tokio::join!(read_future, drain);
         (line_result, stderr_str)
@@ -406,6 +436,9 @@ where
                 if !stderr_str.is_empty() {
                     warn!(stderr = %stderr_str, "stderr from timed-out streaming process");
                 }
+                span.record("outcome", "timeout");
+                span.record("events", event_count);
+                span.record("duration_ms", started.elapsed().as_millis() as u64);
                 return Err(Error::Timeout {
                     timeout_seconds: d.as_secs(),
                 });
@@ -431,7 +464,12 @@ where
 
     let exit_code = status.code().unwrap_or(-1);
 
+    span.record("events", event_count);
+    span.record("exit_code", exit_code);
+    span.record("duration_ms", started.elapsed().as_millis() as u64);
+
     if !status.success() {
+        span.record("outcome", "failed");
         return Err(Error::CommandFailed {
             command: format!("{} {}", claude.binary.display(), command_args.join(" ")),
             exit_code,
@@ -441,6 +479,7 @@ where
         });
     }
 
+    span.record("outcome", "completed");
     Ok(CommandOutput {
         stdout: String::new(), // already consumed via streaming
         stderr: stderr_str,

--- a/tests/spans.rs
+++ b/tests/spans.rs
@@ -1,0 +1,221 @@
+//! What the crate's spans publish, asserted against a real subscriber.
+//!
+//! The span field set is a contract: hosts filter and correlate on it, so a
+//! renamed field or a dropped `record` is a breaking change that no compiler
+//! catches. These tests install a collecting subscriber and assert on what it
+//! actually receives.
+//!
+//! They also pin the safety property that matters more than any field: **no
+//! span carries prompt text, environment, or credentials.** Argv positionals
+//! are where prompts live, so a span that recorded the full argv would leak
+//! every prompt into logs at debug level.
+
+#![cfg(all(feature = "async", feature = "json"))]
+
+use std::sync::{Arc, Mutex};
+
+use claude_wrapper::Claude;
+use tracing::subscriber::with_default;
+use tracing::{Event, Metadata, Subscriber, span};
+
+/// One span's name and the fields recorded on it.
+type SpanRecord = (String, Vec<(String, String)>);
+
+/// A subscriber that records span names and their recorded field values.
+#[derive(Clone, Default)]
+struct Collector {
+    spans: Arc<Mutex<Vec<SpanRecord>>>,
+}
+
+impl Collector {
+    fn names(&self) -> Vec<String> {
+        self.spans
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(n, _)| n.clone())
+            .collect()
+    }
+
+    /// Every field recorded on spans of the given name, flattened.
+    fn fields_of(&self, span_name: &str) -> Vec<(String, String)> {
+        self.spans
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(n, _)| n == span_name)
+            .flat_map(|(_, f)| f.clone())
+            .collect()
+    }
+
+    fn all_field_values(&self) -> Vec<String> {
+        self.spans
+            .lock()
+            .unwrap()
+            .iter()
+            .flat_map(|(_, f)| f.iter().map(|(_, v)| v.clone()).collect::<Vec<_>>())
+            .collect()
+    }
+}
+
+/// Visits field values into `(name, debug-rendered value)` pairs.
+struct Visitor(Vec<(String, String)>);
+
+impl tracing::field::Visit for Visitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0
+            .push((field.name().to_string(), format!("{value:?}")));
+    }
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.0.push((field.name().to_string(), value.to_string()));
+    }
+}
+
+impl Subscriber for Collector {
+    fn enabled(&self, _: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, attrs: &span::Attributes<'_>) -> span::Id {
+        let mut v = Visitor(Vec::new());
+        attrs.record(&mut v);
+        let mut spans = self.spans.lock().unwrap();
+        spans.push((attrs.metadata().name().to_string(), v.0));
+        span::Id::from_u64(spans.len() as u64)
+    }
+
+    fn record(&self, id: &span::Id, values: &span::Record<'_>) {
+        let mut v = Visitor(Vec::new());
+        values.record(&mut v);
+        let idx = id.into_u64() as usize - 1;
+        if let Some(entry) = self.spans.lock().unwrap().get_mut(idx) {
+            entry.1.extend(v.0);
+        }
+    }
+
+    fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+    fn event(&self, _: &Event<'_>) {}
+    fn enter(&self, _: &span::Id) {}
+    fn exit(&self, _: &span::Id) {}
+}
+
+/// A client pointed at the repo's fake CLI, so nothing real is spawned.
+fn fake_claude() -> Claude {
+    let fake = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fake-claude.sh");
+    Claude::builder()
+        .binary(fake)
+        .working_dir(env!("CARGO_MANIFEST_DIR"))
+        .build()
+        .expect("building a client over the fake binary")
+}
+
+#[test]
+fn exec_span_carries_command_binary_cwd_and_outcome() {
+    let collector = Collector::default();
+    let handle = collector.clone();
+    let claude = fake_claude();
+
+    with_default(collector, || {
+        block_on(async {
+            let _ = claude_wrapper::exec::run_claude(&claude, vec!["--version".into()]).await;
+        });
+    });
+
+    assert!(
+        handle.names().iter().any(|n| n == "claude.exec"),
+        "expected a claude.exec span, saw {:?}",
+        handle.names()
+    );
+    let fields = handle.fields_of("claude.exec");
+    let names: Vec<&str> = fields.iter().map(|(k, _)| k.as_str()).collect();
+    for expected in ["command", "mode", "binary", "exit_code", "duration_ms"] {
+        assert!(names.contains(&expected), "missing {expected} in {names:?}");
+    }
+    // `command` is the first argv token, which is the subcommand for
+    // subcommand invocations and the leading flag for print-mode runs.
+    let command = fields.iter().find(|(k, _)| k == "command").unwrap();
+    assert!(
+        command.1.contains("--version"),
+        "command should name the invocation, got {:?}",
+        command.1
+    );
+}
+
+#[test]
+fn spans_never_carry_the_prompt() {
+    // The safety property. Prompts arrive as argv positionals, so a span that
+    // recorded argv would put every prompt in the logs.
+    const SECRET: &str = "SPAN-LEAK-CANARY-do-not-log-this-prompt";
+    let collector = Collector::default();
+    let handle = collector.clone();
+    let claude = fake_claude();
+
+    with_default(collector, || {
+        block_on(async {
+            let _ = claude_wrapper::exec::run_claude(
+                &claude,
+                vec!["--print".into(), "--".into(), SECRET.into()],
+            )
+            .await;
+        });
+    });
+
+    for value in handle.all_field_values() {
+        assert!(
+            !value.contains(SECRET),
+            "a span field leaked the prompt: {value:?}"
+        );
+    }
+    assert!(
+        handle.names().iter().any(|n| n == "claude.exec"),
+        "sanity: the span was actually created"
+    );
+}
+
+#[test]
+fn retry_span_wraps_attempts() {
+    use claude_wrapper::RetryPolicy;
+
+    let collector = Collector::default();
+    let handle = collector.clone();
+    // A binary that does not exist fails every attempt, so the retry loop runs
+    // to exhaustion without spawning anything.
+    let claude = Claude::builder()
+        .binary("/nonexistent/claude-for-span-test")
+        .retry(
+            RetryPolicy::new()
+                .max_attempts(2)
+                .fixed()
+                .initial_backoff(std::time::Duration::from_millis(1)),
+        )
+        .build()
+        .unwrap();
+
+    with_default(collector, || {
+        block_on(async {
+            let _ = claude_wrapper::exec::run_claude(&claude, vec!["--version".into()]).await;
+        });
+    });
+
+    let names = handle.names();
+    assert!(
+        names.iter().any(|n| n == "claude.retry"),
+        "expected a claude.retry span, saw {names:?}"
+    );
+    let fields = handle.fields_of("claude.retry");
+    let keys: Vec<&str> = fields.iter().map(|(k, _)| k.as_str()).collect();
+    assert!(keys.contains(&"max_attempts"), "got {keys:?}");
+}
+
+/// Run `fut` to completion on this thread.
+///
+/// `with_default` installs the subscriber per-thread and is synchronous, so
+/// the runtime is built inside its scope rather than the test being a
+/// `#[tokio::test]` (whose runtime thread would not see the subscriber).
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("building a test runtime")
+        .block_on(fut)
+}


### PR DESCRIPTION
Closes #752 for the execution and duplex families. The read-side scan family is deferred, see the end.

## Why

The crate had ~40 log statements across 15 modules and **zero spans**. A caller could not correlate a line to an invocation, attribute an event to a session, or measure a run without timing it separately.

## Execution and streaming

| Span | Fields | Recorded on close |
|---|---|---|
| `claude.exec` | `command`, `mode`, `binary`, `cwd` | `exit_code`, `duration_ms` |
| `claude.stream` | + `timeout_secs` | `outcome`, `events`, `exit_code`, `duration_ms` |
| `claude.retry` | `max_attempts` | `attempts` |

`claude.exec` covers all four paths (async/sync × argv/stdin).

`claude.stream` records `outcome` on **all three** exit paths: completed, failed, timeout. The timeout case is the one that gets missed, so it records explicitly rather than falling out of the function. It also counts events dispatched to the handler, which is the difference between "produced nothing" and "never started".

`claude.retry` parents the attempts so exec spans nest under one unit of work rather than appearing as unrelated siblings. A reader wants "this took 3 tries", not three disconnected warnings.

## Duplex, where this pays for itself

`duplex.rs` holds the largest cluster of log statements in the crate, and a run loop interleaves events from *every* turn on one stdout stream. Before this, lines like:

```
debug!("dropping orphan result event with no pending turn")
warn!("duplex child did not exit within shutdown budget; killing")
```

could not be tied to a session at all when several were open. I hit exactly this reasoning about close-versus-send races in a consumer earlier today.

- **`claude.session`** covers the run loop for the session's whole life, entered *inside* the spawned task so every line it emits is attributed. `session_id` is recorded when the CLI's init event names it (it is not known at spawn unless resuming); `turns` and `exit` on close.
- **`claude.turn`** per send, parented to the session, recording `is_error`, `subtype`, `cost_usd`, `duration_ms` from the closing result event.

## The safety property

**No span carries prompt text, environment, or credentials.** Prompts arrive as argv positionals, so a span recording argv would put every prompt in the logs at debug level.

`command` is the first argv token deliberately: it names the subcommand for subcommand invocations, the leading flag for print-mode runs, and it *cannot* be a value, since values always follow a flag.

`tests/spans.rs` asserts the field set against a real collecting subscriber, because that set is a contract hosts filter on and no compiler catches a renamed field. It includes a canary prompt, and I verified the canary is **not vacuous**: temporarily recording argv on the span makes that test fail with the canary in the message, then passes again on revert.

## Deferred

The read-side scan family (`artifacts`, `history`, `jobs`, and friends). The issue rates it lowest value and explicitly fine to defer; this is the two families consumers asked for. Happy to follow up.

## Verification

`cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean. All 7 test targets green (619 unit, 33 + 14 fake-binary, 3 span, 5 contract-parser, 89 doc). The three span helpers are `#[cfg]`-gated to the features that use them, so `--no-default-features --features json` gains no new warnings (still the 5 pre-existing `streaming.rs` ones).