### PR TITLE
feat: opt-in parent-death signal so a SIGKILLed supervisor leaves no orphan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ tokio = { version = "1", features = ["full"] }
 # so a test needs to observe what a subscriber actually receives.
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
+# The parent-death behavioural test signals processes directly.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+
 # All examples use the async API; require the feature so they're
 # skipped automatically on sync-only builds.
 [[example]]

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -147,6 +147,7 @@ pub(crate) struct SpawnPolicy<'a> {
     pub(crate) on_spawn: Option<&'a crate::SpawnObserver>,
 }
 
+#[cfg(any(feature = "async", feature = "sync"))]
 impl SpawnPolicy<'_> {
     /// The policy a [`Claude`] client describes.
     pub(crate) fn of(claude: &Claude) -> SpawnPolicy<'_> {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -131,18 +131,32 @@ pub struct CommandOutput {
 /// Kept together so the two cannot disagree about whether the child leads its
 /// own group: the `pgid` reported is `Some` exactly when the guard is armed,
 /// which is exactly when the pid is safe to `killpg`.
-/// The spawn-policy knobs the timeout paths carry together.
+/// The spawn-policy knobs every spawn path carries together.
 ///
-/// Bundled because those two functions otherwise exceed clippy's argument
-/// threshold, and because these three always travel as a set: whether the
-/// child leads its own group, how long to wait before escalating a kill, and
-/// who to tell that it exists.
+/// Bundled because they always travel as a set and because threading them
+/// individually pushed the timeout paths past clippy's argument threshold:
+/// whether the child leads its own group, how long to wait before escalating a
+/// kill, whether the child should die with its parent, and who to tell that it
+/// exists.
 #[cfg(any(feature = "async", feature = "sync"))]
 #[derive(Clone, Copy)]
 pub(crate) struct SpawnPolicy<'a> {
     pub(crate) process_group: bool,
     pub(crate) kill_grace: Option<Duration>,
+    pub(crate) die_with_parent: bool,
     pub(crate) on_spawn: Option<&'a crate::SpawnObserver>,
+}
+
+impl SpawnPolicy<'_> {
+    /// The policy a [`Claude`] client describes.
+    pub(crate) fn of(claude: &Claude) -> SpawnPolicy<'_> {
+        SpawnPolicy {
+            process_group: claude.process_group,
+            kill_grace: claude.kill_grace,
+            die_with_parent: claude.die_with_parent,
+            on_spawn: claude.on_spawn.as_ref(),
+        }
+    }
 }
 
 #[cfg(any(feature = "async", feature = "sync"))]
@@ -241,6 +255,95 @@ impl GroupKillGuard {
 impl Drop for GroupKillGuard {
     fn drop(&mut self) {
         self.kill_now();
+    }
+}
+
+/// Whether [`ClaudeBuilder::die_with_parent`](crate::ClaudeBuilder::die_with_parent)
+/// does anything on this platform.
+///
+/// `true` only on Linux, which is the only target with a kernel-level
+/// parent-death signal (`PR_SET_PDEATHSIG`). Elsewhere the option is accepted
+/// and has no effect, so a supervisor that needs the guarantee everywhere must
+/// check this and run its own watchdog rather than assume coverage it does not
+/// have.
+#[must_use]
+pub const fn die_with_parent_supported() -> bool {
+    cfg!(target_os = "linux")
+}
+
+/// Ask the kernel to SIGKILL the child when this process dies.
+///
+/// Linux only. Two things make this correct rather than merely present:
+///
+/// - **The fork/prctl race.** `PR_SET_PDEATHSIG` is set by the child *after*
+///   the fork. If the parent dies in that window the signal never arrives and
+///   the child orphans anyway, which is the exact case this exists to prevent.
+///   So the hook re-reads `getppid()` immediately afterwards and exits if the
+///   parent already changed.
+/// - **Async-signal-safety.** Everything called here (`prctl`, `getppid`,
+///   `_exit`) is on the post-fork allowlist. Anything that allocates or takes a
+///   lock would risk deadlocking the child.
+///
+/// The signal is also cleared across `execve` only for setuid binaries, which
+/// `claude` is not, so it survives into the CLI itself.
+#[cfg(all(unix, any(feature = "async", feature = "sync")))]
+fn pdeathsig_hook() -> impl FnMut() -> std::io::Result<()> + Send + Sync + 'static {
+    // Read the parent pid before the fork: inside the child, "the parent we
+    // meant" is this value, not whatever getppid happens to return later.
+    let parent = std::process::id();
+    move || {
+        #[cfg(target_os = "linux")]
+        {
+            // SAFETY: async-signal-safe calls only, as required post-fork.
+            unsafe {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                // Lost the race: the parent died before the signal was armed.
+                if libc::getppid() as u32 != parent {
+                    libc::_exit(1);
+                }
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = parent;
+        }
+        Ok(())
+    }
+}
+
+/// Apply the parent-death policy to an async spawn. No-op off Linux; see
+/// [`die_with_parent_supported`].
+#[cfg(feature = "async")]
+pub(crate) fn apply_die_with_parent(cmd: &mut Command, enabled: bool) {
+    #[cfg(unix)]
+    if enabled {
+        // SAFETY: the hook is async-signal-safe; see `pdeathsig_hook`.
+        unsafe {
+            cmd.pre_exec(pdeathsig_hook());
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (cmd, enabled);
+    }
+}
+
+/// Blocking mirror of [`apply_die_with_parent`].
+#[cfg(feature = "sync")]
+pub(crate) fn apply_die_with_parent_sync(cmd: &mut std::process::Command, enabled: bool) {
+    #[cfg(unix)]
+    if enabled {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: the hook is async-signal-safe; see `pdeathsig_hook`.
+        unsafe {
+            cmd.pre_exec(pdeathsig_hook());
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (cmd, enabled);
     }
 }
 
@@ -378,11 +481,9 @@ async fn run_claude_with_stdin_prompt_internal(
             &command_args,
             env,
             working_dir,
-            claude.process_group,
             timeout,
-            claude.kill_grace,
             stdin_content,
-            claude.on_spawn.as_ref(),
+            SpawnPolicy::of(claude),
         )
         .await
     } else {
@@ -391,9 +492,8 @@ async fn run_claude_with_stdin_prompt_internal(
             &command_args,
             env,
             working_dir,
-            claude.process_group,
             stdin_content,
-            claude.on_spawn.as_ref(),
+            SpawnPolicy::of(claude),
         )
         .await
     };
@@ -410,10 +510,15 @@ async fn run_internal_stdin(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
-    process_group: bool,
     stdin_content: String,
-    on_spawn: Option<&crate::SpawnObserver>,
+    policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
+    let SpawnPolicy {
+        process_group,
+        kill_grace: _, // no kill site on this path
+        die_with_parent,
+        on_spawn,
+    } = policy;
     use tokio::io::AsyncWriteExt;
 
     let mut cmd = Command::new(binary);
@@ -428,6 +533,7 @@ async fn run_internal_stdin(
     // tree, not just the direct child (see GroupKillGuard). Opt out
     // via ClaudeBuilder::process_group.
     apply_process_group(&mut cmd, process_group);
+    apply_die_with_parent(&mut cmd, die_with_parent);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
@@ -504,12 +610,16 @@ async fn run_with_timeout_stdin(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
-    process_group: bool,
     timeout: Duration,
-    kill_grace: Option<Duration>,
     stdin_content: String,
-    on_spawn: Option<&crate::SpawnObserver>,
+    policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
+    let SpawnPolicy {
+        process_group,
+        kill_grace,
+        die_with_parent,
+        on_spawn,
+    } = policy;
     use tokio::io::AsyncWriteExt;
 
     let mut cmd = Command::new(binary);
@@ -524,6 +634,7 @@ async fn run_with_timeout_stdin(
     // tree, not just the direct child (see GroupKillGuard). Opt out
     // via ClaudeBuilder::process_group.
     apply_process_group(&mut cmd, process_group);
+    apply_die_with_parent(&mut cmd, die_with_parent);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
@@ -639,11 +750,7 @@ async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOu
             &claude.env,
             claude.working_dir.as_deref(),
             timeout,
-            SpawnPolicy {
-                process_group: claude.process_group,
-                kill_grace: claude.kill_grace,
-                on_spawn: claude.on_spawn.as_ref(),
-            },
+            SpawnPolicy::of(claude),
         )
         .await?
     } else {
@@ -652,8 +759,7 @@ async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOu
             &command_args,
             &claude.env,
             claude.working_dir.as_deref(),
-            claude.process_group,
-            claude.on_spawn.as_ref(),
+            SpawnPolicy::of(claude),
         )
         .await?
     };
@@ -695,9 +801,14 @@ async fn run_internal(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
-    process_group: bool,
-    on_spawn: Option<&crate::SpawnObserver>,
+    policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
+    let SpawnPolicy {
+        process_group,
+        kill_grace: _, // no kill site on this path
+        die_with_parent,
+        on_spawn,
+    } = policy;
     let mut cmd = Command::new(binary);
     cmd.args(args);
 
@@ -713,6 +824,7 @@ async fn run_internal(
     // tree, not just the direct child (see GroupKillGuard). Opt out
     // via ClaudeBuilder::process_group.
     apply_process_group(&mut cmd, process_group);
+    apply_die_with_parent(&mut cmd, die_with_parent);
 
     // Remove Claude Code env vars to prevent nested session detection
     cmd.env_remove("CLAUDECODE");
@@ -797,6 +909,7 @@ async fn run_with_timeout(
     let SpawnPolicy {
         process_group,
         kill_grace,
+        die_with_parent,
         on_spawn,
     } = policy;
     let mut cmd = Command::new(binary);
@@ -811,6 +924,7 @@ async fn run_with_timeout(
     // tree, not just the direct child (see GroupKillGuard). Opt out
     // via ClaudeBuilder::process_group.
     apply_process_group(&mut cmd, process_group);
+    apply_die_with_parent(&mut cmd, die_with_parent);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
@@ -1003,11 +1117,9 @@ pub fn run_claude_with_stdin_prompt_sync(
             &command_args,
             &claude.env,
             claude.working_dir.as_deref(),
-            claude.process_group,
             timeout,
-            claude.kill_grace,
             stdin_content,
-            claude.on_spawn.as_ref(),
+            SpawnPolicy::of(claude),
         )
     } else {
         run_internal_stdin_sync(
@@ -1015,9 +1127,8 @@ pub fn run_claude_with_stdin_prompt_sync(
             &command_args,
             &claude.env,
             claude.working_dir.as_deref(),
-            claude.process_group,
             stdin_content,
-            claude.on_spawn.as_ref(),
+            SpawnPolicy::of(claude),
         )
     };
 
@@ -1033,10 +1144,15 @@ fn run_internal_stdin_sync(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
-    process_group: bool,
     stdin_content: String,
-    on_spawn: Option<&crate::SpawnObserver>,
+    policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
+    let SpawnPolicy {
+        process_group,
+        kill_grace: _, // no kill site on this path
+        die_with_parent,
+        on_spawn,
+    } = policy;
     use std::io::Write;
     use std::process::{Command as StdCommand, Stdio};
 
@@ -1049,6 +1165,7 @@ fn run_internal_stdin_sync(
     // not just the direct child (see GroupKillGuard). Opt out via
     // ClaudeBuilder::process_group.
     apply_process_group_sync(&mut cmd, process_group);
+    apply_die_with_parent_sync(&mut cmd, die_with_parent);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
@@ -1120,12 +1237,16 @@ fn run_with_timeout_stdin_sync(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
-    process_group: bool,
     timeout: Duration,
-    kill_grace: Option<Duration>,
     stdin_content: String,
-    on_spawn: Option<&crate::SpawnObserver>,
+    policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
+    let SpawnPolicy {
+        process_group,
+        kill_grace,
+        die_with_parent,
+        on_spawn,
+    } = policy;
     use std::io::Write;
     use std::process::{Command as StdCommand, Stdio};
     use std::thread;
@@ -1140,6 +1261,7 @@ fn run_with_timeout_stdin_sync(
     // not just the direct child (see GroupKillGuard). Opt out via
     // ClaudeBuilder::process_group.
     apply_process_group_sync(&mut cmd, process_group);
+    apply_die_with_parent_sync(&mut cmd, die_with_parent);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
@@ -1248,11 +1370,7 @@ fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOut
             &claude.env,
             claude.working_dir.as_deref(),
             timeout,
-            SpawnPolicy {
-                process_group: claude.process_group,
-                kill_grace: claude.kill_grace,
-                on_spawn: claude.on_spawn.as_ref(),
-            },
+            SpawnPolicy::of(claude),
         )
     } else {
         run_internal_sync(
@@ -1260,8 +1378,7 @@ fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOut
             &command_args,
             &claude.env,
             claude.working_dir.as_deref(),
-            claude.process_group,
-            claude.on_spawn.as_ref(),
+            SpawnPolicy::of(claude),
         )
     };
 
@@ -1300,9 +1417,14 @@ fn run_internal_sync(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
-    process_group: bool,
-    on_spawn: Option<&crate::SpawnObserver>,
+    policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
+    let SpawnPolicy {
+        process_group,
+        kill_grace: _, // no kill site on this path
+        die_with_parent,
+        on_spawn,
+    } = policy;
     use std::process::{Command as StdCommand, Stdio};
 
     let mut cmd = StdCommand::new(binary);
@@ -1313,6 +1435,7 @@ fn run_internal_sync(
     // there is no guard to arm -- but the child still exists and a
     // supervisor still wants its pid, so the spawn is observed below.
     apply_process_group_sync(&mut cmd, process_group);
+    apply_die_with_parent_sync(&mut cmd, die_with_parent);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
@@ -1374,6 +1497,7 @@ fn run_with_timeout_sync(
     let SpawnPolicy {
         process_group,
         kill_grace,
+        die_with_parent,
         on_spawn,
     } = policy;
     use std::process::{Command as StdCommand, Stdio};
@@ -1389,6 +1513,7 @@ fn run_with_timeout_sync(
     // not just the direct child (see GroupKillGuard). Opt out via
     // ClaudeBuilder::process_group.
     apply_process_group_sync(&mut cmd, process_group);
+    apply_die_with_parent_sync(&mut cmd, die_with_parent);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,6 +463,8 @@ pub struct Claude {
     pub(crate) kill_grace: Option<Duration>,
     #[allow(dead_code)]
     pub(crate) on_spawn: Option<SpawnObserver>,
+    #[allow(dead_code)]
+    pub(crate) die_with_parent: bool,
 }
 
 impl std::fmt::Debug for Claude {
@@ -760,6 +762,7 @@ pub struct ClaudeBuilder {
     process_group: Option<bool>,
     kill_grace: Option<Duration>,
     on_spawn: Option<SpawnObserver>,
+    die_with_parent: bool,
 }
 
 impl std::fmt::Debug for ClaudeBuilder {
@@ -1007,6 +1010,50 @@ impl ClaudeBuilder {
         self
     }
 
+    /// Ask the kernel to kill spawned children when this process dies.
+    ///
+    /// **Linux only.** Check [`die_with_parent_supported`](crate::exec::die_with_parent_supported)
+    /// rather than assuming; elsewhere this is accepted and does nothing.
+    ///
+    /// # The problem it addresses
+    ///
+    /// Every other cleanup path in this crate is a destructor: `kill_on_drop`,
+    /// and the process-group kill on drop, timeout, or stream error. None of
+    /// them run when *this* process is SIGKILLed. The child is then reparented
+    /// to init, and because it leads its own process group (see
+    /// [`process_group`](Self::process_group)) terminal signals cannot reach it
+    /// either. It keeps running, keeps billing, and keeps appending to the
+    /// session transcript, so a restarted supervisor that resumes the same
+    /// session id can find itself interleaving with an orphan still writing.
+    ///
+    /// On Linux `PR_SET_PDEATHSIG` closes that: the kernel delivers SIGKILL to
+    /// the child the moment its parent dies, with no cooperation from either
+    /// side.
+    ///
+    /// # What it does not cover
+    ///
+    /// - **Non-Linux targets.** macOS has no equivalent. A supervisor that
+    ///   needs the guarantee there has to poll and kill by pid; recording the
+    ///   pid is what [`on_spawn`](Self::on_spawn) is for.
+    /// - **Re-parenting.** The signal fires when the *immediate* parent dies.
+    ///   If the crate's caller is itself an intermediate process that exits
+    ///   normally, the child dies then, which is usually what you want but is
+    ///   worth knowing if you daemonize between building the client and
+    ///   spawning.
+    /// - **The fork/prctl window.** Handled: the hook re-checks `getppid()`
+    ///   after arming and exits if the parent already changed. Without that
+    ///   check a parent dying in that window leaves exactly the orphan this
+    ///   option exists to prevent.
+    ///
+    /// Off by default, because killing children on parent exit is the right
+    /// default for a supervisor and the wrong one for a CLI that deliberately
+    /// backgrounds work.
+    #[must_use]
+    pub fn die_with_parent(mut self, enabled: bool) -> Self {
+        self.die_with_parent = enabled;
+        self
+    }
+
     /// Build the Claude client, resolving the binary path.
     pub fn build(self) -> Result<Claude> {
         let binary = match self.binary {
@@ -1025,6 +1072,7 @@ impl ClaudeBuilder {
             process_group: self.process_group.unwrap_or(true),
             kill_grace: self.kill_grace,
             on_spawn: self.on_spawn,
+            die_with_parent: self.die_with_parent,
         })
     }
 }

--- a/tests/die_with_parent.rs
+++ b/tests/die_with_parent.rs
@@ -1,0 +1,164 @@
+//! The parent-death policy: does the option plumb through, and on Linux does
+//! the child actually die with its parent.
+//!
+//! The behavioural half is inherently a multi-process test: it spawns a helper
+//! that itself spawns a child through this crate, SIGKILLs the helper, and asks
+//! whether the grandchild survived. It is `#[ignore]`d off Linux, where
+//! `PR_SET_PDEATHSIG` has no equivalent and the answer is "it survives, by
+//! design".
+
+#![cfg(all(feature = "async", feature = "json"))]
+
+use std::sync::{Arc, Mutex};
+
+use claude_wrapper::Claude;
+
+fn fake() -> &'static str {
+    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fake-claude.sh")
+}
+
+#[test]
+fn support_is_reported_honestly_per_platform() {
+    // The whole point of exposing this: a caller must be able to tell whether
+    // the option did anything, rather than assuming coverage it lacks.
+    assert_eq!(
+        claude_wrapper::exec::die_with_parent_supported(),
+        cfg!(target_os = "linux"),
+        "support must track the platform, not the build"
+    );
+}
+
+#[tokio::test]
+async fn enabling_it_does_not_disturb_a_normal_run() {
+    // Off Linux this proves the no-op is truly a no-op; on Linux it proves the
+    // pre_exec hook does not break an ordinary spawn.
+    let claude = Claude::builder()
+        .binary(fake())
+        .die_with_parent(true)
+        .build()
+        .unwrap();
+
+    let out = claude_wrapper::exec::run_claude(&claude, vec!["--version".into()])
+        .await
+        .expect("a run with die_with_parent enabled still succeeds");
+    assert!(!out.stdout.is_empty());
+}
+
+#[tokio::test]
+async fn it_composes_with_the_spawn_observer() {
+    // A supervisor will use both: pdeathsig for the common case, the pid for
+    // the platforms and crash modes it cannot cover.
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let sink = seen.clone();
+    let claude = Claude::builder()
+        .binary(fake())
+        .die_with_parent(true)
+        .on_spawn(Arc::new(move |info| sink.lock().unwrap().push(info)))
+        .build()
+        .unwrap();
+
+    claude_wrapper::exec::run_claude(&claude, vec!["--version".into()])
+        .await
+        .unwrap();
+
+    assert_eq!(seen.lock().unwrap().len(), 1, "observer still fires");
+}
+
+#[test]
+fn default_is_off() {
+    // Killing children on parent exit is right for a supervisor and wrong for a
+    // CLI that deliberately backgrounds work, so it must be opt-in.
+    let claude = Claude::builder().binary(fake()).build().unwrap();
+    let rendered = format!("{claude:?}");
+    assert!(
+        !rendered.contains("die_with_parent: true"),
+        "default must be off, got {rendered}"
+    );
+}
+
+/// Set on the re-executed copy of this binary that plays the middle process.
+const HELPER_ENV: &str = "CLAUDE_WRAPPER_PDEATHSIG_HELPER";
+
+/// The middle process: spawns a long-lived child through this crate with the
+/// policy enabled, prints its pid, then blocks so it can be killed.
+///
+/// A no-op in ordinary runs; only the re-exec below sets `HELPER_ENV`.
+#[test]
+fn pdeathsig_helper_process() {
+    if std::env::var(HELPER_ENV).is_err() {
+        return;
+    }
+    let claude = Claude::builder()
+        // `sleep` stands in for the CLI: what matters is a child that outlives
+        // its parent unless something kills it.
+        .binary("/bin/sleep")
+        .die_with_parent(true)
+        .on_spawn(Arc::new(|info| {
+            // The parent reads this to learn what to watch.
+            println!("PID {}", info.pid);
+            use std::io::Write;
+            let _ = std::io::stdout().flush();
+        }))
+        .build()
+        .unwrap();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    // Blocks until killed, which is the point.
+    let _ = rt.block_on(claude_wrapper::exec::run_claude(
+        &claude,
+        vec!["300".into()],
+    ));
+}
+
+/// The behavioural test, and the only one that proves the feature works.
+///
+/// Linux-gated rather than `#[ignore]`d, so CI actually runs it on the one
+/// platform where `PR_SET_PDEATHSIG` exists. Elsewhere it is compiled out: the
+/// documented answer there is "the child survives", which is exactly why
+/// `die_with_parent_supported` exists.
+#[cfg(target_os = "linux")]
+#[test]
+fn child_dies_when_the_parent_is_sigkilled() {
+    use std::io::{BufRead, BufReader};
+    use std::process::{Command, Stdio};
+
+    let exe = std::env::current_exe().expect("test binary path");
+    let mut helper = Command::new(&exe)
+        .args(["--exact", "pdeathsig_helper_process", "--nocapture"])
+        .env(HELPER_ENV, "1")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawning the helper");
+
+    let stdout = helper.stdout.take().expect("piped");
+    let mut pid = None;
+    for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+        if let Some(rest) = line.strip_prefix("PID ") {
+            pid = rest.trim().parse::<u32>().ok();
+            break;
+        }
+    }
+    let pid = pid.expect("helper reported a child pid");
+
+    // SIGKILL: no destructor in the helper can run, which is the scenario.
+    unsafe { libc::kill(helper.id() as i32, libc::SIGKILL) };
+    let _ = helper.wait();
+
+    // The kernel delivers the death signal promptly, but not instantly.
+    let mut alive = true;
+    for _ in 0..50 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        // SAFETY: signal 0 is an existence check only.
+        if unsafe { libc::kill(pid as i32, 0) } != 0 {
+            alive = false;
+            break;
+        }
+    }
+    assert!(
+        !alive,
+        "child {pid} survived its SIGKILLed parent; PR_SET_PDEATHSIG did not fire"
+    );
+}


### PR DESCRIPTION
Closes #776 with **option 1** from the issue. Builds on #775, which shipped the pid.

## The gap

Every cleanup path in the crate is a destructor: `kill_on_drop`, and the process-group kill on drop, timeout, or stream error. **None run when the parent is SIGKILLed.** The child is reparented to init and, leading its own process group, is unreachable by terminal signals too. It keeps running, keeps billing, and keeps appending to the session transcript, so a restarted supervisor that resumes that session id can interleave with an orphan still writing to it.

## Shape

```rust
let claude = Claude::builder().die_with_parent(true).build()?;
```

`PR_SET_PDEATHSIG` in a `pre_exec` hook: the kernel SIGKILLs the child the moment its parent dies, with no cooperation from either side. Off by default, since killing children on parent exit is right for a supervisor and wrong for a CLI that deliberately backgrounds work.

## Two things that make it correct rather than merely present

**The fork/prctl race is handled.** The signal is armed by the child *after* the fork, so a parent dying in that window leaves exactly the orphan this exists to prevent. The hook re-reads `getppid()` after arming and `_exit`s if the parent already changed.

**The hook is async-signal-safe.** `prctl`, `getppid`, `_exit` only — anything that allocates or takes a lock risks deadlocking the child post-fork.

## Honest about the platform

Linux only, and the crate *says so* rather than implying coverage:

```rust
claude_wrapper::exec::die_with_parent_supported()  // true only on Linux
```

macOS has no equivalent. A supervisor there needs its own pid-based watchdog, which is what #775's `on_spawn` is for — and there's a test that the two compose. A silently-no-op `die_with_parent()` would have been exactly the dishonest API this whole cluster of issues is about avoiding.

The docs also name two things it does *not* cover: re-parenting (the signal fires when the *immediate* parent dies, which matters if you daemonize between building the client and spawning), and non-Linux targets.

## The test that matters

Four tests cover plumbing, defaults, honest platform reporting, and composition with the observer. Those don't prove the feature works.

The one that does is a three-level process tree: a helper spawns a child through this crate, gets SIGKILLed with no chance to run destructors, and the test asserts the grandchild is gone. **Gated to `cfg(target_os = "linux")` rather than `#[ignore]`d**, so CI runs it for real on ubuntu instead of it sitting dormant. Off Linux it compiles out, because the documented answer there is that the child survives.

I could not run it locally (macOS); ubuntu CI is its first real execution.

## Refactor included

All eight internal spawn functions now take `SpawnPolicy` instead of threading `process_group`, `kill_grace`, `die_with_parent`, and `on_spawn` separately. I deferred this twice; a fourth knob settled it. Paths with no kill site explicitly ignore `kill_grace` rather than silently accepting it.

## Verification

`fmt`, `clippy --all-targets --all-features -D warnings`, full suite green (9 test targets). All four feature combos build — the second commit fixes a `json`-only break the combo check caught, where the `SpawnPolicy` impl was not gated to match its struct.