### PR TITLE
feat(process): support cleared child environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ let claude = Claude::builder()
 - `binary()` -- path to the `claude` binary (auto-detected from PATH by default)
 - `working_dir()` / `with_working_dir()` -- working directory for commands
 - `env()` / `envs()` -- environment variables applied to every command
+- `clear_env()` -- clear inherited child environment before applying `env()` / `envs()`
 - `arg()` -- global arg applied before every subcommand
 - `timeout_secs()` / `timeout()` -- command timeout (no default)
 - `retry()` -- default `RetryPolicy` applied to every command
@@ -114,6 +115,31 @@ let claude = Claude::builder()
 
 - `cli_version()` / `cli_version_sync()` -- parsed `CliVersion`
 - `check_version()` / `check_version_sync()` -- assert a minimum version
+
+### Child environment policy
+
+Children inherit the parent process environment by default for compatibility.
+Hosts that need an explicitly constructed environment can opt into clearing it:
+
+```rust
+let claude = Claude::builder()
+    .clear_env()
+    .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+    .env("LANG", "C.UTF-8")
+    .env("CLAUDE_CONFIG_DIR", "/srv/claude/config")
+    .build()?;
+```
+
+`clear_env()` is call-order independent: explicit entries survive whether
+`env()` / `envs()` appear before or after it. Every buffered, stdin, timeout,
+retry, streaming, sync, and duplex child uses the same policy.
+
+Clearing the environment controls only what the direct Claude CLI child
+inherits. It is not operating-system or process isolation. A same-UID child
+may still read accessible files or inspect other processes where the OS
+permits it. Callers are responsible for choosing the minimal `PATH`, locale,
+config-home, credential, proxy, Git, and SSH entries appropriate for their
+deployment.
 
 ## Command builders
 

--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -1157,13 +1157,11 @@ impl DuplexSession {
 
         let mut cmd = Command::new(&claude.binary);
         cmd.args(&command_args)
-            .env_remove("CLAUDECODE")
-            .env_remove("CLAUDE_CODE_ENTRYPOINT")
-            .envs(&claude.env)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        crate::exec::apply_child_environment(cmd.as_std_mut(), claude.clear_env, &claude.env);
         // Own process group (Unix) so shutdown can signal the whole
         // tree, not just the direct child (see exec::GroupKillGuard).
         // Opt out via ClaudeBuilder::process_group.

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -54,6 +54,26 @@ pub(crate) fn full_command_args(claude: &Claude, args: Vec<String>) -> Vec<Strin
     command_args
 }
 
+/// Apply the client's environment policy to one CLI child command.
+///
+/// Kept as the single environment assembly point for buffered, streaming,
+/// sync, timeout, retry, stdin, and duplex spawns. Explicit entries are
+/// applied after clearing and after the nested-session scrub, so callers can
+/// deliberately restore an entry when required.
+#[cfg(any(feature = "async", feature = "sync"))]
+pub(crate) fn apply_child_environment(
+    cmd: &mut std::process::Command,
+    clear_env: bool,
+    env: &std::collections::HashMap<String, String>,
+) {
+    if clear_env {
+        cmd.env_clear();
+    }
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    cmd.envs(env);
+}
+
 /// The subcommand label for a span, derived from the argv.
 ///
 /// The first token is the subcommand for subcommand-style invocations
@@ -474,6 +494,7 @@ async fn run_claude_with_stdin_prompt_internal(
 
     let binary = &claude.binary;
     let env = &claude.env;
+    let clear_env = claude.clear_env;
     let working_dir = claude.working_dir.as_deref();
 
     let result = if let Some(timeout) = claude.timeout {
@@ -481,6 +502,7 @@ async fn run_claude_with_stdin_prompt_internal(
             binary,
             &command_args,
             env,
+            clear_env,
             working_dir,
             timeout,
             stdin_content,
@@ -492,6 +514,7 @@ async fn run_claude_with_stdin_prompt_internal(
             binary,
             &command_args,
             env,
+            clear_env,
             working_dir,
             stdin_content,
             SpawnPolicy::of(claude),
@@ -510,6 +533,7 @@ async fn run_internal_stdin(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     stdin_content: String,
     policy: SpawnPolicy<'_>,
@@ -535,15 +559,10 @@ async fn run_internal_stdin(
     // via ClaudeBuilder::process_group.
     apply_process_group(&mut cmd, process_group);
     apply_die_with_parent(&mut cmd, die_with_parent);
-    cmd.env_remove("CLAUDECODE");
-    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    apply_child_environment(cmd.as_std_mut(), clear_env, env);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
-    }
-
-    for (key, value) in env {
-        cmd.env(key, value);
     }
 
     let mut child = spawn_retrying_txtbsy(&mut cmd)
@@ -610,6 +629,7 @@ async fn run_with_timeout_stdin(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     timeout: Duration,
     stdin_content: String,
@@ -636,15 +656,10 @@ async fn run_with_timeout_stdin(
     // via ClaudeBuilder::process_group.
     apply_process_group(&mut cmd, process_group);
     apply_die_with_parent(&mut cmd, die_with_parent);
-    cmd.env_remove("CLAUDECODE");
-    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    apply_child_environment(cmd.as_std_mut(), clear_env, env);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
-    }
-
-    for (key, value) in env {
-        cmd.env(key, value);
     }
 
     let mut child = spawn_retrying_txtbsy(&mut cmd)
@@ -749,6 +764,7 @@ async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOu
             &claude.binary,
             &command_args,
             &claude.env,
+            claude.clear_env,
             claude.working_dir.as_deref(),
             timeout,
             SpawnPolicy::of(claude),
@@ -759,6 +775,7 @@ async fn run_claude_once(claude: &Claude, args: Vec<String>) -> Result<CommandOu
             &claude.binary,
             &command_args,
             &claude.env,
+            claude.clear_env,
             claude.working_dir.as_deref(),
             SpawnPolicy::of(claude),
         )
@@ -801,6 +818,7 @@ async fn run_internal(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
@@ -827,16 +845,10 @@ async fn run_internal(
     apply_process_group(&mut cmd, process_group);
     apply_die_with_parent(&mut cmd, die_with_parent);
 
-    // Remove Claude Code env vars to prevent nested session detection
-    cmd.env_remove("CLAUDECODE");
-    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    apply_child_environment(cmd.as_std_mut(), clear_env, env);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
-    }
-
-    for (key, value) in env {
-        cmd.env(key, value);
     }
 
     // Spawn explicitly (rather than `Command::output`) so the pid is
@@ -903,6 +915,7 @@ async fn run_with_timeout(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     timeout: Duration,
     policy: SpawnPolicy<'_>,
@@ -926,15 +939,10 @@ async fn run_with_timeout(
     // via ClaudeBuilder::process_group.
     apply_process_group(&mut cmd, process_group);
     apply_die_with_parent(&mut cmd, die_with_parent);
-    cmd.env_remove("CLAUDECODE");
-    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    apply_child_environment(cmd.as_std_mut(), clear_env, env);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
-    }
-
-    for (key, value) in env {
-        cmd.env(key, value);
     }
 
     let mut child = spawn_retrying_txtbsy(&mut cmd)
@@ -1117,6 +1125,7 @@ pub fn run_claude_with_stdin_prompt_sync(
             &claude.binary,
             &command_args,
             &claude.env,
+            claude.clear_env,
             claude.working_dir.as_deref(),
             timeout,
             stdin_content,
@@ -1127,6 +1136,7 @@ pub fn run_claude_with_stdin_prompt_sync(
             &claude.binary,
             &command_args,
             &claude.env,
+            claude.clear_env,
             claude.working_dir.as_deref(),
             stdin_content,
             SpawnPolicy::of(claude),
@@ -1144,6 +1154,7 @@ fn run_internal_stdin_sync(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     stdin_content: String,
     policy: SpawnPolicy<'_>,
@@ -1167,15 +1178,10 @@ fn run_internal_stdin_sync(
     // ClaudeBuilder::process_group.
     apply_process_group_sync(&mut cmd, process_group);
     apply_die_with_parent_sync(&mut cmd, die_with_parent);
-    cmd.env_remove("CLAUDECODE");
-    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    apply_child_environment(&mut cmd, clear_env, env);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
-    }
-
-    for (key, value) in env {
-        cmd.env(key, value);
     }
 
     let mut child = spawn_retrying_txtbsy_sync(&mut cmd).map_err(|e| Error::Io {
@@ -1237,6 +1243,7 @@ fn run_with_timeout_stdin_sync(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     timeout: Duration,
     stdin_content: String,
@@ -1263,15 +1270,10 @@ fn run_with_timeout_stdin_sync(
     // ClaudeBuilder::process_group.
     apply_process_group_sync(&mut cmd, process_group);
     apply_die_with_parent_sync(&mut cmd, die_with_parent);
-    cmd.env_remove("CLAUDECODE");
-    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    apply_child_environment(&mut cmd, clear_env, env);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
-    }
-
-    for (key, value) in env {
-        cmd.env(key, value);
     }
 
     let mut child = spawn_retrying_txtbsy_sync(&mut cmd).map_err(|e| Error::Io {
@@ -1369,6 +1371,7 @@ fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOut
             &claude.binary,
             &command_args,
             &claude.env,
+            claude.clear_env,
             claude.working_dir.as_deref(),
             timeout,
             SpawnPolicy::of(claude),
@@ -1378,6 +1381,7 @@ fn run_claude_once_sync(claude: &Claude, args: Vec<String>) -> Result<CommandOut
             &claude.binary,
             &command_args,
             &claude.env,
+            claude.clear_env,
             claude.working_dir.as_deref(),
             SpawnPolicy::of(claude),
         )
@@ -1417,6 +1421,7 @@ fn run_internal_sync(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     policy: SpawnPolicy<'_>,
 ) -> Result<CommandOutput> {
@@ -1437,15 +1442,10 @@ fn run_internal_sync(
     // supervisor still wants its pid, so the spawn is observed below.
     apply_process_group_sync(&mut cmd, process_group);
     apply_die_with_parent_sync(&mut cmd, die_with_parent);
-    cmd.env_remove("CLAUDECODE");
-    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    apply_child_environment(&mut cmd, clear_env, env);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
-    }
-
-    for (key, value) in env {
-        cmd.env(key, value);
     }
 
     let output =
@@ -1491,6 +1491,7 @@ fn run_with_timeout_sync(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     timeout: Duration,
     policy: SpawnPolicy<'_>,
@@ -1515,15 +1516,10 @@ fn run_with_timeout_sync(
     // ClaudeBuilder::process_group.
     apply_process_group_sync(&mut cmd, process_group);
     apply_die_with_parent_sync(&mut cmd, die_with_parent);
-    cmd.env_remove("CLAUDECODE");
-    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    apply_child_environment(&mut cmd, clear_env, env);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
-    }
-
-    for (key, value) in env {
-        cmd.env(key, value);
     }
 
     let mut child = spawn_retrying_txtbsy_sync(&mut cmd).map_err(|e| Error::Io {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,6 +450,8 @@ pub struct Claude {
     // `sync` feature.
     #[allow(dead_code)]
     pub(crate) env: HashMap<String, String>,
+    #[allow(dead_code)]
+    pub(crate) clear_env: bool,
     pub(crate) global_args: Vec<String>,
     #[allow(dead_code)]
     pub(crate) timeout: Option<Duration>,
@@ -472,6 +474,7 @@ impl std::fmt::Debug for Claude {
         f.debug_struct("Claude")
             .field("binary", &self.binary)
             .field("working_dir", &self.working_dir)
+            .field("clear_env", &self.clear_env)
             .field("global_args", &self.global_args)
             .field("timeout", &self.timeout)
             .field("process_group", &self.process_group)
@@ -755,6 +758,7 @@ pub struct ClaudeBuilder {
     binary: Option<PathBuf>,
     working_dir: Option<PathBuf>,
     env: HashMap<String, String>,
+    clear_env: bool,
     global_args: Vec<String>,
     timeout: Option<Duration>,
     retry_policy: Option<RetryPolicy>,
@@ -772,6 +776,7 @@ impl std::fmt::Debug for ClaudeBuilder {
         f.debug_struct("ClaudeBuilder")
             .field("binary", &self.binary)
             .field("working_dir", &self.working_dir)
+            .field("clear_env", &self.clear_env)
             .field("global_args", &self.global_args)
             .field("timeout", &self.timeout)
             .field("process_group", &self.process_group)
@@ -816,6 +821,43 @@ impl ClaudeBuilder {
         for (k, v) in vars {
             self.env.insert(k.into(), v.into());
         }
+        self
+    }
+
+    /// Clear the inherited environment of every spawned Claude CLI child.
+    ///
+    /// By default, children inherit the parent process environment and
+    /// [`env`](Self::env) / [`envs`](Self::envs) add or replace entries. With
+    /// this option enabled, the inherited environment is cleared first and
+    /// only explicitly configured entries are applied. The order in which
+    /// `clear_env`, `env`, and `envs` are called does not affect the result.
+    ///
+    /// Callers normally need to rebuild a minimal environment including
+    /// `PATH`, locale settings, the Claude config directory, and the intended
+    /// authentication selector.
+    ///
+    /// This controls only the direct child process environment. It is not an
+    /// operating-system sandbox and does not prevent a same-UID child from
+    /// reading accessible files or inspecting other processes where the OS
+    /// permits it.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use claude_wrapper::Claude;
+    ///
+    /// # fn example() -> claude_wrapper::Result<()> {
+    /// let claude = Claude::builder()
+    ///     .clear_env()
+    ///     .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+    ///     .env("CLAUDE_CONFIG_DIR", "/srv/claude/config")
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn clear_env(mut self) -> Self {
+        self.clear_env = true;
         self
     }
 
@@ -1065,6 +1107,7 @@ impl ClaudeBuilder {
             binary,
             working_dir: self.working_dir,
             env: self.env,
+            clear_env: self.clear_env,
             global_args: self.global_args,
             timeout: self.timeout,
             retry_policy: self.retry_policy,
@@ -1095,6 +1138,26 @@ mod tests {
             .build()
             .unwrap();
         assert!(!off.process_group);
+    }
+
+    #[test]
+    fn builder_clear_env_defaults_off_and_is_call_order_independent() {
+        let inherited = Claude::builder()
+            .binary("/nonexistent/claude")
+            .build()
+            .unwrap();
+        assert!(!inherited.clear_env);
+
+        let cleared = Claude::builder()
+            .binary("/nonexistent/claude")
+            .env("FIRST", "1")
+            .clear_env()
+            .env("SECOND", "2")
+            .build()
+            .unwrap();
+        assert!(cleared.clear_env);
+        assert_eq!(cleared.env.get("FIRST").map(String::as_str), Some("1"));
+        assert_eq!(cleared.env.get("SECOND").map(String::as_str), Some("2"));
     }
 
     #[test]

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -421,14 +421,13 @@ where
 
     let mut cmd = Command::new(&claude.binary);
     cmd.args(&command_args)
-        .env_remove("CLAUDECODE")
-        .envs(&claude.env)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .stdin(std::process::Stdio::null())
         // Dropping the in-flight future must kill the child, not leave
         // the CLI running unattended (see the `exec` module docs).
         .kill_on_drop(true);
+    crate::exec::apply_child_environment(cmd.as_std_mut(), claude.clear_env, &claude.env);
     // Own process group (Unix) so cancellation can signal the whole
     // tree, not just the direct child (see exec::GroupKillGuard). Opt
     // out via ClaudeBuilder::process_group.
@@ -652,12 +651,10 @@ where
     let mut cmd_builder = StdCommand::new(&claude.binary);
     cmd_builder
         .args(&command_args)
-        .env_remove("CLAUDECODE")
-        .env_remove("CLAUDE_CODE_ENTRYPOINT")
-        .envs(&claude.env)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    crate::exec::apply_child_environment(&mut cmd_builder, claude.clear_env, &claude.env);
     // Own process group (Unix) so a kill can signal the whole tree,
     // not just the direct child (see exec::GroupKillGuard). Opt out
     // via ClaudeBuilder::process_group.

--- a/tests/fake-claude.sh
+++ b/tests/fake-claude.sh
@@ -19,6 +19,10 @@
 #   FAKE_CLAUDE_PID_FILE    - if set, write this process's pid there before
 #       any delay or output, so tests can observe the process itself
 #       (e.g. that dropping an in-flight future kills it).
+#   FAKE_CLAUDE_ENV_CAPTURE_FILE - if set, write the complete exported child
+#       environment there before any delay or output.
+#   FAKE_CLAUDE_FAIL_ONCE_FILE - if set, create this marker and exit 75 on
+#       the first invocation, then succeed on later invocations.
 #   FAKE_CLAUDE_GRANDCHILD_PID_FILE - if set, spawn a long-sleeping
 #       same-process-group grandchild that records its pid there, to
 #       test that cancellation kills the whole group. Written before
@@ -63,6 +67,18 @@ fi
 # the moment it starts.
 if [[ -n "${FAKE_CLAUDE_PID_FILE:-}" ]]; then
     echo $$ > "$FAKE_CLAUDE_PID_FILE"
+fi
+
+# Capture the actual child environment before the test-only controls below
+# can exit. This lets tests verify both successful and retried spawn attempts.
+if [[ -n "${FAKE_CLAUDE_ENV_CAPTURE_FILE:-}" ]]; then
+    env > "$FAKE_CLAUDE_ENV_CAPTURE_FILE"
+fi
+
+if [[ -n "${FAKE_CLAUDE_FAIL_ONCE_FILE:-}" && ! -e "$FAKE_CLAUDE_FAIL_ONCE_FILE" ]]; then
+    : > "$FAKE_CLAUDE_FAIL_ONCE_FILE"
+    echo "transient fake failure" >&2
+    exit 75
 fi
 
 # Optional delay before any output - used to test timeouts.

--- a/tests/fake_claude.rs
+++ b/tests/fake_claude.rs
@@ -54,13 +54,15 @@ fn captured_env(path: &Path) -> std::collections::HashMap<String, String> {
 
 fn assert_cleared_environment(path: &Path) {
     let env = captured_env(path);
+    let mut keys: Vec<_> = env.keys().cloned().collect();
+    keys.sort();
     assert_eq!(
         env.get("WRAPPER_EXPLICIT").map(String::as_str),
         Some("present")
     );
     assert!(
         !env.contains_key("HOME"),
-        "cleared child unexpectedly inherited HOME: {env:?}"
+        "cleared child unexpectedly inherited HOME; exported keys: {keys:?}"
     );
 }
 

--- a/tests/fake_claude.rs
+++ b/tests/fake_claude.rs
@@ -4,7 +4,7 @@
 
 #![cfg(feature = "async")]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use claude_wrapper::{Claude, ClaudeCommand, OutputFormat, QueryCommand, RetryPolicy};
 
@@ -23,6 +23,61 @@ fn claude_with_env(pairs: &[(&str, &str)]) -> Claude {
     builder.build().expect("failed to build Claude client")
 }
 
+fn env_capture_builder(capture_path: &Path) -> claude_wrapper::ClaudeBuilder {
+    Claude::builder()
+        .binary(fake_binary())
+        .clear_env()
+        .env(
+            "FAKE_CLAUDE_ENV_CAPTURE_FILE",
+            capture_path.to_string_lossy(),
+        )
+        .env("FAKE_CLAUDE_OUTPUT", "environment captured")
+        .env("WRAPPER_EXPLICIT", "present")
+}
+
+fn env_capture_client(capture_path: &Path) -> Claude {
+    env_capture_builder(capture_path)
+        .build()
+        .expect("failed to build cleared Claude client")
+}
+
+fn captured_env(path: &Path) -> std::collections::HashMap<String, String> {
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+        .lines()
+        .filter_map(|line| {
+            line.split_once('=')
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+fn assert_cleared_environment(path: &Path) {
+    let env = captured_env(path);
+    assert_eq!(
+        env.get("WRAPPER_EXPLICIT").map(String::as_str),
+        Some("present")
+    );
+    assert!(
+        !env.contains_key("HOME"),
+        "cleared child unexpectedly inherited HOME: {env:?}"
+    );
+}
+
+async fn wait_for_capture(path: &Path) {
+    for _ in 0..100 {
+        if std::fs::read_to_string(path).is_ok_and(|contents| {
+            contents
+                .lines()
+                .any(|line| line == "WRAPPER_EXPLICIT=present")
+        }) {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
 /// Verify that the fake binary executes and returns expected plain-text output.
 #[tokio::test]
 async fn fake_claude_basic_execution() {
@@ -35,6 +90,198 @@ async fn fake_claude_basic_execution() {
 
     assert!(output.success);
     assert!(output.stdout.contains("hello from fake"));
+}
+
+#[tokio::test]
+async fn child_environment_inherits_by_default_and_clears_on_request() {
+    let parent_home = std::env::var("HOME").expect("test process should have HOME");
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let inherited_path = dir.path().join("inherited.env");
+    let inherited = Claude::builder()
+        .binary(fake_binary())
+        .env(
+            "FAKE_CLAUDE_ENV_CAPTURE_FILE",
+            inherited_path.to_string_lossy(),
+        )
+        .env("WRAPPER_EXPLICIT", "present")
+        .build()
+        .expect("inheriting client");
+    claude_wrapper::VersionCommand::new()
+        .execute(&inherited)
+        .await
+        .expect("inheriting spawn");
+    let inherited_env = captured_env(&inherited_path);
+    assert_eq!(
+        inherited_env.get("HOME").map(String::as_str),
+        Some(parent_home.as_str())
+    );
+    assert_eq!(
+        inherited_env.get("WRAPPER_EXPLICIT").map(String::as_str),
+        Some("present")
+    );
+
+    let cleared_path = dir.path().join("cleared.env");
+    claude_wrapper::VersionCommand::new()
+        .execute(&env_capture_client(&cleared_path))
+        .await
+        .expect("cleared spawn");
+    assert_cleared_environment(&cleared_path);
+}
+
+#[tokio::test]
+async fn clear_env_applies_to_all_async_exec_paths() {
+    use claude_wrapper::exec::run_claude_with_stdin_prompt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let buffered_path = dir.path().join("buffered.env");
+    claude_wrapper::VersionCommand::new()
+        .execute(&env_capture_client(&buffered_path))
+        .await
+        .expect("buffered execution");
+    assert_cleared_environment(&buffered_path);
+
+    let buffered_timeout_path = dir.path().join("buffered-timeout.env");
+    let buffered_timeout = env_capture_builder(&buffered_timeout_path)
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("timeout client");
+    claude_wrapper::VersionCommand::new()
+        .execute(&buffered_timeout)
+        .await
+        .expect("buffered timeout-path execution");
+    assert_cleared_environment(&buffered_timeout_path);
+
+    let stdin_path = dir.path().join("stdin.env");
+    run_claude_with_stdin_prompt(
+        &env_capture_client(&stdin_path),
+        vec!["--version".to_string()],
+        "prompt on stdin".to_string(),
+    )
+    .await
+    .expect("stdin execution");
+    assert_cleared_environment(&stdin_path);
+
+    let stdin_timeout_path = dir.path().join("stdin-timeout.env");
+    let stdin_timeout = env_capture_builder(&stdin_timeout_path)
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("stdin timeout client");
+    run_claude_with_stdin_prompt(
+        &stdin_timeout,
+        vec!["--version".to_string()],
+        "prompt on stdin".to_string(),
+    )
+    .await
+    .expect("stdin timeout-path execution");
+    assert_cleared_environment(&stdin_timeout_path);
+
+    let retry_path = dir.path().join("retry.env");
+    let retry_marker = dir.path().join("retried");
+    let retry = env_capture_builder(&retry_path)
+        .env("FAKE_CLAUDE_FAIL_ONCE_FILE", retry_marker.to_string_lossy())
+        .retry(
+            RetryPolicy::new()
+                .max_attempts(2)
+                .initial_backoff(std::time::Duration::from_millis(1))
+                .retry_on_exit_codes([75]),
+        )
+        .build()
+        .expect("retry client");
+    claude_wrapper::VersionCommand::new()
+        .execute(&retry)
+        .await
+        .expect("second retry attempt should succeed");
+    assert!(retry_marker.is_file(), "first attempt should create marker");
+    assert_cleared_environment(&retry_path);
+}
+
+#[cfg(feature = "json")]
+#[tokio::test]
+async fn clear_env_applies_to_streaming_and_session_open_resume() {
+    use claude_wrapper::session::Session;
+    use claude_wrapper::streaming::{StreamEvent, stream_query};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let stream_path = dir.path().join("stream.env");
+    let stream_client = env_capture_client(&stream_path);
+    let stream_command = QueryCommand::new("stream")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+    stream_query(&stream_client, &stream_command, |_: StreamEvent| {})
+        .await
+        .expect("streaming execution");
+    assert_cleared_environment(&stream_path);
+
+    let fresh_path = dir.path().join("session-fresh.env");
+    let mut fresh = Session::new(Arc::new(env_capture_client(&fresh_path)));
+    fresh.send("fresh").await.expect("fresh session turn");
+    assert_cleared_environment(&fresh_path);
+
+    let resumed_path = dir.path().join("session-resumed.env");
+    let mut resumed = Session::resume(
+        Arc::new(env_capture_client(&resumed_path)),
+        "existing-session-id",
+    );
+    resumed.send("resume").await.expect("resumed session turn");
+    assert_cleared_environment(&resumed_path);
+}
+
+#[cfg(feature = "json")]
+#[tokio::test]
+async fn clear_env_applies_to_duplex_open_and_resume() {
+    use claude_wrapper::duplex::{DuplexOptions, DuplexSession};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let fresh_path = dir.path().join("duplex-fresh.env");
+    let fresh_client = env_capture_client(&fresh_path);
+    let fresh = DuplexSession::spawn(&fresh_client, DuplexOptions::default())
+        .await
+        .expect("fresh duplex spawn");
+    wait_for_capture(&fresh_path).await;
+    assert_cleared_environment(&fresh_path);
+    fresh.close().await.expect("close fresh duplex session");
+
+    let resumed_path = dir.path().join("duplex-resumed.env");
+    let resumed_client = env_capture_client(&resumed_path);
+    let resumed = DuplexSession::spawn(
+        &resumed_client,
+        DuplexOptions::default().resume("existing-session-id"),
+    )
+    .await
+    .expect("resumed duplex spawn");
+    wait_for_capture(&resumed_path).await;
+    assert_cleared_environment(&resumed_path);
+    resumed.close().await.expect("close resumed duplex session");
+}
+
+#[tokio::test]
+async fn environment_values_are_absent_from_debug_and_errors() {
+    let secret = "issue-782-environment-secret";
+    let builder = Claude::builder()
+        .binary(fake_binary())
+        .clear_env()
+        .env("WRAPPER_SECRET", secret);
+    assert!(!format!("{builder:?}").contains(secret));
+
+    let claude = Claude::builder()
+        .binary(fake_binary())
+        .clear_env()
+        .env("WRAPPER_SECRET", secret)
+        .env("FAKE_CLAUDE_EXIT_CODE", "1")
+        .env("FAKE_CLAUDE_ERROR_MSG", "generic failure")
+        .build()
+        .expect("client");
+    assert!(!format!("{claude:?}").contains(secret));
+    let error = claude_wrapper::VersionCommand::new()
+        .execute(&claude)
+        .await
+        .expect_err("fake failure");
+    assert!(!error.to_string().contains(secret));
 }
 
 /// Verify that stream-json NDJSON output is parsed correctly by execute_json.

--- a/tests/fake_claude_sync.rs
+++ b/tests/fake_claude_sync.rs
@@ -7,7 +7,7 @@
 
 #![cfg(feature = "sync")]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use claude_wrapper::Claude;
@@ -27,6 +27,43 @@ fn claude_with_env(pairs: &[(&str, &str)]) -> Claude {
     builder.build().expect("failed to build Claude client")
 }
 
+fn env_capture_builder(capture_path: &Path) -> claude_wrapper::ClaudeBuilder {
+    Claude::builder()
+        .binary(fake_binary())
+        .clear_env()
+        .env(
+            "FAKE_CLAUDE_ENV_CAPTURE_FILE",
+            capture_path.to_string_lossy(),
+        )
+        .env("FAKE_CLAUDE_OUTPUT", "environment captured")
+        .env("WRAPPER_EXPLICIT", "present")
+}
+
+fn env_capture_client(capture_path: &Path) -> Claude {
+    env_capture_builder(capture_path)
+        .build()
+        .expect("failed to build cleared Claude client")
+}
+
+fn assert_cleared_environment(path: &Path) {
+    let env: std::collections::HashMap<String, String> = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+        .lines()
+        .filter_map(|line| {
+            line.split_once('=')
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+        })
+        .collect();
+    assert_eq!(
+        env.get("WRAPPER_EXPLICIT").map(String::as_str),
+        Some("present")
+    );
+    assert!(
+        !env.contains_key("HOME"),
+        "cleared child unexpectedly inherited HOME: {env:?}"
+    );
+}
+
 #[test]
 fn sync_basic_execution_returns_stdout() {
     let claude = claude_with_env(&[("FAKE_CLAUDE_OUTPUT", "hello sync")]);
@@ -39,6 +76,85 @@ fn sync_basic_execution_returns_stdout() {
         output.stdout
     );
     assert_eq!(output.exit_code, 0);
+}
+
+#[test]
+fn clear_env_applies_to_all_sync_exec_paths() {
+    use claude_wrapper::exec::run_claude_with_stdin_prompt_sync;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let buffered_path = dir.path().join("buffered.env");
+    run_claude_sync(
+        &env_capture_client(&buffered_path),
+        vec!["--version".to_string()],
+    )
+    .expect("buffered sync execution");
+    assert_cleared_environment(&buffered_path);
+
+    let buffered_timeout_path = dir.path().join("buffered-timeout.env");
+    let buffered_timeout = env_capture_builder(&buffered_timeout_path)
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("timeout client");
+    run_claude_sync(&buffered_timeout, vec!["--version".to_string()])
+        .expect("buffered sync timeout-path execution");
+    assert_cleared_environment(&buffered_timeout_path);
+
+    let stdin_path = dir.path().join("stdin.env");
+    run_claude_with_stdin_prompt_sync(
+        &env_capture_client(&stdin_path),
+        vec!["--version".to_string()],
+        "prompt on stdin".to_string(),
+    )
+    .expect("stdin sync execution");
+    assert_cleared_environment(&stdin_path);
+
+    let stdin_timeout_path = dir.path().join("stdin-timeout.env");
+    let stdin_timeout = env_capture_builder(&stdin_timeout_path)
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("stdin timeout client");
+    run_claude_with_stdin_prompt_sync(
+        &stdin_timeout,
+        vec!["--version".to_string()],
+        "prompt on stdin".to_string(),
+    )
+    .expect("stdin sync timeout-path execution");
+    assert_cleared_environment(&stdin_timeout_path);
+
+    let retry_path = dir.path().join("retry.env");
+    let retry_marker = dir.path().join("retried");
+    let retry = env_capture_builder(&retry_path)
+        .env("FAKE_CLAUDE_FAIL_ONCE_FILE", retry_marker.to_string_lossy())
+        .retry(
+            claude_wrapper::RetryPolicy::new()
+                .max_attempts(2)
+                .initial_backoff(Duration::from_millis(1))
+                .retry_on_exit_codes([75]),
+        )
+        .build()
+        .expect("retry client");
+    run_claude_sync(&retry, vec!["--version".to_string()])
+        .expect("second sync retry attempt should succeed");
+    assert!(retry_marker.is_file(), "first attempt should create marker");
+    assert_cleared_environment(&retry_path);
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn clear_env_applies_to_sync_streaming() {
+    use claude_wrapper::streaming::{StreamEvent, stream_query_sync};
+    use claude_wrapper::{OutputFormat, QueryCommand};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let capture_path = dir.path().join("stream.env");
+    let claude = env_capture_client(&capture_path);
+    let command = QueryCommand::new("stream")
+        .output_format(OutputFormat::StreamJson)
+        .no_session_persistence();
+    stream_query_sync(&claude, &command, |_: StreamEvent| {}).expect("sync streaming execution");
+    assert_cleared_environment(&capture_path);
 }
 
 #[test]

--- a/tests/fake_claude_sync.rs
+++ b/tests/fake_claude_sync.rs
@@ -54,13 +54,15 @@ fn assert_cleared_environment(path: &Path) {
                 .map(|(key, value)| (key.to_string(), value.to_string()))
         })
         .collect();
+    let mut keys: Vec<_> = env.keys().cloned().collect();
+    keys.sort();
     assert_eq!(
         env.get("WRAPPER_EXPLICIT").map(String::as_str),
         Some("present")
     );
     assert!(
         !env.contains_key("HOME"),
-        "cleared child unexpectedly inherited HOME: {env:?}"
+        "cleared child unexpectedly inherited HOME; exported keys: {keys:?}"
     );
 }
 


### PR DESCRIPTION
Closes #782.

Adds opt-in `ClaudeBuilder::clear_env()` while preserving inherited-environment compatibility by default.

- applies one clear/scrub/explicit-overlay policy to every async, sync, streaming, timeout/retry, session, and duplex spawn path
- keeps explicit `env` / `envs` values call-order independent
- documents that this is direct-child environment control, not OS or same-UID isolation
- captures default inheritance, cleared environments, open/resume parity, and Debug/error redaction with deterministic fake-child tests

Verification:
- repository-wide all-feature tests
- sync-only tests
- strict clippy across default/all/sync-only
- docs and formatting