### PR TITLE
chore: add a git-cliff config and a changelog preview workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,38 @@
+name: Changelog
+
+# Preview-only: renders the unreleased changelog section with git-cliff
+# so grouping-rule changes are reviewable before a release. The actual
+# CHANGELOG.md write stays with release-plz, which reads the same
+# cliff.toml (changelog_config in release-plz.toml), so a release
+# cannot rewrite what a preview showed.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - cliff.toml
+      - release-plz.toml
+      - .github/workflows/changelog.yml
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    name: Changelog preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Render unreleased changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --verbose --unreleased
+        env:
+          OUTPUT: changelog-preview.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Publish preview to job summary
+        run: cat changelog-preview.md >> "$GITHUB_STEP_SUMMARY"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,58 @@
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+footer = """
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_preprocessors = [
+    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+]
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Style" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    # claude-wrapper adaptations: release-plz commits here are unscoped
+    # ("chore: release"), and dependabot uses "chore: bump" / "ci: bump".
+    # Both were excluded by the previous release-plz default config, so
+    # keep them out of the changelog.
+    { message = "^chore: release", skip = true },
+    { message = "^chore: bump", skip = true },
+    { message = "^ci: bump", skip = true },
+    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore\\(version\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore|^ci", group = "Miscellaneous" },
+    { body = ".*security", group = "Security" },
+]
+filter_commits = false
+tag_pattern = "v[0-9].*"
+topo_order = false
+sort_commits = "oldest"
+

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,9 @@
 [workspace]
 changelog_update = true
+# Changelog rules live in cliff.toml (shared shape with codex-wrapper);
+# release-plz and the changelog preview workflow both read it, so the
+# release cannot rewrite what a preview showed.
+changelog_config = "cliff.toml"
 git_release_enable = true
 git_tag_enable = true
 pr_labels = ["release"]


### PR DESCRIPTION
Closes #758.

## Plan

The repo has `CHANGELOG.md` and `release-plz.toml` but no `cliff.toml` and no changelog workflow, so the grouping rules live in release-plz's defaults rather than in a reviewable file.

Per the issue's note, this is an adapted copy rather than a straight one, because both repos release through release-plz and claude-wrapper's release-plz already updates `CHANGELOG.md` (`changelog_update = true`). codex-wrapper's post-release regenerate-and-PR workflow would introduce a second writer with potentially different rules.

1. `cliff.toml` copied from codex-wrapper verbatim, so the two crates group commits identically for the shared-adapter parity goal.
2. `release-plz.toml` gains `changelog_config = "cliff.toml"`, so release-plz generates the changelog from the same rules. Agreement between preview and release is by construction, not by convention.
3. `.github/workflows/changelog.yml` is a preview: on `workflow_dispatch` and on PRs touching `cliff.toml` / `release-plz.toml` / the workflow itself, it renders the unreleased section with git-cliff into the job summary. No commits, no PR creation, read-only permissions.

## Validation

- git-cliff run locally against the config to confirm it renders current history sanely
- workflow YAML matches the action-pinning style already in `.github/workflows/`