### PR TITLE
fix: quote an empty argument in shell_quote

### DIFF
--- a/src/command/spawn_args.rs
+++ b/src/command/spawn_args.rs
@@ -273,8 +273,17 @@ impl SharedSpawnArgs {
 /// Shared by [`QueryCommand::to_command_string`](crate::QueryCommand::to_command_string)
 /// and [`DuplexOptions::to_command_string`](crate::duplex::DuplexOptions::to_command_string).
 pub(crate) fn shell_quote(arg: &str) -> String {
-    // Check if the argument needs quoting (contains whitespace or shell metacharacters)
-    if arg.contains(|c: char| c.is_whitespace() || "\"'$\\`|;<>&()[]{}".contains(c)) {
+    // An empty argument has to be quoted. Unquoted it contributes nothing to
+    // the joined command, so the preview would describe an invocation with one
+    // fewer argument than the real one (#773).
+    if arg.is_empty() {
+        return "''".to_string();
+    }
+    // Check if the argument needs quoting (contains whitespace or shell
+    // metacharacters). The globbing and history characters are in the set
+    // because an unquoted `*.rs` pastes back as a shell expansion rather than
+    // the literal the process received.
+    if arg.contains(|c: char| c.is_whitespace() || "\"'$\\`|;<>&()[]{}*?!~#".contains(c)) {
         // Use single quotes and escape any existing single quotes
         format!("'{}'", arg.replace("'", "'\\''"))
     } else {
@@ -455,8 +464,26 @@ mod tests {
     #[test]
     fn shell_quote_plain_word_is_unchanged() {
         assert_eq!(shell_quote("simple"), "simple");
-        assert_eq!(shell_quote(""), "");
         assert_eq!(shell_quote("file.rs"), "file.rs");
+    }
+
+    /// An unquoted empty argument disappears once the arguments are joined,
+    /// so the rendered command would run with one fewer argument than the one
+    /// it claims to preview (#773).
+    #[test]
+    fn shell_quote_keeps_an_empty_argument_visible() {
+        assert_eq!(shell_quote(""), "''");
+    }
+
+    /// A glob left unquoted pastes back as a shell expansion rather than the
+    /// literal the process was given.
+    #[test]
+    fn shell_quote_globbing_and_history_characters_get_quoted() {
+        assert_eq!(shell_quote("*.rs"), "'*.rs'");
+        assert_eq!(shell_quote("a?b"), "'a?b'");
+        assert_eq!(shell_quote("!!"), "'!!'");
+        assert_eq!(shell_quote("~/x"), "'~/x'");
+        assert_eq!(shell_quote("#comment"), "'#comment'");
     }
 
     #[test]


### PR DESCRIPTION
Closes #773.

## The defect

An empty argument took the unquoted branch and returned `""`, contributing nothing once the arguments were joined:

| Input argv | Rendered before | Rendered now |
|---|---|---|
| `["--flag", "", "next"]` | `--flag  next` | `--flag '' next` |

`to_command_string` exists to show what actually spawns, so silently dropping an argument is the one failure it cannot have.

## The old behavior was pinned by a test

`shell_quote_plain_word_is_unchanged` asserted `shell_quote("") == ""`, which is why this read as deliberate rather than an oversight. That assertion moves to its own test with the reasoning stated, so the next person sees why it is `''`.

## Also: globbing and history characters

The quoted set gained `*`, `?`, `!`, `~` and `#`. An unquoted `*.rs` pastes back as a shell expansion rather than the literal the process received, which is the same class of defect as the empty argument: the rendered command runs differently from the one it previews.

## Cross-crate

The equivalent function in `codex-wrapper` already behaves this way, added in joshrotenberg/codex-wrapper#93 where this was noticed. The two crates should agree here.

## Local checks

fmt, clippy `-D warnings`, 628 lib tests.