### PR TITLE
feat: report every spawned child's pid via an on_spawn observer

### DIFF
--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -1178,7 +1178,8 @@ impl DuplexSession {
             source: e,
             working_dir: claude.working_dir.clone(),
         })?;
-        let group = crate::exec::GroupKillGuard::new_if(claude.process_group, child.id());
+        let group =
+            crate::exec::arm_and_notify(claude.process_group, child.id(), claude.on_spawn.as_ref());
 
         let stdin = child.stdin.take().expect("stdin was piped");
         let stdout = child.stdout.take().expect("stdout was piped");

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -126,6 +126,40 @@ pub struct CommandOutput {
 /// cannot be recycled, so firing is safe.
 ///
 /// On non-Unix targets the guard is a no-op.
+/// Arm the group-kill guard and tell the observer the child exists.
+///
+/// Kept together so the two cannot disagree about whether the child leads its
+/// own group: the `pgid` reported is `Some` exactly when the guard is armed,
+/// which is exactly when the pid is safe to `killpg`.
+/// The spawn-policy knobs the timeout paths carry together.
+///
+/// Bundled because those two functions otherwise exceed clippy's argument
+/// threshold, and because these three always travel as a set: whether the
+/// child leads its own group, how long to wait before escalating a kill, and
+/// who to tell that it exists.
+#[cfg(any(feature = "async", feature = "sync"))]
+#[derive(Clone, Copy)]
+pub(crate) struct SpawnPolicy<'a> {
+    pub(crate) process_group: bool,
+    pub(crate) kill_grace: Option<Duration>,
+    pub(crate) on_spawn: Option<&'a crate::SpawnObserver>,
+}
+
+#[cfg(any(feature = "async", feature = "sync"))]
+pub(crate) fn arm_and_notify(
+    process_group: bool,
+    pid: Option<u32>,
+    on_spawn: Option<&crate::SpawnObserver>,
+) -> GroupKillGuard {
+    if let (Some(pid), Some(observer)) = (pid, on_spawn) {
+        observer(crate::SpawnInfo {
+            pid,
+            pgid: process_group.then_some(pid),
+        });
+    }
+    GroupKillGuard::new_if(process_group, pid)
+}
+
 #[cfg(any(feature = "async", feature = "sync"))]
 pub(crate) struct GroupKillGuard {
     #[cfg(unix)]
@@ -348,6 +382,7 @@ async fn run_claude_with_stdin_prompt_internal(
             timeout,
             claude.kill_grace,
             stdin_content,
+            claude.on_spawn.as_ref(),
         )
         .await
     } else {
@@ -358,6 +393,7 @@ async fn run_claude_with_stdin_prompt_internal(
             working_dir,
             claude.process_group,
             stdin_content,
+            claude.on_spawn.as_ref(),
         )
         .await
     };
@@ -376,6 +412,7 @@ async fn run_internal_stdin(
     working_dir: Option<&std::path::Path>,
     process_group: bool,
     stdin_content: String,
+    on_spawn: Option<&crate::SpawnObserver>,
 ) -> Result<CommandOutput> {
     use tokio::io::AsyncWriteExt;
 
@@ -409,7 +446,7 @@ async fn run_internal_stdin(
             source: e,
             working_dir: working_dir.map(|p| p.to_path_buf()),
         })?;
-    let mut group = GroupKillGuard::new_if(process_group, child.id());
+    let mut group = arm_and_notify(process_group, child.id(), on_spawn);
 
     // Write the prompt to stdin, then drop the handle so the child sees EOF.
     if let Some(mut stdin) = child.stdin.take() {
@@ -471,6 +508,7 @@ async fn run_with_timeout_stdin(
     timeout: Duration,
     kill_grace: Option<Duration>,
     stdin_content: String,
+    on_spawn: Option<&crate::SpawnObserver>,
 ) -> Result<CommandOutput> {
     use tokio::io::AsyncWriteExt;
 
@@ -504,7 +542,7 @@ async fn run_with_timeout_stdin(
             source: e,
             working_dir: working_dir.map(|p| p.to_path_buf()),
         })?;
-    let mut group = GroupKillGuard::new_if(process_group, child.id());
+    let mut group = arm_and_notify(process_group, child.id(), on_spawn);
 
     // Write the prompt to stdin, then drop the handle so the child sees EOF.
     if let Some(mut stdin) = child.stdin.take() {
@@ -600,9 +638,12 @@ async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOu
             &command_args,
             &claude.env,
             claude.working_dir.as_deref(),
-            claude.process_group,
             timeout,
-            claude.kill_grace,
+            SpawnPolicy {
+                process_group: claude.process_group,
+                kill_grace: claude.kill_grace,
+                on_spawn: claude.on_spawn.as_ref(),
+            },
         )
         .await?
     } else {
@@ -612,6 +653,7 @@ async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOu
             &claude.env,
             claude.working_dir.as_deref(),
             claude.process_group,
+            claude.on_spawn.as_ref(),
         )
         .await?
     };
@@ -654,6 +696,7 @@ async fn run_internal(
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
     process_group: bool,
+    on_spawn: Option<&crate::SpawnObserver>,
 ) -> Result<CommandOutput> {
     let mut cmd = Command::new(binary);
     cmd.args(args);
@@ -692,7 +735,7 @@ async fn run_internal(
             source: e,
             working_dir: working_dir.map(|p| p.to_path_buf()),
         })?;
-    let mut group = GroupKillGuard::new_if(process_group, child.id());
+    let mut group = arm_and_notify(process_group, child.id(), on_spawn);
 
     let mut stdout_handle = child.stdout.take().expect("stdout was piped");
     let mut stderr_handle = child.stderr.take().expect("stderr was piped");
@@ -748,10 +791,14 @@ async fn run_with_timeout(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
-    process_group: bool,
     timeout: Duration,
-    kill_grace: Option<Duration>,
+    policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
+    let SpawnPolicy {
+        process_group,
+        kill_grace,
+        on_spawn,
+    } = policy;
     let mut cmd = Command::new(binary);
     cmd.args(args);
     cmd.stdin(std::process::Stdio::null());
@@ -782,7 +829,7 @@ async fn run_with_timeout(
             source: e,
             working_dir: working_dir.map(|p| p.to_path_buf()),
         })?;
-    let mut group = GroupKillGuard::new_if(process_group, child.id());
+    let mut group = arm_and_notify(process_group, child.id(), on_spawn);
 
     let mut stdout = child.stdout.take().expect("stdout was piped");
     let mut stderr = child.stderr.take().expect("stderr was piped");
@@ -960,6 +1007,7 @@ pub fn run_claude_with_stdin_prompt_sync(
             timeout,
             claude.kill_grace,
             stdin_content,
+            claude.on_spawn.as_ref(),
         )
     } else {
         run_internal_stdin_sync(
@@ -969,6 +1017,7 @@ pub fn run_claude_with_stdin_prompt_sync(
             claude.working_dir.as_deref(),
             claude.process_group,
             stdin_content,
+            claude.on_spawn.as_ref(),
         )
     };
 
@@ -986,6 +1035,7 @@ fn run_internal_stdin_sync(
     working_dir: Option<&std::path::Path>,
     process_group: bool,
     stdin_content: String,
+    on_spawn: Option<&crate::SpawnObserver>,
 ) -> Result<CommandOutput> {
     use std::io::Write;
     use std::process::{Command as StdCommand, Stdio};
@@ -1015,7 +1065,7 @@ fn run_internal_stdin_sync(
         source: e,
         working_dir: working_dir.map(|p| p.to_path_buf()),
     })?;
-    let mut group = GroupKillGuard::new_if(process_group, Some(child.id()));
+    let mut group = arm_and_notify(process_group, Some(child.id()), on_spawn);
 
     // Write the prompt to stdin, then drop the handle so the child sees EOF.
     if let Some(mut stdin) = child.stdin.take() {
@@ -1074,6 +1124,7 @@ fn run_with_timeout_stdin_sync(
     timeout: Duration,
     kill_grace: Option<Duration>,
     stdin_content: String,
+    on_spawn: Option<&crate::SpawnObserver>,
 ) -> Result<CommandOutput> {
     use std::io::Write;
     use std::process::{Command as StdCommand, Stdio};
@@ -1105,7 +1156,7 @@ fn run_with_timeout_stdin_sync(
         source: e,
         working_dir: working_dir.map(|p| p.to_path_buf()),
     })?;
-    let mut group = GroupKillGuard::new_if(process_group, Some(child.id()));
+    let mut group = arm_and_notify(process_group, Some(child.id()), on_spawn);
 
     // Write the prompt to stdin, then drop the handle so the child sees EOF.
     if let Some(mut stdin) = child.stdin.take() {
@@ -1196,9 +1247,12 @@ fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOut
             &command_args,
             &claude.env,
             claude.working_dir.as_deref(),
-            claude.process_group,
             timeout,
-            claude.kill_grace,
+            SpawnPolicy {
+                process_group: claude.process_group,
+                kill_grace: claude.kill_grace,
+                on_spawn: claude.on_spawn.as_ref(),
+            },
         )
     } else {
         run_internal_sync(
@@ -1207,6 +1261,7 @@ fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOut
             &claude.env,
             claude.working_dir.as_deref(),
             claude.process_group,
+            claude.on_spawn.as_ref(),
         )
     };
 
@@ -1246,6 +1301,7 @@ fn run_internal_sync(
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
     process_group: bool,
+    on_spawn: Option<&crate::SpawnObserver>,
 ) -> Result<CommandOutput> {
     use std::process::{Command as StdCommand, Stdio};
 
@@ -1254,7 +1310,8 @@ fn run_internal_sync(
     cmd.stdin(Stdio::null());
     // Own process group (Unix); see the module docs. This path has no
     // kill site (a blocking call cannot be cancelled mid-flight), so
-    // there is no guard to arm.
+    // there is no guard to arm -- but the child still exists and a
+    // supervisor still wants its pid, so the spawn is observed below.
     apply_process_group_sync(&mut cmd, process_group);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
@@ -1267,11 +1324,14 @@ fn run_internal_sync(
         cmd.env(key, value);
     }
 
-    let output = output_retrying_txtbsy_sync(&mut cmd).map_err(|e| Error::Io {
-        message: format!("failed to spawn claude: {e}"),
-        source: e,
-        working_dir: working_dir.map(|p| p.to_path_buf()),
-    })?;
+    let output =
+        output_retrying_txtbsy_sync_observed(&mut cmd, process_group, on_spawn).map_err(|e| {
+            Error::Io {
+                message: format!("failed to spawn claude: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            }
+        })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -1308,10 +1368,14 @@ fn run_with_timeout_sync(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
-    process_group: bool,
     timeout: Duration,
-    kill_grace: Option<Duration>,
+    policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
+    let SpawnPolicy {
+        process_group,
+        kill_grace,
+        on_spawn,
+    } = policy;
     use std::process::{Command as StdCommand, Stdio};
     use std::thread;
     use wait_timeout::ChildExt;
@@ -1341,7 +1405,7 @@ fn run_with_timeout_sync(
         source: e,
         working_dir: working_dir.map(|p| p.to_path_buf()),
     })?;
-    let mut group = GroupKillGuard::new_if(process_group, Some(child.id()));
+    let mut group = arm_and_notify(process_group, Some(child.id()), on_spawn);
 
     // Detach stdout/stderr onto their own threads so neither can block
     // the child by filling its pipe buffer. Each thread owns its half
@@ -1447,13 +1511,36 @@ fn spawn_retrying_txtbsy_sync(
 /// needs the same retry wrapped around `output` itself. The `ETXTBSY`
 /// still occurs at the `execve` inside `output`.
 #[cfg(feature = "sync")]
-fn output_retrying_txtbsy_sync(
+/// Run to completion, reporting the child to `on_spawn` first.
+///
+/// `Command::output` is `spawn` followed by `wait_with_output`, so splitting
+/// the two is behaviour-identical and makes the pid observable on a path that
+/// otherwise never exposes it.
+#[cfg(feature = "sync")]
+fn output_retrying_txtbsy_sync_observed(
     cmd: &mut std::process::Command,
+    process_group: bool,
+    on_spawn: Option<&crate::SpawnObserver>,
 ) -> std::io::Result<std::process::Output> {
+    // `Command::output` pipes stdout and stderr implicitly; `spawn` does not,
+    // so setting them here keeps this split behaviour-identical rather than
+    // silently returning empty captures.
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
     let start = std::time::Instant::now();
     let mut backoff = Duration::from_millis(1);
     loop {
-        match cmd.output() {
+        let spawned = cmd.spawn().inspect(|child| {
+            if let Some(observer) = on_spawn {
+                let pid = child.id();
+                observer(crate::SpawnInfo {
+                    pid,
+                    pgid: process_group.then_some(pid),
+                });
+            }
+        });
+        match spawned.and_then(std::process::Child::wait_with_output) {
             Err(e)
                 if e.kind() == std::io::ErrorKind::ExecutableFileBusy
                     && start.elapsed() < TXTBSY_RETRY_BUDGET =>
@@ -2193,7 +2280,7 @@ mod tests {
     #[test]
     fn sync_output_retry_passes_through_non_txtbsy_error() {
         let mut cmd = std::process::Command::new("/nonexistent/definitely-not-a-real-binary");
-        let err = output_retrying_txtbsy_sync(&mut cmd)
+        let err = output_retrying_txtbsy_sync_observed(&mut cmd, false, None)
             .expect_err("output of missing binary should fail");
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound, "got: {err:?}");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,10 +413,34 @@ pub use version::{
     CliVersion, CliVersionStatus, TESTED_CLI_VERSION_MAX, TESTED_CLI_VERSION_MIN, VersionParseError,
 };
 
+/// What the crate knows about a child the moment it is spawned.
+///
+/// Delivered to the [`ClaudeBuilder::on_spawn`] observer before the run can
+/// produce output, which is the point: a supervisor that records the pid only
+/// after a run *finishes* has nothing to reconcile when it crashes mid-run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SpawnInfo {
+    /// The child's process id.
+    pub pid: u32,
+    /// The child's process group id, when it leads its own group.
+    ///
+    /// `None` when [`ClaudeBuilder::process_group`] is disabled, in which case
+    /// the child shares the parent's group and its pid must never be passed to
+    /// `killpg`: that would signal the caller's own process group.
+    pub pgid: Option<u32>,
+}
+
+/// Called with [`SpawnInfo`] each time the crate spawns a CLI child.
+///
+/// Must not block: it runs inline on the spawning thread, between `spawn` and
+/// the first read of the child's output.
+pub type SpawnObserver = std::sync::Arc<dyn Fn(SpawnInfo) + Send + Sync>;
+
 /// The Claude CLI client. Holds shared configuration applied to all commands.
 ///
 /// Create one via [`Claude::builder()`] and reuse it across commands.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Claude {
     pub(crate) binary: PathBuf,
     pub(crate) working_dir: Option<PathBuf>,
@@ -437,6 +461,24 @@ pub struct Claude {
     pub(crate) process_group: bool,
     #[allow(dead_code)]
     pub(crate) kill_grace: Option<Duration>,
+    #[allow(dead_code)]
+    pub(crate) on_spawn: Option<SpawnObserver>,
+}
+
+impl std::fmt::Debug for Claude {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Claude")
+            .field("binary", &self.binary)
+            .field("working_dir", &self.working_dir)
+            .field("global_args", &self.global_args)
+            .field("timeout", &self.timeout)
+            .field("process_group", &self.process_group)
+            .field("kill_grace", &self.kill_grace)
+            // A closure cannot be rendered, and env may hold credentials, so
+            // neither is printed: only whether an observer is installed.
+            .field("on_spawn", &self.on_spawn.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 impl Claude {
@@ -706,7 +748,7 @@ fn warn_on_drift(status: &CliVersionStatus) {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct ClaudeBuilder {
     binary: Option<PathBuf>,
     working_dir: Option<PathBuf>,
@@ -717,6 +759,23 @@ pub struct ClaudeBuilder {
     tested_cli_version_range: Option<(CliVersion, CliVersion)>,
     process_group: Option<bool>,
     kill_grace: Option<Duration>,
+    on_spawn: Option<SpawnObserver>,
+}
+
+impl std::fmt::Debug for ClaudeBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Mirrors Claude's Debug: a closure cannot be rendered and env may
+        // hold credentials, so neither is printed.
+        f.debug_struct("ClaudeBuilder")
+            .field("binary", &self.binary)
+            .field("working_dir", &self.working_dir)
+            .field("global_args", &self.global_args)
+            .field("timeout", &self.timeout)
+            .field("process_group", &self.process_group)
+            .field("kill_grace", &self.kill_grace)
+            .field("on_spawn", &self.on_spawn.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 impl ClaudeBuilder {
@@ -909,6 +968,45 @@ impl ClaudeBuilder {
         self
     }
 
+    /// Observe every child this client spawns, at spawn time.
+    ///
+    /// The observer receives a [`SpawnInfo`] before the run produces output,
+    /// which is what makes it useful to a supervisor: recording the pid only
+    /// once a run *finishes* leaves nothing to reconcile after a crash
+    /// mid-run. Fires for one-shot runs, streaming runs, and duplex sessions
+    /// alike, and on retry it fires once per attempt, since each attempt is a
+    /// distinct process.
+    ///
+    /// The observer runs inline on the spawning thread, so it must not block.
+    /// Write a pidfile or push to a channel; do not do I/O that can stall.
+    ///
+    /// # Why a callback rather than a return value
+    ///
+    /// The crash case needs the pid to be durable *before* the run can be
+    /// orphaned. A pid on the result type arrives too late for exactly the
+    /// scenario that motivates recording it.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use claude_wrapper::Claude;
+    ///
+    /// # fn example() -> claude_wrapper::Result<()> {
+    /// let claude = Claude::builder()
+    ///     .on_spawn(Arc::new(|info| {
+    ///         eprintln!("spawned pid {} (group {:?})", info.pid, info.pgid);
+    ///     }))
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn on_spawn(mut self, observer: SpawnObserver) -> Self {
+        self.on_spawn = Some(observer);
+        self
+    }
+
     /// Build the Claude client, resolving the binary path.
     pub fn build(self) -> Result<Claude> {
         let binary = match self.binary {
@@ -926,6 +1024,7 @@ impl ClaudeBuilder {
             tested_cli_version_range: self.tested_cli_version_range,
             process_group: self.process_group.unwrap_or(true),
             kill_grace: self.kill_grace,
+            on_spawn: self.on_spawn,
         })
     }
 }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -390,7 +390,8 @@ where
         source: e,
         working_dir: claude.working_dir.clone(),
     })?;
-    let mut group = crate::exec::GroupKillGuard::new_if(claude.process_group, child.id());
+    let mut group =
+        crate::exec::arm_and_notify(claude.process_group, child.id(), claude.on_spawn.as_ref());
 
     let stdout = child.stdout.take().expect("stdout was piped");
     let mut stderr = child.stderr.take().expect("stderr was piped");
@@ -613,7 +614,11 @@ where
         source: e,
         working_dir: claude.working_dir.clone(),
     })?;
-    let mut group = crate::exec::GroupKillGuard::new_if(claude.process_group, Some(child.id()));
+    let mut group = crate::exec::arm_and_notify(
+        claude.process_group,
+        Some(child.id()),
+        claude.on_spawn.as_ref(),
+    );
 
     let stdout = child.stdout.take().expect("stdout was piped");
     let stderr = child.stderr.take().expect("stderr was piped");

--- a/tests/spawn_observer.rs
+++ b/tests/spawn_observer.rs
@@ -1,0 +1,143 @@
+//! The spawn observer: does it fire, when, and with what.
+//!
+//! A supervisor uses this to record `(run_id, pid)` durably *before* a run can
+//! be orphaned, so the properties that matter are timing (before output) and
+//! the honesty of `pgid` (only `Some` when the pid is safe to `killpg`).
+
+#![cfg(all(feature = "async", feature = "json"))]
+
+use std::sync::{Arc, Mutex};
+
+use claude_wrapper::{Claude, SpawnInfo};
+
+/// Collect every `SpawnInfo` the crate reports.
+fn recording() -> (Arc<Mutex<Vec<SpawnInfo>>>, claude_wrapper::SpawnObserver) {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let sink = seen.clone();
+    (seen, Arc::new(move |info| sink.lock().unwrap().push(info)))
+}
+
+fn fake() -> &'static str {
+    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fake-claude.sh")
+}
+
+#[tokio::test]
+async fn observer_reports_a_live_pid_for_a_one_shot_run() {
+    let (seen, observer) = recording();
+    let claude = Claude::builder()
+        .binary(fake())
+        .on_spawn(observer)
+        .build()
+        .unwrap();
+
+    claude_wrapper::exec::run_claude(&claude, vec!["--version".into()])
+        .await
+        .expect("fake binary reports a version");
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(seen.len(), 1, "exactly one spawn, got {seen:?}");
+    assert!(seen[0].pid > 0, "pid must be real, got {}", seen[0].pid);
+}
+
+#[tokio::test]
+async fn pgid_is_some_only_when_the_child_leads_its_own_group() {
+    // The distinction is load-bearing: with process_group disabled the child
+    // shares the caller's group, so passing its pid to killpg would signal the
+    // supervisor's own process tree. Reporting pgid: None is what stops that.
+    for (process_group, expect_pgid) in [(true, true), (false, false)] {
+        let (seen, observer) = recording();
+        let claude = Claude::builder()
+            .binary(fake())
+            .process_group(process_group)
+            .on_spawn(observer)
+            .build()
+            .unwrap();
+
+        claude_wrapper::exec::run_claude(&claude, vec!["--version".into()])
+            .await
+            .unwrap();
+
+        let seen = seen.lock().unwrap();
+        let info = seen.first().expect("observer fired");
+        assert_eq!(
+            info.pgid.is_some(),
+            expect_pgid,
+            "process_group={process_group} should give pgid.is_some()={expect_pgid}, got {info:?}"
+        );
+        if let Some(pgid) = info.pgid {
+            assert_eq!(pgid, info.pid, "a group leader's pgid is its own pid");
+        }
+    }
+}
+
+#[tokio::test]
+async fn observer_fires_before_the_run_produces_output() {
+    // The whole point: a pid recorded only after the run finishes is useless
+    // for reconciling a supervisor crash that happened mid-run.
+    let order = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+    let sink = order.clone();
+    let claude = Claude::builder()
+        .binary(fake())
+        .on_spawn(Arc::new(move |_| sink.lock().unwrap().push("spawn")))
+        .build()
+        .unwrap();
+
+    let out = claude_wrapper::exec::run_claude(&claude, vec!["--version".into()])
+        .await
+        .unwrap();
+    order.lock().unwrap().push("output");
+
+    assert_eq!(
+        *order.lock().unwrap(),
+        vec!["spawn", "output"],
+        "the observer must fire before output is available"
+    );
+    assert!(!out.stdout.is_empty(), "the run really did produce output");
+}
+
+#[tokio::test]
+async fn each_retry_attempt_is_its_own_spawn() {
+    use claude_wrapper::RetryPolicy;
+
+    // Every attempt is a distinct process, so a supervisor tracking pids must
+    // see one report per attempt or it will fail to reconcile the earlier ones.
+    let (seen, observer) = recording();
+    let claude = Claude::builder()
+        // Spawns successfully and exits 1, which the policy below retries on.
+        // The repo's fake binary always succeeds, so it cannot drive this.
+        // `false` lives in /usr/bin on macOS and /bin on most Linux.
+        .binary(if std::path::Path::new("/usr/bin/false").exists() {
+            "/usr/bin/false"
+        } else {
+            "/bin/false"
+        })
+        .retry(
+            RetryPolicy::new()
+                .max_attempts(3)
+                .fixed()
+                .initial_backoff(std::time::Duration::from_millis(1))
+                .retry_on_exit_codes([1]),
+        )
+        .on_spawn(observer)
+        .build()
+        .unwrap();
+
+    let _ = claude_wrapper::exec::run_claude(&claude, vec!["--version".into()]).await;
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(seen.len(), 3, "one spawn per attempt, got {seen:?}");
+    // Distinct processes, so distinct pids.
+    let first = seen[0].pid;
+    assert!(
+        seen.iter().any(|i| i.pid != first),
+        "attempts should be different processes, got {seen:?}"
+    );
+}
+
+#[tokio::test]
+async fn no_observer_configured_is_fine() {
+    let claude = Claude::builder().binary(fake()).build().unwrap();
+    claude_wrapper::exec::run_claude(&claude, vec!["--version".into()])
+        .await
+        .expect("runs normally with no observer");
+}


### PR DESCRIPTION
Closes #775.

## The gap

Each spawn captured `child.id()` only to arm the crate-private `GroupKillGuard`. Nothing public returned it, so a supervisor could not verify a kill, record `(run_id, pid)` in a ledger, or find orphans after crashing. The reported workaround was substring-matching the prompt in `ps` output, which stops working entirely under `prompt_via_stdin` (#621), since the prompt then never reaches argv at all.

## Shape

```rust
let claude = Claude::builder()
    .on_spawn(Arc::new(|info| ledger.record(run_id, info.pid)))
    .build()?;
```

`SpawnInfo { pid, pgid }`, delivered from **all eleven spawn sites**: one-shot and stdin, async and sync, timeout and not, plus streaming and duplex. Retry fires it once per attempt, since each attempt is a distinct process a supervisor has to reconcile.

## Three decisions worth review

**A callback, not a pid on the result type.** The issue offered both; the callback is the one that solves the stated problem. The crash case needs the pid durable *before* the run can be orphaned, and a pid arriving with the result arrives too late for exactly the scenario that motivates recording it. (The result-type variant remains easy to add later if the post-hoc cases want it.)

**`pgid` is `Some` only when the child leads its own group.** Load-bearing, not cosmetic: with `process_group` disabled the child shares the caller's group, so passing its pid to `killpg` would signal the supervisor's own process tree. Notification and guard-arming now happen in one `arm_and_notify` helper precisely so the two cannot disagree about it. Tested in both directions.

**The sync no-timeout path is now observable.** It used `Command::output`, which never exposes a pid. `output` *is* `spawn` + `wait_with_output`, so splitting it is behaviour-identical. One catch the existing suite caught for me: `output` pipes stdout/stderr implicitly and `spawn` does not, so the split sets them explicitly. Three sync tests failed until it did.

## Incidental

- `Claude` and `ClaudeBuilder` implement `Debug` by hand now (a closure cannot be derived). Neither prints the observer or `env` — only whether an observer is installed.
- The two timeout paths bundle their three policy knobs into a `SpawnPolicy` struct rather than growing an eighth parameter, which also keeps them under clippy's argument threshold.

## Tests

Five, covering a live pid, the `pgid` distinction both ways, **ordering** (the observer fires before output is available — the property the whole design rests on), one report per retry attempt with distinct pids, and that no observer configured still runs normally.

## Verification

`fmt`, `clippy --all-targets --all-features -D warnings`, and the full suite green: 631 unit, 36 + 14 fake-binary, 5 spawn-observer, 3 span, 5 contract-parser, 90 doc. All four feature combos build.

## Note on #776

This composes with the pidfile option there: a pidfile becomes an `on_spawn` handler. I have a design for the rest of #776 (`PR_SET_PDEATHSIG` with its fork/prctl race handled, and an honest platform story since macOS has no equivalent) but left it out of this PR — happy to follow up.