### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.1] - 2026-08-10
+
+### Bug Fixes
+
+- *(streaming)* Preserve stdout failure diagnostics 
+
+### Features
+
+- *(process)* Support cleared child environments 
+
+
+
 ## [0.14.0] - 2026-08-08
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude-wrapper"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "claude-wrapper"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `claude-wrapper`: 0.14.0 -> 0.14.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.1] - 2026-08-10

### Bug Fixes

- *(streaming)* Preserve stdout failure diagnostics 

### Features

- *(process)* Support cleared child environments
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).