### PR TITLE
feat(session): TokenUsage type and per-turn token accounting

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1775,7 +1775,10 @@ mod tests {
         std::fs::read_to_string(path).ok()?.trim().parse().ok()
     }
 
-    /// Read a pid recorded by `group_script`.
+    /// Read a pid recorded by `group_script`. Only the async tests use
+    /// this unconditional variant; the sync timeout test reads through
+    /// `try_read_pid`, so gate it to keep sync-only builds warning-free.
+    #[cfg(feature = "async")]
     fn read_pid(path: &std::path::Path) -> u32 {
         try_read_pid(path).expect("pid file readable")
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -265,6 +265,31 @@ impl Session {
         self.cumulative_turns
     }
 
+    /// Cumulative token count across all recorded turns, summing every
+    /// bucket the CLI reported (cache and non-cache input both count;
+    /// see [`TokenUsage::total`](crate::TokenUsage::total)).
+    ///
+    /// Turns whose result carried no usage contribute nothing here.
+    /// Check [`turns_missing_usage`](Self::turns_missing_usage) to tell
+    /// a genuinely low total from an incomplete one.
+    pub fn total_tokens(&self) -> u64 {
+        self.history
+            .iter()
+            .filter_map(|r| r.usage.as_ref())
+            .map(crate::TokenUsage::total)
+            .sum()
+    }
+
+    /// Number of recorded turns whose result carried no usage at all
+    /// (no `usage` object, or one with every bucket absent). A non-zero
+    /// value means [`total_tokens`](Self::total_tokens) undercounts.
+    pub fn turns_missing_usage(&self) -> usize {
+        self.history
+            .iter()
+            .filter(|r| r.usage.as_ref().is_none_or(crate::TokenUsage::is_empty))
+            .count()
+    }
+
     /// Full per-turn result history.
     pub fn history(&self) -> &[QueryResult] {
         &self.history
@@ -328,6 +353,7 @@ mod tests {
             duration_ms: None,
             num_turns: Some(3),
             is_error: false,
+            usage: None,
             extra: Default::default(),
         };
         session.record(&result);
@@ -351,6 +377,7 @@ mod tests {
             duration_ms: None,
             num_turns: Some(2),
             is_error: false,
+            usage: None,
             extra: Default::default(),
         };
         let r2 = QueryResult {
@@ -360,6 +387,7 @@ mod tests {
             duration_ms: None,
             num_turns: Some(1),
             is_error: false,
+            usage: None,
             extra: Default::default(),
         };
         session.record(&r1);
@@ -367,6 +395,50 @@ mod tests {
         assert_eq!(session.total_turns(), 3);
         assert!((session.total_cost_usd() - 0.03).abs() < f64::EPSILON);
         assert_eq!(session.history().len(), 2);
+    }
+
+    #[test]
+    fn token_accounting_sums_and_flags_missing() {
+        use crate::TokenUsage;
+
+        let mut session = Session::new(test_claude());
+        let with_usage = QueryResult {
+            result: "a".into(),
+            session_id: "sess-1".into(),
+            cost_usd: Some(0.01),
+            duration_ms: None,
+            num_turns: Some(1),
+            is_error: false,
+            usage: Some(TokenUsage {
+                input_tokens: Some(100),
+                output_tokens: Some(25),
+                ..Default::default()
+            }),
+            extra: Default::default(),
+        };
+        let without_usage = QueryResult {
+            result: "b".into(),
+            session_id: "sess-1".into(),
+            cost_usd: Some(0.01),
+            duration_ms: None,
+            num_turns: Some(1),
+            is_error: false,
+            usage: None,
+            extra: Default::default(),
+        };
+        // A usage object with every bucket absent counts as missing,
+        // not as a zero-token turn.
+        let empty_usage = QueryResult {
+            usage: Some(TokenUsage::default()),
+            ..without_usage.clone()
+        };
+
+        session.record(&with_usage);
+        session.record(&without_usage);
+        session.record(&empty_usage);
+
+        assert_eq!(session.total_tokens(), 125);
+        assert_eq!(session.turns_missing_usage(), 2);
     }
 
     #[test]
@@ -383,6 +455,7 @@ mod tests {
             duration_ms: None,
             num_turns: Some(1),
             is_error: false,
+            usage: None,
             extra: Default::default(),
         };
         session.record(&r);

--- a/src/types.rs
+++ b/src/types.rs
@@ -338,6 +338,71 @@ pub struct QueryMessage {
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
+/// Token usage reported by the CLI for a single run.
+///
+/// Field names align with `codex-wrapper`'s `TokenUsage` so an adapter
+/// can map the two directly (see the cross-crate design in issue #760).
+/// Serde aliases accept the Anthropic key names the CLI actually emits
+/// (`cache_read_input_tokens`, `cache_creation_input_tokens`), the same
+/// keys the on-disk history accounting reads, so the live and read-side
+/// paths agree.
+///
+/// Every field is `Option` because the CLI does not report all buckets
+/// on every turn. A missing bucket means "not reported", not zero;
+/// [`Session::turns_missing_usage`](crate::Session::turns_missing_usage)
+/// exists so callers can tell a low total from an incomplete one.
+#[cfg(feature = "json")]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct TokenUsage {
+    /// Non-cached input tokens.
+    #[serde(default)]
+    pub input_tokens: Option<u64>,
+    /// Input tokens served from cache.
+    #[serde(default, alias = "cache_read_input_tokens")]
+    pub cached_input_tokens: Option<u64>,
+    /// Input tokens written to cache.
+    #[serde(default, alias = "cache_creation_input_tokens")]
+    pub cache_write_input_tokens: Option<u64>,
+    /// Output tokens.
+    #[serde(default)]
+    pub output_tokens: Option<u64>,
+    /// Output tokens spent on reasoning, where the CLI reports them
+    /// separately.
+    #[serde(default)]
+    pub reasoning_output_tokens: Option<u64>,
+    /// Explicit total, where the CLI reports one.
+    #[serde(default)]
+    pub total_tokens: Option<u64>,
+}
+
+#[cfg(feature = "json")]
+impl TokenUsage {
+    /// Total tokens for this run: the explicit `total_tokens` if the
+    /// CLI reported one, otherwise the sum of every reported bucket.
+    /// Cache and non-cache input both count, mirroring the on-disk
+    /// accounting in the history module.
+    pub fn total(&self) -> u64 {
+        if let Some(t) = self.total_tokens {
+            return t;
+        }
+        [
+            self.input_tokens,
+            self.cached_input_tokens,
+            self.cache_write_input_tokens,
+            self.output_tokens,
+            self.reasoning_output_tokens,
+        ]
+        .iter()
+        .flatten()
+        .sum()
+    }
+
+    /// True when the CLI reported no usage buckets at all.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 /// Result from a query with `--output-format json`.
 #[cfg(feature = "json")]
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -360,6 +425,10 @@ pub struct QueryResult {
     /// Whether the query resulted in an error.
     #[serde(default)]
     pub is_error: bool,
+    /// Token usage for this run, when the CLI reports it on the result
+    /// event.
+    #[serde(default)]
+    pub usage: Option<TokenUsage>,
     /// Additional fields returned by the CLI not captured in typed fields.
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
@@ -425,10 +494,58 @@ mod tests {
             duration_ms: None,
             num_turns: Some(3),
             is_error: false,
+            usage: None,
             extra: Default::default(),
         };
         let json = serde_json::to_string(&qr).unwrap();
         assert!(json.contains("\"total_cost_usd\""));
         assert!(json.contains("\"num_turns\""));
+    }
+
+    #[test]
+    fn token_usage_deserializes_anthropic_cache_key_names() {
+        let json = r#"{
+            "input_tokens": 100,
+            "cache_read_input_tokens": 400,
+            "cache_creation_input_tokens": 50,
+            "output_tokens": 25
+        }"#;
+        let usage: TokenUsage = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.input_tokens, Some(100));
+        assert_eq!(usage.cached_input_tokens, Some(400));
+        assert_eq!(usage.cache_write_input_tokens, Some(50));
+        assert_eq!(usage.output_tokens, Some(25));
+        assert_eq!(usage.total(), 575);
+        assert!(!usage.is_empty());
+    }
+
+    #[test]
+    fn token_usage_prefers_explicit_total() {
+        let json = r#"{"input_tokens": 100, "output_tokens": 25, "total_tokens": 999}"#;
+        let usage: TokenUsage = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.total(), 999);
+    }
+
+    #[test]
+    fn token_usage_empty_object_is_empty() {
+        let usage: TokenUsage = serde_json::from_str("{}").unwrap();
+        assert!(usage.is_empty());
+        assert_eq!(usage.total(), 0);
+    }
+
+    #[test]
+    fn query_result_parses_usage_off_result_event() {
+        let json = r#"{
+            "result": "hi",
+            "session_id": "s1",
+            "total_cost_usd": 0.01,
+            "is_error": false,
+            "usage": {"input_tokens": 7, "output_tokens": 3}
+        }"#;
+        let qr: QueryResult = serde_json::from_str(json).unwrap();
+        let usage = qr.usage.expect("usage parsed");
+        assert_eq!(usage.total(), 10);
+        // The typed field captures it; it must not also land in extra.
+        assert!(!qr.extra.contains_key("usage"));
     }
 }

--- a/tests/fake-claude.sh
+++ b/tests/fake-claude.sh
@@ -22,6 +22,9 @@
 #       test that cancellation kills the whole group. Written before
 #       FAKE_CLAUDE_PID_FILE, so once the pid file exists the
 #       grandchild pid is readable too.
+#   FAKE_CLAUDE_USAGE_JSON  - if set, raw JSON embedded as the "usage"
+#       field of the result output (stream-json result line and json
+#       object), e.g. '{"input_tokens":100,"output_tokens":25}'.
 #
 # Output format is selected by --output-format argument:
 #   stream-json  ->  three NDJSON lines (system/assistant/result)
@@ -91,17 +94,23 @@ if [[ "$FORK_SESSION" == "true" && -n "$FAKE_CLAUDE_FORKED_SESSION_ID" ]]; then
     SESSION_ID="$FAKE_CLAUDE_FORKED_SESSION_ID"
 fi
 
+# Optional usage object appended to the result output.
+USAGE_FIELD=""
+if [[ -n "${FAKE_CLAUDE_USAGE_JSON:-}" ]]; then
+    USAGE_FIELD=",\"usage\":${FAKE_CLAUDE_USAGE_JSON}"
+fi
+
 if [[ "$OUTPUT_FORMAT" == "stream-json" ]]; then
     # Emit NDJSON matching real claude's stream-json format.
     # Escape the output for safe embedding in a JSON string value.
     ESCAPED_OUTPUT=$(printf '%s' "$OUTPUT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g')
     printf '{"type":"system","subtype":"init","session_id":"%s","tools":[],"mcp_servers":[]}\n' "$SESSION_ID"
     printf '{"type":"assistant","message":{"id":"msg_fake","type":"message","role":"assistant","content":[{"type":"text","text":"%s"}],"model":"claude-fake","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":5,"output_tokens":3}},"session_id":"%s"}\n' "$ESCAPED_OUTPUT" "$SESSION_ID"
-    printf '{"type":"result","subtype":"success","result":"%s","session_id":"%s","total_cost_usd":%s,"num_turns":%s,"is_error":false}\n' "$ESCAPED_OUTPUT" "$SESSION_ID" "$COST_USD" "$NUM_TURNS"
+    printf '{"type":"result","subtype":"success","result":"%s","session_id":"%s","total_cost_usd":%s,"num_turns":%s,"is_error":false%s}\n' "$ESCAPED_OUTPUT" "$SESSION_ID" "$COST_USD" "$NUM_TURNS" "$USAGE_FIELD"
 elif [[ "$OUTPUT_FORMAT" == "json" ]]; then
     # Emit a single JSON object matching QueryResult.
     ESCAPED_OUTPUT=$(printf '%s' "$OUTPUT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g')
-    printf '{"result":"%s","session_id":"%s","total_cost_usd":%s,"num_turns":%s,"is_error":false}\n' "$ESCAPED_OUTPUT" "$SESSION_ID" "$COST_USD" "$NUM_TURNS"
+    printf '{"result":"%s","session_id":"%s","total_cost_usd":%s,"num_turns":%s,"is_error":false%s}\n' "$ESCAPED_OUTPUT" "$SESSION_ID" "$COST_USD" "$NUM_TURNS" "$USAGE_FIELD"
 else
     # Plain text.
     printf '%s\n' "$OUTPUT"

--- a/tests/fake_claude.rs
+++ b/tests/fake_claude.rs
@@ -845,3 +845,63 @@ async fn dropping_in_flight_stream_query_kills_child() {
     assert_pid_killed(pid).await;
     assert_pid_killed(read_pid(&gpid_path)).await;
 }
+
+// ── Token accounting ─────────────────────────────────────────────────
+
+/// A result event carrying a usage object lands typed on QueryResult,
+/// with the Anthropic cache key names mapped onto the shared field names.
+#[tokio::test]
+async fn execute_json_parses_usage() {
+    let claude = claude_with_env(&[
+        ("FAKE_CLAUDE_OUTPUT", "ok"),
+        (
+            "FAKE_CLAUDE_USAGE_JSON",
+            r#"{"input_tokens":100,"cache_read_input_tokens":400,"output_tokens":25}"#,
+        ),
+    ]);
+    let result = QueryCommand::new("hi")
+        .no_session_persistence()
+        .execute_json(&claude)
+        .await
+        .expect("query succeeds");
+    let usage = result.usage.expect("usage present");
+    assert_eq!(usage.input_tokens, Some(100));
+    assert_eq!(usage.cached_input_tokens, Some(400));
+    assert_eq!(usage.output_tokens, Some(25));
+    assert_eq!(usage.total(), 525);
+}
+
+/// A turn whose result carries usage counts toward Session::total_tokens.
+#[tokio::test]
+async fn session_counts_tokens_when_usage_reported() {
+    use claude_wrapper::session::Session;
+    use std::sync::Arc;
+
+    let claude = Arc::new(claude_with_env(&[
+        ("FAKE_CLAUDE_OUTPUT", "one"),
+        (
+            "FAKE_CLAUDE_USAGE_JSON",
+            r#"{"input_tokens":10,"output_tokens":5}"#,
+        ),
+    ]));
+    let mut session = Session::new(claude);
+    session.send("first").await.expect("turn succeeds");
+
+    assert_eq!(session.total_tokens(), 15);
+    assert_eq!(session.turns_missing_usage(), 0);
+}
+
+/// A turn without usage increments turns_missing_usage rather than
+/// counting as a zero-token turn.
+#[tokio::test]
+async fn session_flags_turn_without_usage() {
+    use claude_wrapper::session::Session;
+    use std::sync::Arc;
+
+    let claude = Arc::new(claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "one")]));
+    let mut session = Session::new(claude);
+    session.send("first").await.expect("turn succeeds");
+
+    assert_eq!(session.total_tokens(), 0);
+    assert_eq!(session.turns_missing_usage(), 1);
+}


### PR DESCRIPTION
Closes #757.

## Problem

`Session` accumulates cost but not tokens. Cost alone does not support rate-limit reasoning, context-window budgeting, or cache-hit analysis, and for the #760 adapter the two crates disagree in opposite directions: codex-wrapper reports tokens and not cost, claude-wrapper reports cost and not tokens.

## Plan

1. `TokenUsage` in `src/types.rs`, field names aligned with codex-wrapper (`input_tokens`, `cached_input_tokens`, `cache_write_input_tokens`, `output_tokens`, `reasoning_output_tokens`, `total_tokens`), every field `Option` because the CLI does not report all buckets on every turn. Serde aliases map the Anthropic key names (`cache_read_input_tokens`, `cache_creation_input_tokens`) used by the CLI and already handled in `src/history.rs`, so the live and on-disk paths agree.
2. `QueryResult.usage: Option<TokenUsage>` parsed off the result event (currently the `usage` object lands untyped in `extra`).
3. `Session::total_tokens()` summing recorded turns, and `Session::turns_missing_usage()` counting turns whose result carried no usage, so a caller can tell a low total from an incomplete one.
4. `fake-claude.sh` gains `FAKE_CLAUDE_USAGE_JSON` to embed a usage object in the result event; integration tests cover a turn with usage and a turn without (the latter increments `turns_missing_usage` rather than counting as zero).

## Validation

Standard checklist: fmt, clippy (all-features, default, sync-only), lib + doc tests, fake_claude suites, CI matrix.